### PR TITLE
S1-016: WebProcessor with trafilatura content extraction

### DIFF
--- a/src/course_supporter/ingestion/web.py
+++ b/src/course_supporter/ingestion/web.py
@@ -1,1 +1,148 @@
-"""WebProcessor: HTML fetch and content extraction. TODO: implement."""
+"""Web processor using trafilatura for content extraction."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import structlog
+
+from course_supporter.ingestion.base import (
+    ProcessingError,
+    SourceProcessor,
+    UnsupportedFormatError,
+)
+from course_supporter.models.source import (
+    ChunkType,
+    ContentChunk,
+    SourceDocument,
+    SourceType,
+)
+
+if TYPE_CHECKING:
+    from course_supporter.llm.router import ModelRouter
+    from course_supporter.storage.orm import SourceMaterial
+
+logger = structlog.get_logger()
+
+
+class WebProcessor(SourceProcessor):
+    """Process web pages by fetching HTML and extracting content.
+
+    Uses trafilatura for intelligent content extraction
+    (article text, removing boilerplate/navigation).
+    Raw HTML is saved as content_snapshot for re-processing.
+    """
+
+    async def process(
+        self,
+        source: SourceMaterial,
+        *,
+        router: ModelRouter | None = None,
+    ) -> SourceDocument:
+        if source.source_type != SourceType.WEB:
+            raise UnsupportedFormatError(
+                f"WebProcessor expects 'web', got '{source.source_type}'"
+            )
+
+        url = source.source_url
+        parsed_url = urlparse(url)
+        domain = parsed_url.netloc
+
+        logger.info("web_processing_start", url=url, domain=domain)
+
+        # 1. Fetch HTML
+        html = self._fetch_html(url)
+
+        # 2. Extract content
+        extracted = self._extract_content(html)
+
+        # 3. Split into chunks
+        chunks = self._text_to_chunks(extracted) if extracted else []
+
+        fetched_at = datetime.now(UTC).isoformat()
+
+        logger.info(
+            "web_processing_done",
+            url=url,
+            chunk_count=len(chunks),
+        )
+
+        return SourceDocument(
+            source_type=SourceType.WEB,
+            source_url=url,
+            title=source.filename or domain,
+            chunks=chunks,
+            metadata={
+                "domain": domain,
+                "fetched_at": fetched_at,
+                "content_snapshot": html,
+            },
+        )
+
+    @staticmethod
+    def _fetch_html(url: str) -> str:
+        """Fetch HTML from URL using trafilatura.
+
+        Args:
+            url: The URL to fetch.
+
+        Returns:
+            Raw HTML string.
+
+        Raises:
+            ProcessingError: If fetch fails (returns None).
+        """
+        import trafilatura
+
+        result = trafilatura.fetch_url(url)
+        if result is None:
+            raise ProcessingError(
+                f"Failed to fetch URL: {url}. The page may be unreachable or blocked."
+            )
+        return str(result)
+
+    @staticmethod
+    def _extract_content(html: str) -> str | None:
+        """Extract main content from HTML using trafilatura.
+
+        Args:
+            html: Raw HTML string.
+
+        Returns:
+            Extracted text content, or None if extraction fails.
+        """
+        import trafilatura
+
+        result = trafilatura.extract(
+            html,
+            include_comments=False,
+            include_tables=True,
+        )
+        if result is None:
+            return None
+        return str(result)
+
+    @staticmethod
+    def _text_to_chunks(text: str) -> list[ContentChunk]:
+        """Split extracted text into content chunks.
+
+        Splits on double newlines to create paragraph-like chunks.
+        """
+        chunks: list[ContentChunk] = []
+        paragraphs = text.strip().split("\n\n")
+
+        for idx, para in enumerate(paragraphs):
+            para = para.strip()
+            if not para:
+                continue
+            chunks.append(
+                ContentChunk(
+                    chunk_type=ChunkType.WEB_CONTENT,
+                    text=para,
+                    index=idx,
+                )
+            )
+
+        return chunks

--- a/tests/unit/test_ingestion/test_web.py
+++ b/tests/unit/test_ingestion/test_web.py
@@ -1,0 +1,118 @@
+"""Tests for WebProcessor."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from course_supporter.ingestion.base import ProcessingError, UnsupportedFormatError
+from course_supporter.ingestion.web import WebProcessor
+from course_supporter.models.source import ChunkType, SourceDocument, SourceType
+
+
+def _make_source(
+    source_type: str = "web",
+    url: str = "https://example.com/article",
+    filename: str | None = None,
+) -> MagicMock:
+    """Create a mock SourceMaterial."""
+    source = MagicMock()
+    source.source_type = source_type
+    source.source_url = url
+    source.filename = filename
+    return source
+
+
+class TestWebProcessor:
+    async def test_fetch_success(self) -> None:
+        """Mock trafilatura -> SourceDocument with WEB_CONTENT chunks."""
+        with (
+            patch(
+                "trafilatura.fetch_url",
+                return_value="<html>content</html>",
+            ),
+            patch(
+                "trafilatura.extract",
+                return_value="Extracted paragraph one\n\nParagraph two",
+            ),
+        ):
+            proc = WebProcessor()
+            doc = await proc.process(_make_source())
+
+        assert isinstance(doc, SourceDocument)
+        assert doc.source_type == SourceType.WEB
+        assert len(doc.chunks) == 2
+        assert doc.chunks[0].chunk_type == ChunkType.WEB_CONTENT
+
+    async def test_fetch_failure(self) -> None:
+        """fetch_url returns None -> ProcessingError."""
+        with patch("trafilatura.fetch_url", return_value=None):
+            proc = WebProcessor()
+            with pytest.raises(ProcessingError, match="Failed to fetch URL"):
+                await proc.process(_make_source())
+
+    async def test_extract_empty(self) -> None:
+        """extract returns None -> empty chunks (not an error)."""
+        with (
+            patch("trafilatura.fetch_url", return_value="<html></html>"),
+            patch("trafilatura.extract", return_value=None),
+        ):
+            proc = WebProcessor()
+            doc = await proc.process(_make_source())
+
+        assert doc.chunks == []
+
+    async def test_domain_in_metadata(self) -> None:
+        """URL domain extracted to metadata."""
+        with (
+            patch("trafilatura.fetch_url", return_value="<html>ok</html>"),
+            patch("trafilatura.extract", return_value="text"),
+        ):
+            proc = WebProcessor()
+            doc = await proc.process(
+                _make_source(url="https://docs.python.org/3/tutorial.html")
+            )
+
+        assert doc.metadata["domain"] == "docs.python.org"
+
+    async def test_invalid_source_type(self) -> None:
+        """Non-web source_type -> UnsupportedFormatError."""
+        proc = WebProcessor()
+        with pytest.raises(UnsupportedFormatError, match="expects 'web'"):
+            await proc.process(_make_source(source_type="text"))
+
+    async def test_content_snapshot(self) -> None:
+        """Raw HTML saved in metadata for later re-processing."""
+        raw_html = "<html><body>Raw content</body></html>"
+        with (
+            patch("trafilatura.fetch_url", return_value=raw_html),
+            patch("trafilatura.extract", return_value="Content"),
+        ):
+            proc = WebProcessor()
+            doc = await proc.process(_make_source())
+
+        assert doc.metadata["content_snapshot"] == raw_html
+
+    async def test_chunks_indexed(self) -> None:
+        """Multiple paragraphs -> ordered chunks."""
+        text = "Para 1\n\nPara 2\n\nPara 3"
+        with (
+            patch("trafilatura.fetch_url", return_value="<html>ok</html>"),
+            patch("trafilatura.extract", return_value=text),
+        ):
+            proc = WebProcessor()
+            doc = await proc.process(_make_source())
+
+        assert len(doc.chunks) == 3
+        indices = [c.index for c in doc.chunks]
+        assert indices == [0, 1, 2]
+
+    async def test_fetched_at_in_metadata(self) -> None:
+        """fetched_at timestamp present in metadata."""
+        with (
+            patch("trafilatura.fetch_url", return_value="<html>ok</html>"),
+            patch("trafilatura.extract", return_value="text"),
+        ):
+            proc = WebProcessor()
+            doc = await proc.process(_make_source())
+
+        assert "fetched_at" in doc.metadata


### PR DESCRIPTION
Fetch HTML via trafilatura.fetch_url, extract main content via trafilatura.extract, split into WEB_CONTENT chunks by paragraphs. Metadata includes domain, fetched_at (UTC), and raw HTML content_snapshot. 8 new tests (155 total).

Підсумок S1-016:                                                                                                      
                                                                                                                        
  - WebProcessor — fetch HTML через trafilatura.fetch_url(), extract content через trafilatura.extract(), split на      
  paragraphs → WEB_CONTENT chunks                                                                                       
  - Metadata: domain (з urlparse), fetched_at (UTC ISO), content_snapshot (raw HTML для re-processing)
  - Error handling: fetch failure → ProcessingError, empty extract → empty chunks (не помилка)                          
  - 8 тестів: success, fetch failure, empty extract, domain, invalid source type, content snapshot, chunk indexing,
  fetched_at