### PR TITLE
feat(PD-004): add service scope enforcement with require_scope factory

### DIFF
--- a/src/course_supporter/api/routes/courses.py
+++ b/src/course_supporter/api/routes/courses.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, BackgroundTasks, Depends, Form, HTTPException, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from course_supporter.api.deps import get_current_tenant, get_s3_client, get_session
+from course_supporter.api.deps import get_s3_client, get_session
 from course_supporter.api.schemas import (
     CourseCreateRequest,
     CourseDetailResponse,
@@ -19,6 +19,7 @@ from course_supporter.api.schemas import (
 )
 from course_supporter.api.tasks import ingest_material
 from course_supporter.auth.context import TenantContext
+from course_supporter.auth.scopes import require_scope
 from course_supporter.models.source import SourceType
 from course_supporter.storage.database import async_session
 from course_supporter.storage.repositories import (
@@ -33,7 +34,8 @@ router = APIRouter(tags=["courses"])
 
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
 S3Dep = Annotated[S3Client, Depends(get_s3_client)]
-TenantDep = Annotated[TenantContext, Depends(get_current_tenant)]
+PrepDep = Annotated[TenantContext, Depends(require_scope("prep"))]
+SharedDep = Annotated[TenantContext, Depends(require_scope("prep", "check"))]
 
 VALID_SOURCE_TYPES = {t.value for t in SourceType}
 
@@ -41,7 +43,7 @@ VALID_SOURCE_TYPES = {t.value for t in SourceType}
 @router.post("/courses", status_code=201)
 async def create_course(
     body: CourseCreateRequest,
-    tenant: TenantDep,
+    tenant: PrepDep,
     session: SessionDep,
 ) -> CourseResponse:
     """Create a new course."""
@@ -56,7 +58,7 @@ async def create_course(
 @router.get("/courses/{course_id}")
 async def get_course(
     course_id: uuid.UUID,
-    tenant: TenantDep,
+    tenant: SharedDep,
     session: SessionDep,
 ) -> CourseDetailResponse:
     """Get course by ID with full nested structure."""
@@ -71,7 +73,7 @@ async def get_course(
 async def create_slide_mapping(
     course_id: uuid.UUID,
     body: SlideVideoMapRequest,
-    tenant: TenantDep,
+    tenant: PrepDep,
     session: SessionDep,
 ) -> SlideVideoMapResponse:
     """Create slide-video mappings for a course."""
@@ -93,7 +95,7 @@ async def create_slide_mapping(
 async def get_lesson(
     course_id: uuid.UUID,
     lesson_id: uuid.UUID,
-    tenant: TenantDep,
+    tenant: SharedDep,
     session: SessionDep,
 ) -> LessonDetailResponse:
     """Get lesson by ID within a course."""
@@ -108,7 +110,7 @@ async def get_lesson(
 async def create_material(
     course_id: uuid.UUID,
     background_tasks: BackgroundTasks,
-    tenant: TenantDep,
+    tenant: PrepDep,
     session: SessionDep,
     s3: S3Dep,
     source_type: Annotated[str, Form()],

--- a/src/course_supporter/api/routes/reports.py
+++ b/src/course_supporter/api/routes/reports.py
@@ -4,19 +4,19 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends
 
-from course_supporter.api.deps import get_current_tenant
 from course_supporter.auth.context import TenantContext
+from course_supporter.auth.scopes import require_scope
 from course_supporter.models.reports import CostReport
 from course_supporter.storage.database import async_session
 from course_supporter.storage.repositories import LLMCallRepository
 
 router = APIRouter(tags=["reports"])
 
-TenantDep = Annotated[TenantContext, Depends(get_current_tenant)]
+SharedDep = Annotated[TenantContext, Depends(require_scope("prep", "check"))]
 
 
 @router.get("/reports/cost", response_model=CostReport)
-async def get_cost_report(tenant: TenantDep) -> CostReport:
+async def get_cost_report(tenant: SharedDep) -> CostReport:
     """Get LLM call cost report with summary and breakdowns."""
     async with async_session() as session:
         repo = LLMCallRepository(session)

--- a/src/course_supporter/auth/__init__.py
+++ b/src/course_supporter/auth/__init__.py
@@ -1,4 +1,9 @@
-"""Authentication and API key management."""
+"""Authentication and API key management.
+
+Note: ``require_scope`` lives in ``auth.scopes`` and is NOT re-exported here
+to avoid a circular import (auth → scopes → api.deps → auth).
+Import directly: ``from course_supporter.auth.scopes import require_scope``.
+"""
 
 from course_supporter.auth.context import TenantContext
 from course_supporter.auth.keys import generate_api_key, hash_api_key

--- a/src/course_supporter/auth/scopes.py
+++ b/src/course_supporter/auth/scopes.py
@@ -1,0 +1,39 @@
+"""Scope enforcement dependency factory."""
+
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from fastapi import Depends, HTTPException
+
+from course_supporter.api.deps import get_current_tenant
+from course_supporter.auth.context import TenantContext
+
+_tenant_dep = Depends(get_current_tenant)
+
+
+def require_scope(
+    *required_scopes: str,
+) -> Callable[..., Coroutine[Any, Any, TenantContext]]:
+    """Dependency factory: require at least one of the given scopes.
+
+    Usage as parameter dependency (returns TenantContext)::
+
+        async def endpoint(
+            tenant: TenantContext = Depends(require_scope("prep")),
+        ): ...
+
+    Raises:
+        HTTPException 403: if tenant has none of the required scopes.
+    """
+
+    async def _check_scope(
+        tenant: TenantContext = _tenant_dep,
+    ) -> TenantContext:
+        if not any(s in tenant.scopes for s in required_scopes):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Requires scope: {' or '.join(required_scopes)}",
+            )
+        return tenant
+
+    return _check_scope

--- a/tests/unit/test_api/test_courses_create.py
+++ b/tests/unit/test_api/test_courses_create.py
@@ -16,7 +16,7 @@ from course_supporter.storage.repositories import CourseRepository
 STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
-    scopes=["courses:write"],
+    scopes=["prep"],
     rate_limit_prep=100,
     rate_limit_check=1000,
     key_prefix="cs_test",

--- a/tests/unit/test_api/test_courses_detail.py
+++ b/tests/unit/test_api/test_courses_detail.py
@@ -16,7 +16,7 @@ from course_supporter.storage.repositories import CourseRepository
 STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
-    scopes=["courses:read"],
+    scopes=["prep"],
     rate_limit_prep=100,
     rate_limit_check=1000,
     key_prefix="cs_test",

--- a/tests/unit/test_api/test_health.py
+++ b/tests/unit/test_api/test_health.py
@@ -15,7 +15,7 @@ from course_supporter.storage.database import get_session
 STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
-    scopes=[],
+    scopes=["prep", "check"],
     rate_limit_prep=100,
     rate_limit_check=1000,
     key_prefix="cs_test",

--- a/tests/unit/test_api/test_lesson_detail.py
+++ b/tests/unit/test_api/test_lesson_detail.py
@@ -15,7 +15,7 @@ from course_supporter.storage.repositories import LessonRepository
 STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
-    scopes=["courses:read"],
+    scopes=["prep"],
     rate_limit_prep=100,
     rate_limit_check=1000,
     key_prefix="cs_test",

--- a/tests/unit/test_api/test_materials.py
+++ b/tests/unit/test_api/test_materials.py
@@ -20,7 +20,7 @@ from course_supporter.storage.repositories import (
 STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
-    scopes=["courses:write"],
+    scopes=["prep"],
     rate_limit_prep=100,
     rate_limit_check=1000,
     key_prefix="cs_test",

--- a/tests/unit/test_api/test_slide_mapping.py
+++ b/tests/unit/test_api/test_slide_mapping.py
@@ -19,7 +19,7 @@ from course_supporter.storage.repositories import (
 STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
-    scopes=["courses:write"],
+    scopes=["prep"],
     rate_limit_prep=100,
     rate_limit_check=1000,
     key_prefix="cs_test",

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -31,7 +31,7 @@ def _make_api_key_record(
     api_key_record.tenant = tenant
     api_key_record.is_active = is_active
     api_key_record.expires_at = expires_at
-    api_key_record.scopes = scopes or ["courses:read", "courses:write"]
+    api_key_record.scopes = scopes or ["prep", "check"]
     api_key_record.rate_limit_prep = rate_limit_prep
     api_key_record.rate_limit_check = rate_limit_check
     api_key_record.key_prefix = "cs_test"
@@ -164,7 +164,7 @@ class TestAuthMiddleware:
     ) -> None:
         """Valid auth populates all TenantContext fields correctly."""
         record = _make_api_key_record(
-            scopes=["courses:read"],
+            scopes=["prep"],
             rate_limit_prep=50,
             rate_limit_check=500,
         )

--- a/tests/unit/test_cost_report.py
+++ b/tests/unit/test_cost_report.py
@@ -19,7 +19,7 @@ from course_supporter.storage.repositories import LLMCallRepository
 STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
-    scopes=[],
+    scopes=["prep", "check"],
     rate_limit_prep=100,
     rate_limit_check=1000,
     key_prefix="cs_test",

--- a/tests/unit/test_scope_enforcement.py
+++ b/tests/unit/test_scope_enforcement.py
@@ -1,0 +1,203 @@
+"""Tests for service scope enforcement (PD-004)."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from course_supporter.api.app import app
+from course_supporter.api.deps import get_current_tenant
+from course_supporter.auth.context import TenantContext
+from course_supporter.auth.scopes import require_scope
+from course_supporter.storage.database import get_session
+from course_supporter.storage.repositories import CourseRepository
+
+
+def _make_tenant(scopes: list[str]) -> TenantContext:
+    """Create a TenantContext with given scopes."""
+    return TenantContext(
+        tenant_id=uuid.uuid4(),
+        tenant_name="test-tenant",
+        scopes=scopes,
+        rate_limit_prep=100,
+        rate_limit_check=1000,
+        key_prefix="cs_test",
+    )
+
+
+def _make_course_mock() -> MagicMock:
+    """Create a mock Course ORM object."""
+    course = MagicMock()
+    course.id = uuid.uuid4()
+    course.title = "Test"
+    course.description = None
+    course.created_at = datetime.now(UTC)
+    course.updated_at = datetime.now(UTC)
+    return course
+
+
+@pytest.fixture()
+def mock_session() -> AsyncMock:
+    session = AsyncMock()
+    session.add = MagicMock()
+    return session
+
+
+class TestScopeEnforcement:
+    @pytest.mark.asyncio
+    async def test_prep_scope_allows_prep_endpoint(
+        self, mock_session: AsyncMock
+    ) -> None:
+        """Tenant with 'prep' scope can access POST /courses."""
+        tenant = _make_tenant(scopes=["prep"])
+        app.dependency_overrides[get_session] = lambda: mock_session
+        app.dependency_overrides[get_current_tenant] = lambda: tenant
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                with patch.object(
+                    CourseRepository, "create", return_value=_make_course_mock()
+                ):
+                    response = await client.post(
+                        "/api/v1/courses",
+                        json={"title": "Test Course"},
+                    )
+            assert response.status_code == 201
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_check_scope_denied_prep_endpoint(
+        self, mock_session: AsyncMock
+    ) -> None:
+        """Tenant with only 'check' scope is denied POST /courses."""
+        tenant = _make_tenant(scopes=["check"])
+        app.dependency_overrides[get_session] = lambda: mock_session
+        app.dependency_overrides[get_current_tenant] = lambda: tenant
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.post(
+                    "/api/v1/courses",
+                    json={"title": "Test Course"},
+                )
+            assert response.status_code == 403
+            assert "Requires scope: prep" in response.json()["detail"]
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_prep_scope_denied_check_only_endpoint(self) -> None:
+        """Tenant with 'prep' scope is denied a 'check'-only endpoint.
+
+        Since no 'check'-only endpoint exists yet, test via a temporary
+        FastAPI app with a check-only route.
+        """
+        test_app = FastAPI()
+        check_dep = Depends(require_scope("check"))
+
+        @test_app.get("/check-only")
+        async def check_only(
+            tenant: TenantContext = check_dep,
+        ) -> dict[str, str]:
+            return {"ok": "true"}
+
+        tenant = _make_tenant(scopes=["prep"])
+        test_app.dependency_overrides[get_current_tenant] = lambda: tenant
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=test_app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get("/check-only")
+            assert response.status_code == 403
+            assert "Requires scope: check" in response.json()["detail"]
+        finally:
+            test_app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_shared_endpoint_allows_prep(self, mock_session: AsyncMock) -> None:
+        """Tenant with 'prep' scope can access shared GET /courses/{id}."""
+        tenant = _make_tenant(scopes=["prep"])
+        course = _make_course_mock()
+        course.modules = []
+        course.source_materials = []
+        course.learning_goal = None
+        app.dependency_overrides[get_session] = lambda: mock_session
+        app.dependency_overrides[get_current_tenant] = lambda: tenant
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                with patch.object(
+                    CourseRepository, "get_with_structure", return_value=course
+                ):
+                    response = await client.get(f"/api/v1/courses/{course.id}")
+            assert response.status_code == 200
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_shared_endpoint_allows_check(self, mock_session: AsyncMock) -> None:
+        """Tenant with 'check' scope can access shared GET /courses/{id}."""
+        tenant = _make_tenant(scopes=["check"])
+        course = _make_course_mock()
+        course.modules = []
+        course.source_materials = []
+        course.learning_goal = None
+        app.dependency_overrides[get_session] = lambda: mock_session
+        app.dependency_overrides[get_current_tenant] = lambda: tenant
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                with patch.object(
+                    CourseRepository, "get_with_structure", return_value=course
+                ):
+                    response = await client.get(f"/api/v1/courses/{course.id}")
+            assert response.status_code == 200
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_both_scopes_tenant(self, mock_session: AsyncMock) -> None:
+        """Tenant with both scopes can access all endpoints."""
+        tenant = _make_tenant(scopes=["prep", "check"])
+        app.dependency_overrides[get_session] = lambda: mock_session
+        app.dependency_overrides[get_current_tenant] = lambda: tenant
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                # prep endpoint
+                with patch.object(
+                    CourseRepository, "create", return_value=_make_course_mock()
+                ):
+                    resp_prep = await client.post(
+                        "/api/v1/courses",
+                        json={"title": "Test"},
+                    )
+                assert resp_prep.status_code == 201
+
+                # shared endpoint
+                course = _make_course_mock()
+                course.modules = []
+                course.source_materials = []
+                course.learning_goal = None
+                with patch.object(
+                    CourseRepository, "get_with_structure", return_value=course
+                ):
+                    resp_shared = await client.get(f"/api/v1/courses/{course.id}")
+                assert resp_shared.status_code == 200
+        finally:
+            app.dependency_overrides.clear()


### PR DESCRIPTION
- require_scope() dependency factory in auth/scopes.py
- Prep endpoints (POST /courses, /materials, /slide-mapping) require "prep"
- Shared endpoints (GET /courses/{id}, /lessons/{id}, /reports/cost) allow "prep" or "check"
- All existing test scopes updated from courses:read/write to prep/check
- 6 new scope enforcement tests (365 total)

Зроблено:                                                                                                                   
  - auth/scopes.py — require_scope() factory dependency (повертає TenantContext або 403)
  - Prep endpoints (POST /courses, /materials, /slide-mapping) → require_scope("prep")                                        
  - Shared endpoints (GET /courses/{id}, /lessons/{id}, /reports/cost) → require_scope("prep", "check")                       
  - require_scope не re-експортується з auth/__init__.py (circular import через auth → scopes → api.deps → auth)
  - Всі існуючі тести оновлені: scopes з courses:read/write → prep/check
  - 6 нових тестів в test_scope_enforcement.py
  - 365 тестів, make check зелений