### PR TITLE
fix: use env context for secret check in workflow if-condition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,9 @@ jobs:
             echo "=== Deploy complete: $(date) ==="
 
       - name: Smoke test
-        if: ${{ secrets.SMOKE_TEST_API_KEY != '' }}
+        env:
+          SMOKE_KEY: ${{ secrets.SMOKE_TEST_API_KEY }}
+        if: env.SMOKE_KEY != ''
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.VPS_HOST }}


### PR DESCRIPTION
secrets context is not available in step-level if expressions. Use env variable as intermediary.