### PR TITLE
added: S2-014

### DIFF
--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -171,6 +171,13 @@ class MaterialEntry(Base):
 
     __tablename__ = "material_entries"
 
+    def __repr__(self) -> str:
+        return (
+            f"<MaterialEntry(id={self.id}, "
+            f"source_type='{self.source_type}', "
+            f"node_id={self.node_id})>"
+        )
+
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
     node_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("material_nodes.id", ondelete="CASCADE"), index=True

--- a/tests/unit/test_material_entry.py
+++ b/tests/unit/test_material_entry.py
@@ -96,6 +96,20 @@ class TestMaterialEntryModel:
             col = table.c[col_name]
             assert col.type.length == 64, f"{col_name} should be 64 chars"  # type: ignore[union-attr]
 
+    def test_repr(self) -> None:
+        """__repr__ includes id, source_type, and node_id."""
+        node_id = _uuid7()
+        entry = MaterialEntry(
+            id=_uuid7(),
+            node_id=node_id,
+            source_type="web",
+            source_url="https://example.com",
+        )
+        r = repr(entry)
+        assert "MaterialEntry" in r
+        assert "web" in r
+        assert str(node_id) in r
+
     def test_source_type_reuses_enum(self) -> None:
         """source_type uses existing source_type_enum (shared with SourceMaterial)."""
         col = MaterialEntry.__table__.c.source_type


### PR DESCRIPTION
S2-014 готова. Результат:                                                                                             
                                                                                                                        
  1. src/course_supporter/storage/orm.py — додано MaterialEntry модель (AR-2):                                          
    - Raw layer: source_url, filename, raw_hash, raw_size_bytes                                                         
    - Processed layer: processed_hash, processed_content, processed_at                                                  
    - Pending receipt: pending_job_id (FK → jobs, SET NULL), pending_since                                              
    - Fingerprint: content_fingerprint (SHA-256, nullable — lazy cached)
    - Error: error_message
    - source_type reuses existing source_type_enum (create_type=False)
    - Relationships: node (→ MaterialNode), pending_job (→ Job)
    - MaterialNode.materials зворотній relationship з cascade delete-orphan
  2. tests/unit/test_material_entry.py — 20 тестів:
    - TestMaterialEntryModel (9): minimal/raw/processed creation, pending receipt, order default, field lengths, enum
  reuse
    - TestMaterialEntryForeignKeys (5): node_id FK+CASCADE, pending_job_id FK+SET NULL+nullable
    - TestMaterialEntryRelationships (4): node/pending_job, MaterialNode.materials back_populates+cascade
    - TestMaterialEntryIndexes (2): node_id, pending_job_id indexed
