### PR TITLE
S1-003: Docker Compose середовище — PostgreSQL з pgvector та MinIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Docker volumes (bind mount fallback)
+postgres_data/
+minio_data/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install lint format typecheck test test-cov check all
+.PHONY: help install lint format typecheck test test-cov check all up down reset logs ps
 
 help:  ## Показати цю довідку
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
@@ -27,3 +27,24 @@ test-cov:  ## Запустити тести з coverage
 check: lint typecheck test  ## Повна перевірка (lint + types + tests)
 
 all: format check  ## Форматувати + повна перевірка
+
+# --- Infrastructure ---
+
+up:  ## Запустити інфраструктуру (PostgreSQL + MinIO)
+	docker compose up -d
+	@echo "Waiting for services..."
+	@docker compose exec postgres pg_isready -U $${POSTGRES_USER:-course_supporter} > /dev/null 2>&1 && \
+		echo "PostgreSQL: ready" || echo "PostgreSQL: waiting..."
+	@echo "MinIO Console: http://localhost:9001"
+
+down:  ## Зупинити інфраструктуру
+	docker compose down
+
+reset:  ## Зупинити та видалити всі дані (чистий рестарт)
+	docker compose down -v
+
+logs:  ## Показати логи сервісів
+	docker compose logs -f
+
+ps:  ## Статус сервісів
+	docker compose ps

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,52 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg17
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./scripts/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: minio/minio:latest
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY}
+    ports:
+      - "9000:9000"   # API
+      - "9001:9001"   # Console UI
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 ${S3_ACCESS_KEY} ${S3_SECRET_KEY};
+      mc mb local/${S3_BUCKET} --ignore-existing;
+      exit 0;
+      "
+
+volumes:
+  postgres_data:
+  minio_data:

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE EXTENSION IF NOT EXISTS vector;
+EOSQL
+
+echo "pgvector extension created successfully"


### PR DESCRIPTION
Локальна інфраструктура для розробки (додаток запускається через uv run, НЕ в контейнері):

docker-compose.yaml:
- PostgreSQL через pgvector/pgvector:pg17 (офіційний образ з pgvector, замість postgres:17-alpine, де pgvector відсутній)
- Явний environment замість env_file (не завантажує зайві змінні)
- MinIO з curl-based healthcheck (замість mc ready, що потребує alias)
- minio-init: одноразовий контейнер для створення бакету course-materials
- Health checks для обох сервісів, named volumes для персистентності

scripts/init-db.sh:
- CREATE EXTENSION IF NOT EXISTS vector при першому створенні БД

Makefile:
- Додано targets: up, down, reset (down -v), logs, ps

.gitignore:
- Додано postgres_data/, minio_data/ (bind mount fallback)

Верифікація:
- PostgreSQL healthy, pgvector 0.8.1 встановлено
- MinIO healthy, бакет course-materials створено автоматично
- Clean restart (down -v + up -d) працює коректно