### PR TITLE
Відкладено branch protection — недоступний на free plan GitHub

### DIFF
--- a/current-doc/S1-materials-to-structure/E1-zero-to-make-check/T6-ci/T006-ci.md
+++ b/current-doc/S1-materials-to-structure/E1-zero-to-make-check/T6-ci/T006-ci.md
@@ -17,7 +17,7 @@
 - [x] Pipeline: ruff check → ruff format --check → mypy → pytest → AI review (тільки PR)
 - [x] AI review запускається ТІЛЬКИ після успішного проходження lint + typecheck + test
 - [x] AI review залишає inline-коментарі до PR з рекомендаціями
-- [ ] Будь-який fail lint/typecheck/test — блокує merge PR
+- [ ] ~~Будь-який fail lint/typecheck/test — блокує merge PR~~ — відкладено: branch protection недоступний на free plan GitHub для приватних репо
 - [x] AI review fail НЕ блокує merge (залежить від зовнішнього API)
 - [x] `uv` використовується для встановлення залежностей (з кешуванням)
 - [ ] Pipeline завершується за < 5 хвилин (3 parallel jobs + AI review)
@@ -171,6 +171,8 @@ jobs:
 > `AI Code Review` НЕ додаємо як required status check — він `allow_failure` за своєю природою (залежить від зовнішнього API, може бути rate limited). Але його результати видно як коментарі до PR.
 
 > Це не автоматизується через CI — робиться вручну один раз в GitHub UI.
+
+> **⚠️ Статус:** відкладено. Branch protection rules недоступні на free plan GitHub для приватних репозиторіїв. Увімкнути при переході на Team/Pro план або при переведенні репо в public.
 
 ---
 

--- a/current-doc/S1-materials-to-structure/E1-zero-to-make-check/T6-ci/T006-github-issue.md
+++ b/current-doc/S1-materials-to-structure/E1-zero-to-make-check/T6-ci/T006-github-issue.md
@@ -28,7 +28,7 @@ PR створено → lint + typecheck + tests паралельно → все
 - [x] AI review залишає inline-коментарі до PR
 - [x] AI review НЕ запускається на push в main (тільки PR)
 - [ ] Pipeline завершується за < 5 хвилин
-- [ ] При fail lint/typecheck/test — PR не можна merge
+- [ ] ~~При fail lint/typecheck/test — PR не можна merge~~ — відкладено: branch protection недоступний на free plan GitHub для приватних репо
 - [x] CI badge відображається в README
 
 ## Залежності


### PR DESCRIPTION
Приватний репо на безкоштовному тарифі не підтримує branch protection rules. Увімкнути при переході на Team/Pro або public.