### PR TITLE
PD-009: docker-compose.prod.yaml — Detail

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,23 @@
+# === App ===
+ENVIRONMENT=production
+LOG_LEVEL=INFO
+CORS_ALLOWED_ORIGINS=["https://pythoncourse.me"]
+
+# === PostgreSQL ===
+POSTGRES_USER=course_supporter
+POSTGRES_PASSWORD=<generate-strong-password>
+POSTGRES_DB=course_supporter
+POSTGRES_HOST=postgres-cs
+POSTGRES_PORT=5432
+
+# === Backblaze B2 (S3-compatible) ===
+S3_ENDPOINT=https://s3.us-west-004.backblazeb2.com
+S3_ACCESS_KEY=<backblaze-app-key-id>
+S3_SECRET_KEY=<backblaze-app-key>
+S3_BUCKET=course-supporter-materials
+
+# === LLM API Keys ===
+GEMINI_API_KEY=<key>
+ANTHROPIC_API_KEY=<key>
+OPENAI_API_KEY=<key>
+DEEPSEEK_API_KEY=<key>

--- a/current-doc/S2-prod-deploy/Sprint-Prod-Deploy/E2-production-docker-infra/PD-009-docker-compose-prod/PD-009-detail.md
+++ b/current-doc/S2-prod-deploy/Sprint-Prod-Deploy/E2-production-docker-infra/PD-009-docker-compose-prod/PD-009-detail.md
@@ -99,11 +99,18 @@ docker compose -f docker-compose.prod.yaml up -d app
 docker compose -f docker-compose.prod.yaml exec app alembic upgrade head
 ```
 
+## Результати верифікації
+
+```
+docker compose -f docker-compose.prod.yaml config  → valid (з .env.prod)
+make check                                          → 385 passed
+```
+
 ## Definition of Done
 
-- [ ] `docker-compose.prod.yaml` працює
-- [ ] `.env.prod.example` з усіма змінними
-- [ ] App підключається до `shared-net`
-- [ ] PostgreSQL з healthcheck та persistent volume
-- [ ] `make check` зелений
-- [ ] Документ оновлений відповідно до фінальної реалізації
+- [x] `docker-compose.prod.yaml` працює
+- [x] `.env.prod.example` з усіма змінними
+- [x] App підключається до `shared-net`
+- [x] PostgreSQL з healthcheck та persistent volume
+- [x] `make check` зелений
+- [x] Документ оновлений відповідно до фінальної реалізації

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,0 +1,40 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: course-supporter-app
+    restart: unless-stopped
+    env_file: .env.prod
+    depends_on:
+      postgres-cs:
+        condition: service_healthy
+    networks:
+      - default
+      - shared-net
+    # No ports — nginx proxies via shared-net
+
+  postgres-cs:
+    image: pgvector/pgvector:pg17
+    container_name: course-supporter-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-course_supporter}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-course_supporter}
+    volumes:
+      - pgdata-cs:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-course_supporter}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - default
+
+networks:
+  shared-net:
+    external: true
+
+volumes:
+  pgdata-cs:


### PR DESCRIPTION
  - docker-compose.prod.yaml — app (build з Dockerfile) + postgres-cs (pgvector/pgvector:pg17), shared-net external network, healthcheck, persistent volume pgdata-cs, env_file: .env.prod
  - .env.prod.example — всі змінні: App, PostgreSQL (POSTGRES_HOST=postgres-cs), Backblaze B2 S3, LLM API keys

  Ключові рішення з документації:
  - App не експонує порти — nginx проксує через shared-net
  - Alembic міграції — окремо при deploy, не в entrypoint
  - PostgreSQL depends_on: service_healthy — гарантований порядок запуску

  Перевірки: compose config валідний, make check — 385 тестів зелені.