### PR TITLE
PD-015: Netdata monitoring + infrastructure documentation

### DIFF
--- a/current-doc/S2-prod-deploy/infrastructure/README.md
+++ b/current-doc/S2-prod-deploy/infrastructure/README.md
@@ -1,0 +1,98 @@
+# Infrastructure Overview
+
+## Architecture
+
+Course Supporter API runs on a shared VPS alongside an existing Django application.
+Both projects communicate through a shared Docker network and a single nginx reverse proxy.
+
+```
+                        Internet
+                           │
+                      :80 / :443
+                           │
+                    ┌──────┴──────┐
+                    │    nginx    │  (Django compose)
+                    │  (shared)  │
+                    └──┬─────┬───┘
+                       │     │
+            shared-net │     │ shared-net
+                       │     │
+         ┌─────────────┘     └──────────────┐
+         │                                   │
+ ┌───────┴────────────────┐   ┌─────────────┴─────────┐
+ │  Course Supporter      │   │  Django App            │
+ │  compose               │   │  compose               │
+ │                        │   │                        │
+ │  app (:8000)           │   │  django (:8000)        │
+ │  postgres-cs           │   │  postgres              │
+ │  netdata (:19999)      │   │  nginx (reverse proxy) │
+ └────────────────────────┘   └────────────────────────┘
+```
+
+## Components
+
+| Component | Image | Purpose | Network |
+|-----------|-------|---------|---------|
+| **app** | Custom (Dockerfile) | FastAPI API server, 2 uvicorn workers | default + shared-net |
+| **postgres-cs** | pgvector/pgvector:pg17 | PostgreSQL 17 with pgvector extension | default |
+| **netdata** | netdata/netdata:stable | System monitoring dashboard + alerts | default + shared-net |
+| **nginx** | (Django compose) | TLS termination, reverse proxy | shared-net |
+
+## Networking
+
+- **`default`** network: internal communication between app, postgres-cs, netdata
+- **`shared-net`** (external): cross-compose routing; nginx → app, nginx → netdata
+- No ports exposed on Course Supporter containers — all external traffic goes through nginx
+
+## Domain & TLS
+
+- **Domain:** `api.pythoncourse.me`
+- **DNS:** CNAME → `pythoncourse.me` (same VPS)
+- **TLS:** Let's Encrypt certificate via certbot (auto-renewal via cron)
+- **Protocols:** TLSv1.2 / TLSv1.3, modern ciphers, OCSP stapling, HSTS
+
+## Routing
+
+| Path | Target | Auth |
+|------|--------|------|
+| `/` | app:8000 (FastAPI) | API key (`X-API-Key` header) |
+| `/health` | app:8000 | None (public) |
+| `/docs` | app:8000 (Swagger UI) | None (public) |
+| `/netdata/` | netdata:19999 | HTTP basic auth |
+
+## Storage
+
+- **Database:** PostgreSQL 17 with pgvector, data in Docker named volume `pgdata-cs`
+- **Object storage:** Backblaze B2 (S3-compatible), bucket `course-materials`
+- **Dev storage:** MinIO (local S3, docker-compose.yaml)
+
+## Key Config Files
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.prod.yaml` | Production services: app, postgres-cs, netdata |
+| `docker-compose.yaml` | Dev services: postgres, minio, minio-init |
+| `Dockerfile` | Multi-stage build: builder (uv sync) → runtime (python:3.13-slim) |
+| `deploy/nginx/course-supporter.conf` | Nginx server block for api.pythoncourse.me |
+| `deploy/netdata/` | Netdata config templates (Telegram alerts, custom thresholds) |
+| `.env.prod` | Production env vars (NOT in git) |
+| `.env.example` | Template for env vars |
+
+## Monitoring
+
+Three layers:
+
+1. **Netdata** — system metrics (CPU, RAM, disk, network, Docker containers), dashboard at `/netdata/`, Telegram alerts
+2. **Deep health check** — `/health` endpoint checks DB + S3 connectivity, returns 200/503
+3. **UptimeRobot** (external) — pings `/health` every 5 min, Telegram alert on downtime
+
+## Security
+
+- Non-root Docker user (`app`) in Dockerfile
+- API key authentication with SHA-256 hashing
+- Tenant data isolation via `tenant_id` scoping
+- Rate limiting per tenant per scope (prep/check)
+- TLS hardening (modern ciphers, HSTS, OCSP)
+- Security headers: X-Content-Type-Options, X-Frame-Options, X-XSS-Protection
+- Netdata dashboard behind HTTP basic auth
+- No Docker socket exposed to app container (only to netdata for container metrics)

--- a/current-doc/S2-prod-deploy/infrastructure/deployment-guide.md
+++ b/current-doc/S2-prod-deploy/infrastructure/deployment-guide.md
@@ -1,0 +1,192 @@
+# Deployment Guide
+
+Step-by-step guide to deploy Course Supporter API on a fresh VPS or redeploy after changes.
+
+## Prerequisites
+
+- VPS with Ubuntu 22.04+ and Docker Engine installed
+- Domain `api.pythoncourse.me` with DNS A/CNAME pointing to VPS IP
+- Existing nginx running in a separate Docker compose (Django project) with `shared-net`
+- SSH access to VPS
+
+## 1. Clone Repository
+
+```bash
+ssh user@vps
+cd /opt
+git clone git@github.com:KonstZiv/course-supporter.git
+cd course-supporter
+```
+
+## 2. Create shared-net (if not exists)
+
+```bash
+docker network create shared-net || true
+```
+
+## 3. Configure Environment
+
+```bash
+cp .env.example .env.prod
+nano .env.prod
+```
+
+Required variables:
+
+```bash
+# PostgreSQL
+POSTGRES_USER=course_supporter
+POSTGRES_PASSWORD=<strong-password>
+POSTGRES_DB=course_supporter
+POSTGRES_HOST=postgres-cs
+POSTGRES_PORT=5432
+
+# Backblaze B2 (S3-compatible)
+S3_ENDPOINT=https://s3.us-west-004.backblazeb2.com
+S3_ACCESS_KEY=<b2-key-id>
+S3_SECRET_KEY=<b2-application-key>
+S3_BUCKET=course-materials
+
+# LLM API Keys
+GEMINI_API_KEY=<key>
+ANTHROPIC_API_KEY=<key>
+OPENAI_API_KEY=<key>
+DEEPSEEK_API_KEY=<key>
+
+# App
+ENVIRONMENT=production
+LOG_LEVEL=INFO
+```
+
+## 4. Build and Start Services
+
+```bash
+docker compose -f docker-compose.prod.yaml build
+docker compose -f docker-compose.prod.yaml up -d
+```
+
+Verify containers:
+
+```bash
+docker compose -f docker-compose.prod.yaml ps
+# Expected: app (running), postgres-cs (healthy), netdata (running)
+```
+
+## 5. Run Database Migrations
+
+```bash
+docker compose -f docker-compose.prod.yaml exec app alembic upgrade head
+```
+
+## 6. Configure Nginx
+
+Copy nginx config to the Django project's nginx directory:
+
+```bash
+# Adjust path to your nginx config directory
+cp deploy/nginx/course-supporter.conf /path/to/django-project/nginx/conf.d/
+
+# Reload nginx
+docker exec <nginx-container> nginx -s reload
+```
+
+## 7. SSL Certificate (first time only)
+
+```bash
+# Create certificate via certbot (webroot mode)
+docker exec <nginx-container> certbot certonly \
+    --webroot -w /var/www/html \
+    -d api.pythoncourse.me \
+    --agree-tos --email your@email.com
+
+# Reload nginx to pick up new cert
+docker exec <nginx-container> nginx -s reload
+```
+
+Certificate auto-renews via certbot's cron job.
+
+## 8. Create First Tenant
+
+```bash
+docker compose -f docker-compose.prod.yaml exec app \
+    python -m course_supporter.scripts.manage_tenant \
+    create-tenant --name "MyCompany"
+
+docker compose -f docker-compose.prod.yaml exec app \
+    python -m course_supporter.scripts.manage_tenant \
+    create-key --tenant-name "MyCompany" --label "production" --scopes prep,check
+```
+
+Save the displayed API key — it's shown only once.
+
+## 9. Smoke Test
+
+```bash
+# Health check (no auth)
+curl https://api.pythoncourse.me/health
+# Expected: {"status": "ok", "checks": {"db": "ok", "s3": "ok"}, ...}
+
+# Auth check
+curl -H "X-API-Key: cs_live_..." https://api.pythoncourse.me/api/v1/courses
+# Expected: 200 OK
+
+# No auth → 401
+curl https://api.pythoncourse.me/api/v1/courses
+# Expected: 401 Unauthorized
+```
+
+## 10. Setup Netdata Monitoring
+
+See [netdata-setup.md](netdata-setup.md) for Telegram alerts and custom thresholds.
+
+---
+
+## Redeployment (after code changes)
+
+```bash
+ssh user@vps
+cd /opt/course-supporter
+git pull origin main
+docker compose -f docker-compose.prod.yaml build app
+docker compose -f docker-compose.prod.yaml up -d app
+docker compose -f docker-compose.prod.yaml exec app alembic upgrade head
+```
+
+## Troubleshooting
+
+### App won't start
+
+```bash
+# Check logs
+docker compose -f docker-compose.prod.yaml logs app --tail=50
+
+# Check if postgres is healthy
+docker compose -f docker-compose.prod.yaml ps postgres-cs
+```
+
+### 502 Bad Gateway from nginx
+
+```bash
+# Check if app container is running and on shared-net
+docker inspect course-supporter-app --format '{{json .NetworkSettings.Networks}}' | jq
+
+# Verify nginx can resolve the container
+docker exec <nginx-container> ping -c1 course-supporter-app
+```
+
+### Database connection refused
+
+```bash
+# Check if postgres is accepting connections
+docker compose -f docker-compose.prod.yaml exec postgres-cs pg_isready
+
+# Check .env.prod POSTGRES_HOST matches container name (postgres-cs)
+```
+
+### S3/B2 upload fails
+
+```bash
+# Verify credentials in .env.prod
+# Check app logs for S3 errors
+docker compose -f docker-compose.prod.yaml logs app | grep s3
+```

--- a/current-doc/S2-prod-deploy/infrastructure/netdata-setup.md
+++ b/current-doc/S2-prod-deploy/infrastructure/netdata-setup.md
@@ -1,0 +1,149 @@
+# Netdata Monitoring Setup
+
+Netdata provides real-time system monitoring with a web dashboard and Telegram alerts.
+
+## Architecture
+
+```
+Browser → nginx (/netdata/) → basic auth → netdata:19999
+                                              │
+                                    ┌─────────┼─────────┐
+                                    │         │         │
+                                  /proc    /sys    docker.sock
+                                  (CPU,    (disk,   (container
+                                   RAM)    net)     metrics)
+```
+
+- Dashboard: `https://api.pythoncourse.me/netdata/`
+- Protected by HTTP basic auth
+- Memory limit: 200 MB
+- No Netdata Cloud telemetry (`DO_NOT_TRACK=1`)
+
+## Step 1: Verify Netdata is Running
+
+After `docker compose -f docker-compose.prod.yaml up -d`:
+
+```bash
+docker compose -f docker-compose.prod.yaml ps netdata
+# Status: running
+
+docker compose -f docker-compose.prod.yaml logs netdata --tail=20
+# Should show "NETDATA AGENT STARTED" or similar
+```
+
+## Step 2: Create Basic Auth for Nginx
+
+```bash
+# Install htpasswd utility (on VPS, not in container)
+sudo apt-get install -y apache2-utils
+
+# Create password file (inside nginx container's mounted volume)
+# Adjust path to your nginx config directory
+htpasswd -c /path/to/nginx/.htpasswd_netdata admin
+# Enter password when prompted
+
+# Or create directly in nginx container:
+docker exec -it <nginx-container> sh -c \
+    'apk add apache2-utils && htpasswd -c /etc/nginx/.htpasswd_netdata admin'
+```
+
+Reload nginx after creating the password file:
+
+```bash
+docker exec <nginx-container> nginx -s reload
+```
+
+Verify access: open `https://api.pythoncourse.me/netdata/` — should prompt for credentials.
+
+## Step 3: Configure Telegram Alerts
+
+### 3.1 Create Telegram Bot
+
+1. Open Telegram, search for `@BotFather`
+2. Send `/newbot`
+3. Name: `course-supporter-alerts`
+4. Save the **bot token** (format: `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`)
+
+### 3.2 Get Chat ID
+
+1. Send any message to your new bot
+2. Open in browser:
+   ```
+   https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getUpdates
+   ```
+3. Find `"chat":{"id": 123456789}` — that's your **chat_id**
+
+### 3.3 Copy Alert Config
+
+Edit the template file with your credentials:
+
+```bash
+cd /opt/course-supporter
+
+# Edit template
+nano deploy/netdata/health_alarm_notify.conf
+# Replace <your-bot-token> and <your-chat-id>
+
+# Copy into netdata container
+docker cp deploy/netdata/health_alarm_notify.conf \
+    netdata:/etc/netdata/health_alarm_notify.conf
+```
+
+### 3.4 Copy Custom Alert Thresholds
+
+```bash
+docker cp deploy/netdata/custom-alerts.conf \
+    netdata:/etc/netdata/health.d/custom.conf
+```
+
+### 3.5 Restart Netdata
+
+```bash
+docker restart netdata
+```
+
+### 3.6 Test Alerts
+
+```bash
+docker exec netdata \
+    /usr/libexec/netdata/plugins.d/alarm-notify.sh test
+```
+
+You should receive a test message in Telegram within a few seconds.
+
+## Monitored Metrics
+
+| Metric | Default Alert | Custom Threshold |
+|--------|---------------|------------------|
+| Disk space | < 20% free | > 80% warn, > 90% crit |
+| RAM usage | Built-in | > 85% warn, > 95% crit |
+| CPU | Sustained high | Default |
+| Docker containers | Restart detection | Default |
+| Network I/O | Built-in | Default |
+| PostgreSQL | Connections (if plugin available) | Default |
+
+## Maintenance
+
+### Check Netdata Memory Usage
+
+```bash
+docker stats netdata --no-stream
+# MEM USAGE should be < 200 MB
+```
+
+### Update Netdata
+
+```bash
+docker compose -f docker-compose.prod.yaml pull netdata
+docker compose -f docker-compose.prod.yaml up -d netdata
+```
+
+Note: after update, re-copy config files if using named volumes (configs persist in `netdata-config` volume).
+
+### Disable Netdata (if needed)
+
+```bash
+docker compose -f docker-compose.prod.yaml stop netdata
+```
+
+This does not affect the API — netdata is fully independent.

