### PR TITLE
feat(PD-002): add tenant_id FK to courses and llm_calls

### DIFF
--- a/migrations/versions/ec62b2f8d538_add_tenant_id_to_courses_and_llm_calls.py
+++ b/migrations/versions/ec62b2f8d538_add_tenant_id_to_courses_and_llm_calls.py
@@ -1,0 +1,81 @@
+"""add_tenant_id_to_courses_and_llm_calls
+
+Three-step migration:
+1. Add tenant_id as NULLABLE
+2. Create 'system' tenant and backfill existing rows
+3. Set NOT NULL, add FK constraints and indexes
+
+Revision ID: ec62b2f8d538
+Revises: bb847e98ee7b
+Create Date: 2026-02-15 15:46:07.634156
+
+"""
+
+from typing import Sequence, Union
+
+import uuid_utils as uuid7_lib
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "ec62b2f8d538"
+down_revision: Union[str, Sequence[str], None] = "bb847e98ee7b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add tenant_id to courses and llm_calls with backfill."""
+    # 1. Add columns as NULLABLE
+    op.add_column("courses", sa.Column("tenant_id", sa.Uuid(), nullable=True))
+    op.add_column("llm_calls", sa.Column("tenant_id", sa.Uuid(), nullable=True))
+
+    # 2. Create system tenant and backfill existing rows
+    conn = op.get_bind()
+    system_tenant_id = str(uuid7_lib.uuid7())
+    conn.execute(
+        sa.text("INSERT INTO tenants (id, name, is_active) VALUES (:id, :name, true)"),
+        {"id": system_tenant_id, "name": "system"},
+    )
+    conn.execute(
+        sa.text("UPDATE courses SET tenant_id = :tid WHERE tenant_id IS NULL"),
+        {"tid": system_tenant_id},
+    )
+    conn.execute(
+        sa.text("UPDATE llm_calls SET tenant_id = :tid WHERE tenant_id IS NULL"),
+        {"tid": system_tenant_id},
+    )
+
+    # 3. Set NOT NULL + FK + index
+    op.alter_column("courses", "tenant_id", nullable=False)
+    op.alter_column("llm_calls", "tenant_id", nullable=False)
+    op.create_foreign_key(
+        "fk_courses_tenant_id",
+        "courses",
+        "tenants",
+        ["tenant_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_llm_calls_tenant_id",
+        "llm_calls",
+        "tenants",
+        ["tenant_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index("ix_courses_tenant_id", "courses", ["tenant_id"])
+    op.create_index("ix_llm_calls_tenant_id", "llm_calls", ["tenant_id"])
+
+
+def downgrade() -> None:
+    """Remove tenant_id from courses and llm_calls."""
+    op.drop_index("ix_llm_calls_tenant_id", table_name="llm_calls")
+    op.drop_index("ix_courses_tenant_id", table_name="courses")
+    op.drop_constraint("fk_llm_calls_tenant_id", "llm_calls", type_="foreignkey")
+    op.drop_constraint("fk_courses_tenant_id", "courses", type_="foreignkey")
+    op.drop_column("llm_calls", "tenant_id")
+    op.drop_column("courses", "tenant_id")
+    # Note: system tenant row is NOT removed (idempotent — harmless if kept)

--- a/src/course_supporter/api/routes/courses.py
+++ b/src/course_supporter/api/routes/courses.py
@@ -43,7 +43,11 @@ async def create_course(
 ) -> CourseResponse:
     """Create a new course."""
     repo = CourseRepository(session)
-    course = await repo.create(title=body.title, description=body.description)
+    # TODO(PD-003): replace stub with tenant_id from auth middleware
+    tenant_id = body.tenant_id
+    course = await repo.create(
+        tenant_id=tenant_id, title=body.title, description=body.description
+    )
     await session.commit()
     return CourseResponse.model_validate(course)
 

--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -13,6 +13,8 @@ from course_supporter.models.course import SlideVideoMapEntry
 class CourseCreateRequest(BaseModel):
     """Request body for POST /courses."""
 
+    # TODO(PD-003): remove tenant_id from body; extract from auth token
+    tenant_id: uuid.UUID
     title: str = Field(..., min_length=1, max_length=500)
     description: str | None = None
 

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -86,6 +86,9 @@ class Course(Base):
     __tablename__ = "courses"
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("tenants.id", ondelete="CASCADE"), index=True
+    )
     title: Mapped[str] = mapped_column(String(500))
     description: Mapped[str | None] = mapped_column(Text)
     learning_goal: Mapped[str | None] = mapped_column(Text)
@@ -99,6 +102,7 @@ class Course(Base):
     )
 
     # Relationships
+    tenant: Mapped["Tenant"] = relationship()
     source_materials: Mapped[list["SourceMaterial"]] = relationship(
         back_populates="course", cascade="all, delete-orphan"
     )
@@ -277,6 +281,9 @@ class LLMCall(Base):
     __tablename__ = "llm_calls"
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("tenants.id", ondelete="CASCADE"), index=True
+    )
     action: Mapped[str] = mapped_column(String(100), default="")
     strategy: Mapped[str] = mapped_column(String(50), default="default")
     provider: Mapped[str] = mapped_column(String(50))
