### PR TITLE
S1-017: MergeStep — combine SourceDocuments into CourseContext

### DIFF
--- a/src/course_supporter/ingestion/merge.py
+++ b/src/course_supporter/ingestion/merge.py
@@ -15,7 +15,7 @@ from course_supporter.models.source import (
 logger = structlog.get_logger()
 
 # Priority order for document types (lower index = higher priority)
-SOURCE_TYPE_PRIORITY: dict[str, int] = {
+SOURCE_TYPE_PRIORITY: dict[SourceType, int] = {
     SourceType.VIDEO: 0,
     SourceType.PRESENTATION: 1,
     SourceType.TEXT: 2,


### PR DESCRIPTION
Pure sync data transformation: sort documents by type priority (video → presentation → text → web), cross-reference presentation slides with video timecodes via SlideVideoMapEntry mappings. 11 tests covering ordering, cross-refs, immutability, edge cases.

 Підсумок S1-017                                                                                                     


  │      Метрика      │                    Значення                     │
  │ Файли             │ merge.py (реалізація), test_merge.py (тести)    │

  │ Тести             │ 11 нових, 166 загалом                           │
  │ make check        │ lint ✅, mypy ✅, pytest ✅                     │
  │ Ручний smoke test │ ✅ — сортування, cross-references, immutability │

