### PR TITLE
S1-002: dev-інструменти та лінтинг — ruff, mypy, pre-commit, Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,9 +182,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - pydantic>=2.12
+          - pydantic-settings>=2.12
+        args: [--config-file=pyproject.toml]
+        pass_filenames: false
+        entry: mypy src/
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: debug-statements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Course Materials → Ingestion Engine → SourceDocuments
 
 ## Code Standards
 
-- **Linting/Formatting:** `ruff` only. Base rules: E, W, F, I, N, UP, B, SIM, RUF. Extended in S1-002: ASYNC, S, PTH, T20. No `print()` — use `structlog`.
+- **Linting/Formatting:** `ruff` only. Rules: E, W, F, I, N, UP, B, SIM, RUF, ASYNC, S, PTH, T20. No `print()` — use `structlog`. S101/T20 allowed in tests via per-file-ignores.
 - **Type checking:** `mypy --strict`. Pydantic plugin enabled. Targeted `ignore_missing_imports` for untyped libs (trafilatura, pptx, docx, fitz, whisper).
 - **Testing:** `pytest` with `pytest-asyncio` (`asyncio_mode = "auto"`). Fixtures over classes.
 - **Docstrings/comments:** English only (Google/NumPy style).

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: help install lint format typecheck test test-cov check all
+
+help:  ## Показати цю довідку
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+install:  ## Встановити залежності та pre-commit hooks
+	uv sync
+	uv run pre-commit install
+
+lint:  ## Перевірити код (ruff)
+	uv run ruff check src/ tests/
+
+format:  ## Форматувати код (ruff)
+	uv run ruff format src/ tests/
+	uv run ruff check --fix src/ tests/
+
+typecheck:  ## Перевірити типи (mypy)
+	uv run mypy src/
+
+test:  ## Запустити тести
+	uv run pytest || test $$? -eq 5
+
+test-cov:  ## Запустити тести з coverage
+	uv run pytest --cov --cov-report=term-missing || test $$? -eq 5
+
+check: lint typecheck test  ## Повна перевірка (lint + types + tests)
+
+all: format check  ## Форматувати + повна перевірка

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,12 +78,49 @@ select = [
     "B",      # flake8-bugbear
     "SIM",    # flake8-simplify
     "RUF",    # ruff-specific
+    "ASYNC",  # flake8-async
+    "S",      # flake8-bandit (security)
+    "PTH",    # flake8-use-pathlib
+    "T20",    # flake8-print (use structlog instead)
 ]
+ignore = [
+    "S101",   # assert in tests is fine
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101", "T20"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
 
 [tool.mypy]
 python_version = "3.13"
 strict = true
 plugins = ["pydantic.mypy"]
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = "trafilatura.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pptx.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "docx.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "fitz.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "whisper.*"
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Розширена конфігурація інструментів якості коду:

ruff (pyproject.toml):
- Додано правила: ASYNC (async помилки), S (bandit security), PTH (pathlib замість os.path), T20 (заборона print)
- ignore S101 (assert дозволений), per-file-ignores для тестів
- Секція [tool.ruff.format]: double quotes, spaces

mypy (pyproject.toml):
- warn_return_any, warn_unused_configs, disallow_untyped_defs
- Overrides для бібліотек без type stubs: trafilatura, pptx, docx, fitz, whisper

Pre-commit (.pre-commit-config.yaml):
- ruff v0.15.0 (lint --fix + format)
- mirrors-mypy v1.19.1 (strict на src/)
- pre-commit-hooks v6.0.0 (trailing-whitespace, end-of-file-fixer, check-yaml, check-toml, check-added-large-files 500KB, debug-statements)

Makefile:
- Targets: install, lint, format, typecheck, test, test-cov, check, all
- PEP 735: `uv sync` (dev group за замовчуванням)
- pytest толерує exit code 5 (no tests collected)