@@ -291,3 +298,6 @@ class LLMCall(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
+
+    # Relationships
+    tenant: Mapped["Tenant"] = relationship()

--- a/src/course_supporter/storage/repositories.py
+++ b/src/course_supporter/storage/repositories.py
@@ -48,19 +48,21 @@ class CourseRepository:
     async def create(
         self,
         *,
+        tenant_id: uuid.UUID,
         title: str,
         description: str | None = None,
     ) -> Course:
         """Create a new course.
 
         Args:
+            tenant_id: UUID of the owning tenant.
             title: Course title.
             description: Optional course description.
 
         Returns:
             The newly created Course ORM instance.
         """
-        course = Course(title=title, description=description)
+        course = Course(tenant_id=tenant_id, title=title, description=description)
         self._session.add(course)
         await self._session.flush()
         return course

--- a/tests/unit/test_api/test_courses_create.py
+++ b/tests/unit/test_api/test_courses_create.py
@@ -11,6 +11,8 @@ from course_supporter.api.app import app
 from course_supporter.storage.database import get_session
 from course_supporter.storage.repositories import CourseRepository
 
+STUB_TENANT_ID = str(uuid.uuid4())
+
 
 def _make_course_mock(
     *,
@@ -52,7 +54,7 @@ class TestCreateCourseAPI:
         with patch.object(CourseRepository, "create", return_value=_make_course_mock()):
             response = await client.post(
                 "/api/v1/courses",
-                json={"title": "Python 101"},
+                json={"tenant_id": STUB_TENANT_ID, "title": "Python 101"},
             )
         assert response.status_code == 201
 
@@ -63,7 +65,7 @@ class TestCreateCourseAPI:
         with patch.object(CourseRepository, "create", return_value=course):
             response = await client.post(
                 "/api/v1/courses",
-                json={"title": "Python 101"},
+                json={"tenant_id": STUB_TENANT_ID, "title": "Python 101"},
             )
         data = response.json()
         assert data["id"] == str(course.id)
@@ -75,7 +77,11 @@ class TestCreateCourseAPI:
         with patch.object(CourseRepository, "create", return_value=course):
             response = await client.post(
                 "/api/v1/courses",
-                json={"title": "Python 101", "description": "Intro to Python"},
+                json={
+                    "tenant_id": STUB_TENANT_ID,
+                    "title": "Python 101",
+                    "description": "Intro to Python",
+                },
             )
         assert response.status_code == 201
         assert response.json()["description"] == "Intro to Python"
@@ -87,7 +93,7 @@ class TestCreateCourseAPI:
         with patch.object(CourseRepository, "create", return_value=course):
             response = await client.post(
                 "/api/v1/courses",
-                json={"title": "Python 101"},
+                json={"tenant_id": STUB_TENANT_ID, "title": "Python 101"},
             )
         assert response.status_code == 201
         assert response.json()["description"] is None
@@ -99,7 +105,7 @@ class TestCreateCourseAPI:
         """POST /api/v1/courses rejects empty title."""
         response = await client.post(
             "/api/v1/courses",
-            json={"title": ""},
+            json={"tenant_id": STUB_TENANT_ID, "title": ""},
         )
         assert response.status_code == 422
 
@@ -110,7 +116,7 @@ class TestCreateCourseAPI:
         """POST /api/v1/courses rejects missing title."""
         response = await client.post(
             "/api/v1/courses",
-            json={},
+            json={"tenant_id": STUB_TENANT_ID},
         )
         assert response.status_code == 422
 
@@ -120,7 +126,7 @@ class TestCourseRepository:
     async def test_create_flushes_session(self, mock_session: AsyncMock) -> None:
         """create() calls flush, not commit."""
         repo = CourseRepository(mock_session)
-        await repo.create(title="Test")
+        await repo.create(tenant_id=uuid.uuid4(), title="Test")
         mock_session.flush.assert_awaited_once()
         mock_session.commit.assert_not_called()
 

--- a/tests/unit/test_orm_models.py
+++ b/tests/unit/test_orm_models.py
@@ -68,10 +68,10 @@ class TestORMModels:
         columns = {c.name for c in Concept.__table__.columns}
         assert "embedding" in columns
 
-    def test_llm_call_not_linked_to_course(self) -> None:
-        """LLMCall is independent — no FK to courses."""
+    def test_llm_call_linked_to_tenant(self) -> None:
+        """LLMCall has FK to tenants for billing."""
         fks = {fk.target_fullname for fk in LLMCall.__table__.foreign_keys}
-        assert len(fks) == 0
+        assert fks == {"tenants.id"}
 
     def test_slide_video_mapping_fk(self) -> None:
         """SlideVideoMapping has FK to courses."""

--- a/tests/unit/test_tenant_isolation.py
+++ b/tests/unit/test_tenant_isolation.py
@@ -1,0 +1,66 @@
+"""Tests for tenant_id on existing tables (courses, llm_calls)."""
+
+from __future__ import annotations
+
+from course_supporter.storage.orm import Course, LLMCall, _uuid7
+
+
+class TestCourseTenant:
+    """Tests for tenant_id on Course model."""
+
+    def test_course_has_tenant_id_column(self) -> None:
+        """Course table has tenant_id FK column."""
+        table = Course.__table__
+        col = table.c.tenant_id
+        assert col is not None
+        assert col.nullable is False
+
+    def test_course_with_tenant(self) -> None:
+        """Course accepts tenant_id at construction."""
+        tid = _uuid7()
+        course = Course(tenant_id=tid, title="Python 101")
+        assert course.tenant_id == tid
+        assert course.title == "Python 101"
+
+    def test_course_tenant_fk_cascade(self) -> None:
+        """Course.tenant_id FK has CASCADE ondelete."""
+        table = Course.__table__
+        fks = [fk for fk in table.foreign_keys if fk.column.table.name == "tenants"]
+        assert len(fks) == 1
+        assert fks[0].ondelete == "CASCADE"
+
+    def test_course_tenant_id_indexed(self) -> None:
+        """Course.tenant_id has an index."""
+        table = Course.__table__
+        col = table.c.tenant_id
+        assert col.index is True
+
+
+class TestLLMCallTenant:
+    """Tests for tenant_id on LLMCall model."""
+
+    def test_llm_call_has_tenant_id_column(self) -> None:
+        """LLMCall table has tenant_id FK column."""
+        table = LLMCall.__table__
+        col = table.c.tenant_id
+        assert col is not None
+        assert col.nullable is False
+
+    def test_llm_call_with_tenant(self) -> None:
+        """LLMCall accepts tenant_id at construction."""
+        tid = _uuid7()
+        call = LLMCall(tenant_id=tid, provider="gemini", model_id="gemini-2.0-flash")
+        assert call.tenant_id == tid
+
+    def test_llm_call_tenant_fk_cascade(self) -> None:
+        """LLMCall.tenant_id FK has CASCADE ondelete."""
+        table = LLMCall.__table__
+        fks = [fk for fk in table.foreign_keys if fk.column.table.name == "tenants"]
+        assert len(fks) == 1
+        assert fks[0].ondelete == "CASCADE"
+
+    def test_llm_call_tenant_id_indexed(self) -> None:
+        """LLMCall.tenant_id has an index."""
+        table = LLMCall.__table__
+        col = table.c.tenant_id
+        assert col.index is True


### PR DESCRIPTION
- tenant_id NOT NULL FK on courses and llm_calls with CASCADE delete
- Indexes on both tenant_id columns
- Three-step migration: add nullable → backfill with system tenant → set NOT NULL
- CourseRepository.create() now requires tenant_id
- CourseCreateRequest temporarily includes tenant_id (TODO: extract from auth in PD-003)
- 8 new tests for tenant isolation (351 total)

Що зроблено:                                                                                                                
  - tenant_id FK NOT NULL на courses і llm_calls з CASCADE delete + indexes                                                   
  - Трьохкрокова міграція: nullable → backfill (system tenant) → NOT NULL + FK + index                                        
  - CourseRepository.create() тепер вимагає tenant_id                                                                       
  - CourseCreateRequest тимчасово включає tenant_id (TODO: замінити на auth в PD-003)
  - 8 нових тестів tenant isolation, оновлено існуючі тести
  - 351 тест, make check зелений