### PR TITLE
added: S2-019

### DIFF
--- a/src/course_supporter/api/app.py
+++ b/src/course_supporter/api/app.py
@@ -18,6 +18,7 @@ from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from course_supporter.api.middleware import RequestLoggingMiddleware
 from course_supporter.api.routes.courses import router as courses_router
 from course_supporter.api.routes.jobs import router as jobs_router
+from course_supporter.api.routes.nodes import router as nodes_router
 from course_supporter.api.routes.reports import router as reports_router
 from course_supporter.auth.rate_limiter import InMemoryRateLimiter
 from course_supporter.auth.scopes import rate_limiter
@@ -190,5 +191,6 @@ async def unhandled_exception_handler(
 
 
 app.include_router(courses_router, prefix="/api/v1")
+app.include_router(nodes_router, prefix="/api/v1")
 app.include_router(jobs_router, prefix="/api/v1")
 app.include_router(reports_router, prefix="/api/v1")

--- a/src/course_supporter/api/routes/nodes.py
+++ b/src/course_supporter/api/routes/nodes.py
@@ -1,0 +1,318 @@
+"""Material tree node management API endpoints.
+
+Provides CRUD operations for the hierarchical material tree
+within a course. Nodes form an adjacency-list tree with arbitrary
+depth. Tenant isolation is enforced by verifying course ownership
+before accessing any node.
+
+Routes
+------
+- ``POST   /courses/{id}/nodes``                — Create root node
+- ``POST   /courses/{id}/nodes/{nid}/children``  — Create child node
+- ``GET    /courses/{id}/nodes/tree``            — Get full tree
+- ``GET    /courses/{id}/nodes/{nid}``           — Get single node
+- ``PATCH  /courses/{id}/nodes/{nid}``           — Update node
+- ``POST   /courses/{id}/nodes/{nid}/move``      — Move node (reparent)
+- ``POST   /courses/{id}/nodes/{nid}/reorder``   — Reorder among siblings
+- ``DELETE /courses/{id}/nodes/{nid}``           — Delete node (cascade)
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.api.deps import get_session
+from course_supporter.api.schemas import (
+    NodeCreateRequest,
+    NodeMoveRequest,
+    NodeReorderRequest,
+    NodeResponse,
+    NodeTreeResponse,
+    NodeUpdateRequest,
+)
+from course_supporter.auth.context import TenantContext
+from course_supporter.auth.scopes import require_scope
+from course_supporter.storage.material_node_repository import MaterialNodeRepository
+from course_supporter.storage.repositories import CourseRepository
+
+logger = structlog.get_logger()
+
+router = APIRouter(tags=["nodes"])
+
+SessionDep = Annotated[AsyncSession, Depends(get_session)]
+PrepDep = Annotated[TenantContext, Depends(require_scope("prep"))]
+SharedDep = Annotated[TenantContext, Depends(require_scope("prep", "check"))]
+
+
+async def _require_course(
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    course_id: uuid.UUID,
+) -> None:
+    """Verify the course exists and belongs to the tenant.
+
+    Raises:
+        HTTPException 404: If the course is not found or
+            does not belong to the authenticated tenant.
+    """
+    repo = CourseRepository(session, tenant_id)
+    course = await repo.get_by_id(course_id)
+    if course is None:
+        raise HTTPException(status_code=404, detail="Course not found")
+
+
+async def _require_node(
+    repo: MaterialNodeRepository,
+    node_id: uuid.UUID,
+    course_id: uuid.UUID,
+) -> object:
+    """Verify the node exists and belongs to the course.
+
+    Raises:
+        HTTPException 404: If the node is not found or
+            belongs to a different course.
+    """
+    node = await repo.get_by_id(node_id)
+    if node is None or node.course_id != course_id:
+        raise HTTPException(status_code=404, detail="Node not found")
+    return node
+
+
+@router.post("/courses/{course_id}/nodes", status_code=201)
+async def create_root_node(
+    course_id: uuid.UUID,
+    body: NodeCreateRequest,
+    tenant: PrepDep,
+    session: SessionDep,
+) -> NodeResponse:
+    """Create a root node in the material tree.
+
+    Root nodes have no parent and appear at the top level of the tree.
+    The ``order`` is auto-assigned as the next available position.
+    """
+    await _require_course(session, tenant.tenant_id, course_id)
+
+    repo = MaterialNodeRepository(session)
+    node = await repo.create(
+        course_id=course_id,
+        title=body.title,
+        description=body.description,
+    )
+    await session.commit()
+
+    logger.info(
+        "node_created",
+        node_id=str(node.id),
+        course_id=str(course_id),
+        parent_id=None,
+    )
+    return NodeResponse.model_validate(node)
+
+
+@router.post("/courses/{course_id}/nodes/{node_id}/children", status_code=201)
+async def create_child_node(
+    course_id: uuid.UUID,
+    node_id: uuid.UUID,
+    body: NodeCreateRequest,
+    tenant: PrepDep,
+    session: SessionDep,
+) -> NodeResponse:
+    """Create a child node under an existing parent.
+
+    The child inherits the course from the parent. The ``order``
+    is auto-assigned as the next available position among siblings.
+    """
+    await _require_course(session, tenant.tenant_id, course_id)
+    repo = MaterialNodeRepository(session)
+    await _require_node(repo, node_id, course_id)
+
+    node = await repo.create(
+        course_id=course_id,
+        parent_id=node_id,
+        title=body.title,
+        description=body.description,
+    )
+    await session.commit()
+
+    logger.info(
+        "node_created",
+        node_id=str(node.id),
+        course_id=str(course_id),
+        parent_id=str(node_id),
+    )
+    return NodeResponse.model_validate(node)
+
+
+@router.get("/courses/{course_id}/nodes/tree")
+async def get_tree(
+    course_id: uuid.UUID,
+    tenant: SharedDep,
+    session: SessionDep,
+) -> list[NodeTreeResponse]:
+    """Get the full material tree for a course.
+
+    Returns all nodes in a nested structure, with children
+    recursively populated. Root nodes (no parent) are at
+    the top level. Each level is sorted by ``order``.
+
+    Returns an empty list if the course has no nodes.
+    """
+    await _require_course(session, tenant.tenant_id, course_id)
+
+    repo = MaterialNodeRepository(session)
+    roots = await repo.get_tree(course_id)
+    return [NodeTreeResponse.model_validate(r) for r in roots]
+
+
+@router.get("/courses/{course_id}/nodes/{node_id}")
+async def get_node(
+    course_id: uuid.UUID,
+    node_id: uuid.UUID,
+    tenant: SharedDep,
+    session: SessionDep,
+) -> NodeResponse:
+    """Get a single node by ID.
+
+    Returns the flat node representation without children.
+    Use ``GET /courses/{id}/nodes/tree`` for the nested tree.
+    """
+    await _require_course(session, tenant.tenant_id, course_id)
+    repo = MaterialNodeRepository(session)
+    node = await _require_node(repo, node_id, course_id)
+    return NodeResponse.model_validate(node)
+
+
+@router.patch("/courses/{course_id}/nodes/{node_id}")
+async def update_node(
+    course_id: uuid.UUID,
+    node_id: uuid.UUID,
+    body: NodeUpdateRequest,
+    tenant: PrepDep,
+    session: SessionDep,
+) -> NodeResponse:
+    """Update a node's title and/or description.
+
+    Only fields present in the request body are updated.
+    To clear the description, send ``"description": null``.
+    Omitting a field leaves it unchanged.
+    """
+    await _require_course(session, tenant.tenant_id, course_id)
+    repo = MaterialNodeRepository(session)
+    await _require_node(repo, node_id, course_id)
+
+    # Distinguish "field omitted" from "field set to null"
+    update_kwargs: dict[str, str | None] = {}
+    if "title" in body.model_fields_set:
+        update_kwargs["title"] = body.title
+    if "description" in body.model_fields_set:
+        update_kwargs["description"] = body.description
+
+    node = await repo.update(node_id, **update_kwargs)
+    await session.commit()
+
+    logger.info("node_updated", node_id=str(node_id), fields=list(update_kwargs))
+    return NodeResponse.model_validate(node)
+
+
+@router.post("/courses/{course_id}/nodes/{node_id}/move")
+async def move_node(
+    course_id: uuid.UUID,
+    node_id: uuid.UUID,
+    body: NodeMoveRequest,
+    tenant: PrepDep,
+    session: SessionDep,
+) -> NodeResponse:
+    """Move a node to a new parent (or to root).
+
+    Cycle detection is enforced: a node cannot be moved under
+    one of its own descendants. Set ``parent_id`` to ``null``
+    to make the node a root.
+
+    Returns 422 if the move would create a cycle or is
+    otherwise invalid.
+    """
+    await _require_course(session, tenant.tenant_id, course_id)
+    repo = MaterialNodeRepository(session)
+    await _require_node(repo, node_id, course_id)
+
+    # Validate target parent belongs to the same course
+    if body.parent_id is not None:
+        await _require_node(repo, body.parent_id, course_id)
+
+    try:
+        node = await repo.move(node_id, body.parent_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    await session.commit()
+
+    logger.info(
+        "node_moved",
+        node_id=str(node_id),
+        new_parent_id=str(body.parent_id),
+    )
+    return NodeResponse.model_validate(node)
+
+
+@router.post("/courses/{course_id}/nodes/{node_id}/reorder")
+async def reorder_node(
+    course_id: uuid.UUID,
+    node_id: uuid.UUID,
+    body: NodeReorderRequest,
+    tenant: PrepDep,
+    session: SessionDep,
+) -> NodeResponse:
+    """Reorder a node among its siblings.
+
+    The target ``order`` is 0-based. If the value exceeds the
+    number of siblings, it is clamped to the last position.
+    All siblings are renumbered sequentially after the operation.
+    """
+    await _require_course(session, tenant.tenant_id, course_id)
+    repo = MaterialNodeRepository(session)
+    await _require_node(repo, node_id, course_id)
+
+    try:
+        node = await repo.reorder(node_id, body.order)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    await session.commit()
+
+    logger.info(
+        "node_reordered",
+        node_id=str(node_id),
+        new_order=body.order,
+    )
+    return NodeResponse.model_validate(node)
+
+
+@router.delete("/courses/{course_id}/nodes/{node_id}", status_code=204)
+async def delete_node(
+    course_id: uuid.UUID,
+    node_id: uuid.UUID,
+    tenant: PrepDep,
+    session: SessionDep,
+) -> None:
+    """Delete a node and all its descendants.
+
+    Deletion cascades to all child nodes and their attached
+    material entries. This operation cannot be undone.
+    """
+    await _require_course(session, tenant.tenant_id, course_id)
+    repo = MaterialNodeRepository(session)
+    await _require_node(repo, node_id, course_id)
+
+    await repo.delete(node_id)
+    await session.commit()
+
+    logger.info(
+        "node_deleted",
+        node_id=str(node_id),
+        course_id=str(course_id),
+    )

--- a/tests/unit/test_api/test_nodes.py
+++ b/tests/unit/test_api/test_nodes.py
@@ -1,0 +1,590 @@
+"""Tests for material tree node API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from course_supporter.api.app import app
+from course_supporter.api.deps import get_current_tenant
+from course_supporter.auth.context import TenantContext
+from course_supporter.storage.database import get_session
+from course_supporter.storage.material_node_repository import MaterialNodeRepository
+from course_supporter.storage.repositories import CourseRepository
+
+STUB_TENANT = TenantContext(
+    tenant_id=uuid.uuid4(),
+    tenant_name="test-tenant",
+    scopes=["prep", "check"],
+    rate_limit_prep=100,
+    rate_limit_check=1000,
+    key_prefix="cs_test",
+)
+
+
+def _mock_node(
+    *,
+    node_id: uuid.UUID | None = None,
+    course_id: uuid.UUID | None = None,
+    parent_id: uuid.UUID | None = None,
+    title: str = "Test Node",
+    description: str | None = None,
+    order: int = 0,
+    children: list[object] | None = None,
+) -> MagicMock:
+    """Create a mock MaterialNode with ORM-compatible attributes."""
+    node = MagicMock()
+    node.id = node_id or uuid.uuid4()
+    node.course_id = course_id or uuid.uuid4()
+    node.parent_id = parent_id
+    node.title = title
+    node.description = description
+    node.order = order
+    node.children = children or []
+    node.created_at = datetime.now(UTC)
+    node.updated_at = datetime.now(UTC)
+    return node
+
+
+@pytest.fixture()
+def mock_session() -> AsyncMock:
+    session = AsyncMock()
+    session.add = MagicMock()
+    return session
+
+
+@pytest.fixture()
+def course_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture()
+async def client(mock_session: AsyncMock) -> AsyncClient:
+    app.dependency_overrides[get_session] = lambda: mock_session
+    app.dependency_overrides[get_current_tenant] = lambda: STUB_TENANT
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac  # type: ignore[misc]
+    app.dependency_overrides.clear()
+
+
+def _mock_course(course_id: uuid.UUID) -> MagicMock:
+    """Create a mock Course that passes tenant isolation."""
+    course = MagicMock()
+    course.id = course_id
+    course.tenant_id = STUB_TENANT.tenant_id
+    return course
+
+
+class TestCreateRootNode:
+    """POST /api/v1/courses/{id}/nodes"""
+
+    async def test_returns_201(self, client: AsyncClient, course_id: uuid.UUID) -> None:
+        """Successful root node creation returns 201."""
+        node = _mock_node(course_id=course_id)
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "create", return_value=node),
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes",
+                json={"title": "Module 1"},
+            )
+        assert resp.status_code == 201
+
+    async def test_returns_node_fields(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Response contains all expected node fields."""
+        node = _mock_node(course_id=course_id, title="Module 1")
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "create", return_value=node),
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes",
+                json={"title": "Module 1"},
+            )
+        data = resp.json()
+        assert data["id"] == str(node.id)
+        assert data["title"] == "Module 1"
+        assert data["parent_id"] is None
+        assert data["course_id"] == str(course_id)
+        assert "created_at" in data
+        assert "updated_at" in data
+
+    async def test_with_description(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Root node accepts optional description."""
+        node = _mock_node(course_id=course_id, description="Details")
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "create", return_value=node),
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes",
+                json={"title": "Mod", "description": "Details"},
+            )
+        assert resp.status_code == 201
+        assert resp.json()["description"] == "Details"
+
+    async def test_empty_title_returns_422(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Empty title is rejected with 422."""
+        with patch.object(
+            CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes",
+                json={"title": ""},
+            )
+        assert resp.status_code == 422
+
+    async def test_missing_title_returns_422(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Missing title is rejected with 422."""
+        with patch.object(
+            CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes",
+                json={},
+            )
+        assert resp.status_code == 422
+
+    async def test_course_not_found_returns_404(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Non-existent course returns 404."""
+        with patch.object(CourseRepository, "get_by_id", return_value=None):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes",
+                json={"title": "Module 1"},
+            )
+        assert resp.status_code == 404
+        assert "Course not found" in resp.json()["detail"]
+
+
+class TestCreateChildNode:
+    """POST /api/v1/courses/{id}/nodes/{nid}/children"""
+
+    async def test_returns_201(self, client: AsyncClient, course_id: uuid.UUID) -> None:
+        """Successful child creation returns 201."""
+        parent = _mock_node(course_id=course_id, title="Parent")
+        child = _mock_node(course_id=course_id, parent_id=parent.id, title="Child")
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(
+                MaterialNodeRepository,
+                "get_by_id",
+                return_value=parent,
+            ),
+            patch.object(MaterialNodeRepository, "create", return_value=child),
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes/{parent.id}/children",
+                json={"title": "Child"},
+            )
+        assert resp.status_code == 201
+        assert resp.json()["parent_id"] == str(parent.id)
+
+    async def test_parent_not_found_returns_404(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Non-existent parent returns 404."""
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", return_value=None),
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes/{uuid.uuid4()}/children",
+                json={"title": "Child"},
+            )
+        assert resp.status_code == 404
+        assert "Node not found" in resp.json()["detail"]
+
+    async def test_parent_wrong_course_returns_404(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Parent belonging to a different course returns 404."""
+        other_course = uuid.uuid4()
+        parent = _mock_node(course_id=other_course, title="Wrong course parent")
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", return_value=parent),
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes/{parent.id}/children",
+                json={"title": "Child"},
+            )
+        assert resp.status_code == 404
+
+
+class TestGetTree:
+    """GET /api/v1/courses/{id}/nodes/tree"""
+
+    async def test_returns_empty_list(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Course with no nodes returns empty list."""
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_tree", return_value=[]),
+        ):
+            resp = await client.get(
+                f"/api/v1/courses/{course_id}/nodes/tree",
+            )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_returns_nested_tree(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Tree with parent-child structure returned nested."""
+        child = _mock_node(course_id=course_id, title="Child")
+        root = _mock_node(course_id=course_id, title="Root", children=[child])
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_tree", return_value=[root]),
+        ):
+            resp = await client.get(
+                f"/api/v1/courses/{course_id}/nodes/tree",
+            )
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["title"] == "Root"
+        assert len(data[0]["children"]) == 1
+        assert data[0]["children"][0]["title"] == "Child"
+
+    async def test_course_not_found_returns_404(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Non-existent course returns 404."""
+        with patch.object(CourseRepository, "get_by_id", return_value=None):
+            resp = await client.get(
+                f"/api/v1/courses/{course_id}/nodes/tree",
+            )
+        assert resp.status_code == 404
+
+
+class TestGetNode:
+    """GET /api/v1/courses/{id}/nodes/{nid}"""
+
+    async def test_returns_node(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Existing node returned with correct fields."""
+        node = _mock_node(course_id=course_id, title="Node 1", order=2)
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", return_value=node),
+        ):
+            resp = await client.get(
+                f"/api/v1/courses/{course_id}/nodes/{node.id}",
+            )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Node 1"
+        assert resp.json()["order"] == 2
+
+    async def test_not_found_returns_404(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Non-existent node returns 404."""
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", return_value=None),
+        ):
+            resp = await client.get(
+                f"/api/v1/courses/{course_id}/nodes/{uuid.uuid4()}",
+            )
+        assert resp.status_code == 404
+
+
+class TestUpdateNode:
+    """PATCH /api/v1/courses/{id}/nodes/{nid}"""
+
+    async def test_update_title(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Title updated when provided."""
+        node = _mock_node(course_id=course_id, title="Old")
+        updated = _mock_node(course_id=course_id, title="New Title")
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", return_value=node),
+            patch.object(MaterialNodeRepository, "update", return_value=updated),
+        ):
+            resp = await client.patch(
+                f"/api/v1/courses/{course_id}/nodes/{node.id}",
+                json={"title": "New Title"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "New Title"
+
+    async def test_clear_description(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Description cleared when set to null."""
+        node = _mock_node(course_id=course_id, description="Old desc")
+        updated = _mock_node(course_id=course_id, description=None)
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", return_value=node),
+            patch.object(MaterialNodeRepository, "update", return_value=updated),
+        ):
+            resp = await client.patch(
+                f"/api/v1/courses/{course_id}/nodes/{node.id}",
+                json={"description": None},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["description"] is None
+
+    async def test_empty_body_is_valid(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Empty body (no fields to update) is accepted."""
+        node = _mock_node(course_id=course_id)
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", return_value=node),
+            patch.object(MaterialNodeRepository, "update", return_value=node),
+        ):
+            resp = await client.patch(
+                f"/api/v1/courses/{course_id}/nodes/{node.id}",
+                json={},
+            )
+        assert resp.status_code == 200
+
+    async def test_not_found_returns_404(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Non-existent node returns 404."""
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", return_value=None),
+        ):
+            resp = await client.patch(
+                f"/api/v1/courses/{course_id}/nodes/{uuid.uuid4()}",
+                json={"title": "New"},
+            )
+        assert resp.status_code == 404
+
+
+class TestMoveNode:
+    """POST /api/v1/courses/{id}/nodes/{nid}/move"""
+
+    async def test_move_to_new_parent(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Node moved to a new parent."""
+        node = _mock_node(course_id=course_id, title="Movable")
+        target = _mock_node(course_id=course_id, title="Target")
+        moved = _mock_node(course_id=course_id, parent_id=target.id)
+
+        def fake_get(nid: uuid.UUID) -> MagicMock | None:
+            lookup = {node.id: node, target.id: target}
+            return lookup.get(nid)
+
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", side_effect=fake_get),
+            patch.object(MaterialNodeRepository, "move", return_value=moved),
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes/{node.id}/move",
+                json={"parent_id": str(target.id)},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["parent_id"] == str(target.id)
+
+    async def test_move_to_root(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Node moved to root (parent_id=null)."""
+        node = _mock_node(course_id=course_id, parent_id=uuid.uuid4())
+        moved = _mock_node(course_id=course_id, parent_id=None)
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", return_value=node),
+            patch.object(MaterialNodeRepository, "move", return_value=moved),
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes/{node.id}/move",
+                json={"parent_id": None},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["parent_id"] is None
+
+    async def test_cycle_returns_422(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Cycle detection error returns 422."""
+        node = _mock_node(course_id=course_id)
+        target = _mock_node(course_id=course_id)
+
+        def fake_get(nid: uuid.UUID) -> MagicMock | None:
+            lookup = {node.id: node, target.id: target}
+            return lookup.get(nid)
+
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", side_effect=fake_get),
+            patch.object(
+                MaterialNodeRepository,
+                "move",
+                side_effect=ValueError("would create a cycle"),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes/{node.id}/move",
+                json={"parent_id": str(target.id)},
+            )
+        assert resp.status_code == 422
+        assert "cycle" in resp.json()["detail"]
+
+    async def test_target_wrong_course_returns_404(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Target parent in different course returns 404."""
+        node = _mock_node(course_id=course_id)
+        target = _mock_node(course_id=uuid.uuid4())  # different course
+
+        def fake_get(nid: uuid.UUID) -> MagicMock | None:
+            lookup = {node.id: node, target.id: target}
+            return lookup.get(nid)
+
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", side_effect=fake_get),
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes/{node.id}/move",
+                json={"parent_id": str(target.id)},
+            )
+        assert resp.status_code == 404
+
+
+class TestReorderNode:
+    """POST /api/v1/courses/{id}/nodes/{nid}/reorder"""
+
+    async def test_reorder_success(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Successful reorder returns updated node."""
+        node = _mock_node(course_id=course_id, order=0)
+        reordered = _mock_node(course_id=course_id, order=2)
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", return_value=node),
+            patch.object(MaterialNodeRepository, "reorder", return_value=reordered),
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes/{node.id}/reorder",
+                json={"order": 2},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["order"] == 2
+
+    async def test_negative_order_returns_422(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Negative order is rejected with 422."""
+        with patch.object(
+            CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+        ):
+            resp = await client.post(
+                f"/api/v1/courses/{course_id}/nodes/{uuid.uuid4()}/reorder",
+                json={"order": -1},
+            )
+        assert resp.status_code == 422
+
+
+class TestDeleteNode:
+    """DELETE /api/v1/courses/{id}/nodes/{nid}"""
+
+    async def test_returns_204(self, client: AsyncClient, course_id: uuid.UUID) -> None:
+        """Successful deletion returns 204 No Content."""
+        node = _mock_node(course_id=course_id)
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", return_value=node),
+            patch.object(MaterialNodeRepository, "delete", return_value=None),
+        ):
+            resp = await client.delete(
+                f"/api/v1/courses/{course_id}/nodes/{node.id}",
+            )
+        assert resp.status_code == 204
+
+    async def test_not_found_returns_404(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Non-existent node returns 404."""
+        with (
+            patch.object(
+                CourseRepository, "get_by_id", return_value=_mock_course(course_id)
+            ),
+            patch.object(MaterialNodeRepository, "get_by_id", return_value=None),
+        ):
+            resp = await client.delete(
+                f"/api/v1/courses/{course_id}/nodes/{uuid.uuid4()}",
+            )
+        assert resp.status_code == 404
+
+    async def test_course_not_found_returns_404(
+        self, client: AsyncClient, course_id: uuid.UUID
+    ) -> None:
+        """Non-existent course returns 404."""
+        with patch.object(CourseRepository, "get_by_id", return_value=None):
+            resp = await client.delete(
+                f"/api/v1/courses/{course_id}/nodes/{uuid.uuid4()}",
+            )
+        assert resp.status_code == 404


### PR DESCRIPTION
S2-019: Tree API endpoints (nodes) — Підсумок                                                                         
                                                                                                                        
  Schemas (src/course_supporter/api/schemas.py)                                                                         
                                                                                                                        
  Додано 6 нових schemas з повною документацією (docstrings, Field(description=...), examples):                         
                                                                                                                         
 │  Schema │ Призначення │
 | --- | --- |
 │ NodeCreateRequest  │ Body для POST (title + description) │
 │ NodeUpdateRequest  │ Body для PATCH (optional title/description, model_fields_set для відрізнення omit vs null) │
 │ NodeMoveRequest    │ Body для move (parent_id, null = root)                                                     │
 │ NodeReorderRequest │ Body для reorder (0-based order, ge=0)                                                     │
 │ NodeResponse       │ Flat node response (create/update/move/reorder/get)                                        │
 │ NodeTreeResponse   │ Recursive tree response з children: list[NodeTreeResponse]                                 │

  Routes (src/course_supporter/api/routes/nodes.py)

  8 endpoints, повний CRUD + tree operations:

  
  │ Method │                Path                │            Опис            │
  |---------|-----------------------|--------------------|
  │ POST   │ /courses/{id}/nodes                │ Create root node           │
  │ POST   │ /courses/{id}/nodes/{nid}/children │ Create child               │
  │ GET    │ /courses/{id}/nodes/tree           │ Full nested tree           │
  │ GET    │ /courses/{id}/nodes/{nid}          │ Single node                │
  │ PATCH  │ /courses/{id}/nodes/{nid}          │ Update title/description   │
  │ POST   │ /courses/{id}/nodes/{nid}/move     │ Reparent (cycle detection) │
  │ POST   │ /courses/{id}/nodes/{nid}/reorder  │ Reorder siblings           │
  │ DELETE │ /courses/{id}/nodes/{nid}          │ Cascade delete             │

  Tenant isolation через _require_course() helper. Node ownership через _require_node() (перевіряє course_id). Structlog
   logging на всіх мутаціях.

  Тести (tests/unit/test_api/test_nodes.py) — 27 тестів

  Покриття: create root (6), create child (3), get tree (3), get node (2), update (4), move (4), reorder (2), delete
  (3). Включає: 404 tenant isolation, 404 node not found, 422 validation, 422 cycle detection, cross-course protection.