--- a/deploy/netdata/custom-alerts.conf
+++ b/deploy/netdata/custom-alerts.conf
@@ -1,0 +1,27 @@
+# Custom Netdata alert thresholds
+# Copy into netdata container: /etc/netdata/health.d/custom.conf
+#
+# Netdata has good built-in defaults; these override for tighter thresholds
+# on a small VPS (4 GB RAM, limited disk).
+#
+# Copy to container:
+#   docker cp deploy/netdata/custom-alerts.conf netdata:/etc/netdata/health.d/custom.conf
+#   docker restart netdata
+
+alarm: disk_space_warning
+on: disk.space
+lookup: average -1m percentage of used
+units: %
+every: 1m
+warn: $this > 80
+crit: $this > 90
+info: Disk space usage
+
+alarm: ram_usage_warning
+on: system.ram
+lookup: average -1m percentage of used
+units: %
+every: 1m
+warn: $this > 85
+crit: $this > 95
+info: RAM usage

--- a/deploy/netdata/health_alarm_notify.conf
+++ b/deploy/netdata/health_alarm_notify.conf
@@ -1,0 +1,15 @@
+# Netdata alert notification config
+# Copy into netdata container: /etc/netdata/health_alarm_notify.conf
+#
+# Setup:
+#   1. Create Telegram bot via @BotFather → /newbot
+#   2. Get chat_id: send message to bot, then GET https://api.telegram.org/bot<TOKEN>/getUpdates
+#   3. Replace placeholders below
+#   4. Copy to container:
+#      docker cp deploy/netdata/health_alarm_notify.conf netdata:/etc/netdata/health_alarm_notify.conf
+#   5. Restart netdata: docker restart netdata
+#   6. Test: docker exec netdata /usr/libexec/netdata/plugins.d/alarm-notify.sh test
+
+SEND_TELEGRAM="YES"
+TELEGRAM_BOT_TOKEN="<your-bot-token>"
+DEFAULT_RECIPIENT_TELEGRAM="<your-chat-id>"

--- a/deploy/nginx/course-supporter.conf
+++ b/deploy/nginx/course-supporter.conf
@@ -55,6 +55,7 @@ server {
     # Allows nginx to start even if course-supporter-app is not running yet
     resolver 127.0.0.11 valid=30s;
     set $course_supporter http://course-supporter-app:8000;
+    set $netdata_backend http://netdata:19999;
 
     location / {
         proxy_pass $course_supporter;
@@ -69,5 +70,17 @@ server {
         add_header X-Frame-Options DENY always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    }
+
+    # --- Netdata monitoring dashboard (basic auth protected) ---
+    location /netdata/ {
+        auth_basic "Monitoring";
+        auth_basic_user_file /etc/nginx/.htpasswd_netdata;
+
+        proxy_pass $netdata_backend/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -32,9 +32,38 @@ services:
     networks:
       - default
 
+  netdata:
+    image: netdata/netdata:stable
+    container_name: netdata
+    restart: unless-stopped
+    hostname: course-supporter-vps
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - apparmor:unconfined
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - netdata-config:/etc/netdata
+      - netdata-lib:/var/lib/netdata
+    environment:
+      - DO_NOT_TRACK=1
+      - NETDATA_CLAIM_TOKEN=
+    deploy:
+      resources:
+        limits:
+          memory: 200M
+    networks:
+      - default
+      - shared-net
+    # No ports — nginx proxies via shared-net at /netdata/
+
 networks:
   shared-net:
     external: true
 
 volumes:
   pgdata-cs:
+  netdata-config:
+  netdata-lib:


### PR DESCRIPTION
- Add netdata service to docker-compose.prod.yaml (200M memory limit, SYS_PTRACE, Docker socket for container metrics, no cloud telemetry)
- Add /netdata/ location to nginx config (basic auth, resolver pattern)
- Add deploy/netdata/ config templates (Telegram alerts, disk/RAM thresholds)
- Create infrastructure docs: architecture overview, deployment guide, Netdata setup step-by-step

PD-015 Done                                                                                                           
                                                                                                                        
  Зміни в коді (8 файлів, +576 / -70)                                                                                   
                                                                                                                        
  Інфраструктура:                                                                                                       
  - docker-compose.prod.yaml — netdata сервіс (200M RAM limit, Docker socket, no telemetry)                             
  - deploy/nginx/course-supporter.conf — /netdata/ location з basic auth + resolver pattern                             
  - deploy/netdata/health_alarm_notify.conf — шаблон Telegram alerts                                                    
  - deploy/netdata/custom-alerts.conf — disk (>80%/90%) та RAM (>85%/95%) thresholds                                    

  Документація (current-doc/S2-prod-deploy/infrastructure/):
  - README.md — архітектура (діаграма, компоненти, networking, routing, security)
  - deployment-guide.md — повна покрокова інструкція деплою (clone → env → compose → nginx → certbot → tenant → smoke
  test + troubleshooting)
  - netdata-setup.md — покрокова інструкція Netdata (verify → basic auth → Telegram bot → alerts → test)