### PR TITLE
added: S2-024

### DIFF
--- a/src/course_supporter/fingerprint.py
+++ b/src/course_supporter/fingerprint.py
@@ -1,0 +1,54 @@
+"""Merkle fingerprint service for material tree integrity tracking."""
+
+from __future__ import annotations
+
+import hashlib
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.storage.orm import MaterialEntry
+
+
+class FingerprintService:
+    """Lazy-cached fingerprint calculations for the material tree.
+
+    Fingerprints are computed on demand and stored in the ORM objects.
+    A ``None`` fingerprint means "stale / never computed". Calling
+    ``ensure_*`` either returns the cached value or computes, persists
+    (flush), and returns the new one.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def ensure_material_fp(self, entry: MaterialEntry) -> str:
+        """Lazily compute and cache content_fingerprint.
+
+        Returns the existing fingerprint if already set. Otherwise
+        computes ``sha256(processed_content)`` in UTF-8, stores it on
+        the entry, flushes, and returns the hex digest.
+
+        Args:
+            entry: A loaded MaterialEntry ORM instance.
+
+        Returns:
+            64-char lowercase hex SHA-256 digest.
+
+        Raises:
+            ValueError: If ``processed_content`` is None (entry not
+                yet processed).
+        """
+        if entry.content_fingerprint is not None:
+            return entry.content_fingerprint
+
+        if entry.processed_content is None:
+            msg = (
+                f"Cannot compute fingerprint: MaterialEntry {entry.id} "
+                f"has no processed_content"
+            )
+            raise ValueError(msg)
+
+        fp = hashlib.sha256(entry.processed_content.encode()).hexdigest()
+        entry.content_fingerprint = fp
+        await self._session.flush()
+        return fp

--- a/src/course_supporter/storage/material_entry_repository.py
+++ b/src/course_supporter/storage/material_entry_repository.py
@@ -129,6 +129,7 @@ class MaterialEntryRepository:
         entry.processed_content = processed_content
         entry.processed_hash = processed_hash
         entry.processed_at = now
+        entry.content_fingerprint = None  # invalidate — content changed
         entry.pending_job_id = None
         entry.pending_since = None
         entry.error_message = None
@@ -185,6 +186,7 @@ class MaterialEntryRepository:
         entry.filename = filename
         entry.raw_hash = None
         entry.raw_size_bytes = None
+        entry.content_fingerprint = None  # invalidate — source changed
         await self._session.flush()
         return entry
 

--- a/tests/unit/test_fingerprint.py
+++ b/tests/unit/test_fingerprint.py
@@ -1,0 +1,171 @@
+"""Tests for FingerprintService — material level (S2-024)."""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from course_supporter.fingerprint import FingerprintService
+from course_supporter.storage.orm import MaterialEntry
+
+
+def _make_entry(
+    *,
+    processed_content: str | None = None,
+    content_fingerprint: str | None = None,
+) -> MagicMock:
+    """Create a mock MaterialEntry with the specified fields."""
+    entry = MagicMock(spec=MaterialEntry)
+    entry.id = uuid.uuid4()
+    entry.processed_content = processed_content
+    entry.content_fingerprint = content_fingerprint
+    return entry
+
+
+class TestEnsureMaterialFp:
+    async def test_computes_sha256_of_processed_content(self) -> None:
+        """Fingerprint is sha256 hex digest of processed_content bytes."""
+        content = "Hello, this is processed content."
+        entry = _make_entry(processed_content=content)
+        session = AsyncMock()
+
+        svc = FingerprintService(session)
+        result = await svc.ensure_material_fp(entry)
+
+        expected = hashlib.sha256(content.encode()).hexdigest()
+        assert result == expected
+        assert entry.content_fingerprint == expected
+        session.flush.assert_awaited_once()
+
+    async def test_cache_hit_returns_existing(self) -> None:
+        """If content_fingerprint is already set, return it without flush."""
+        cached = "a" * 64
+        entry = _make_entry(
+            processed_content="some content",
+            content_fingerprint=cached,
+        )
+        session = AsyncMock()
+
+        svc = FingerprintService(session)
+        result = await svc.ensure_material_fp(entry)
+
+        assert result == cached
+        session.flush.assert_not_awaited()
+
+    async def test_invalidation_then_recalculate(self) -> None:
+        """After clearing fingerprint (None), next call recomputes."""
+        content = "original content"
+        fp = hashlib.sha256(content.encode()).hexdigest()
+        entry = _make_entry(processed_content=content, content_fingerprint=fp)
+        session = AsyncMock()
+        svc = FingerprintService(session)
+
+        # Cache hit — no flush
+        result1 = await svc.ensure_material_fp(entry)
+        assert result1 == fp
+        session.flush.assert_not_awaited()
+
+        # Invalidate
+        entry.content_fingerprint = None
+
+        # Recalculate
+        result2 = await svc.ensure_material_fp(entry)
+        assert result2 == fp
+        session.flush.assert_awaited_once()
+
+    async def test_raises_when_no_processed_content(self) -> None:
+        """ValueError if processed_content is None."""
+        entry = _make_entry(processed_content=None)
+        session = AsyncMock()
+        svc = FingerprintService(session)
+
+        with pytest.raises(ValueError, match="no processed_content"):
+            await svc.ensure_material_fp(entry)
+
+    async def test_deterministic_same_content_same_hash(self) -> None:
+        """Same processed_content always produces the same fingerprint."""
+        content = "deterministic test"
+        session = AsyncMock()
+        svc = FingerprintService(session)
+
+        entry1 = _make_entry(processed_content=content)
+        entry2 = _make_entry(processed_content=content)
+
+        fp1 = await svc.ensure_material_fp(entry1)
+        fp2 = await svc.ensure_material_fp(entry2)
+
+        assert fp1 == fp2
+
+    async def test_different_content_different_hash(self) -> None:
+        """Different processed_content produces different fingerprints."""
+        session = AsyncMock()
+        svc = FingerprintService(session)
+
+        entry1 = _make_entry(processed_content="content A")
+        entry2 = _make_entry(processed_content="content B")
+
+        fp1 = await svc.ensure_material_fp(entry1)
+        fp2 = await svc.ensure_material_fp(entry2)
+
+        assert fp1 != fp2
+
+    async def test_fingerprint_is_64_char_hex(self) -> None:
+        """Fingerprint is a valid 64-character hex string (sha256)."""
+        entry = _make_entry(processed_content="test")
+        session = AsyncMock()
+        svc = FingerprintService(session)
+
+        result = await svc.ensure_material_fp(entry)
+
+        assert len(result) == 64
+        int(result, 16)  # valid hex
+
+
+class TestRepositoryInvalidation:
+    """Verify that repository methods clear content_fingerprint."""
+
+    async def test_complete_processing_clears_fingerprint(self) -> None:
+        """complete_processing sets content_fingerprint to None."""
+        from course_supporter.storage.material_entry_repository import (
+            MaterialEntryRepository,
+        )
+
+        entry = MagicMock(spec=MaterialEntry)
+        entry.content_fingerprint = "old_fp"
+
+        session = AsyncMock()
+        repo = MaterialEntryRepository(session)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(repo, "_require", AsyncMock(return_value=entry))
+            await repo.complete_processing(
+                entry.id,
+                processed_content="new content",
+                processed_hash="abc123",
+            )
+
+        assert entry.content_fingerprint is None
+
+    async def test_update_source_clears_fingerprint(self) -> None:
+        """update_source sets content_fingerprint to None."""
+        from course_supporter.storage.material_entry_repository import (
+            MaterialEntryRepository,
+        )
+
+        entry = MagicMock(spec=MaterialEntry)
+        entry.content_fingerprint = "old_fp"
+
+        session = AsyncMock()
+        repo = MaterialEntryRepository(session)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(repo, "_require", AsyncMock(return_value=entry))
+            await repo.update_source(
+                entry.id,
+                source_url="https://new-url.com",
+            )
+
+        assert entry.content_fingerprint is None


### PR DESCRIPTION
S2-024 — готово. Що зроблено:                                                                                         
                                                                                                                        
  1. src/course_supporter/fingerprint.py — FingerprintService з методом ensure_material_fp(entry):                      
    - Якщо content_fingerprint не None → повертає кешоване (без flush)                                                  
    - Якщо processed_content is None → ValueError
    - Інакше: sha256(processed_content.encode()).hexdigest() → зберігає → flush                                         
  2. src/course_supporter/storage/material_entry_repository.py — інвалідація content_fingerprint:
    - complete_processing() — скидає при новому processed_content
    - update_source() — скидає при зміні source
  3. tests/unit/test_fingerprint.py — 9 тестів:
    - compute, cache hit, invalidation → recalculate
    - raises on None processed_content
    - deterministic, different content → different hash, 64-char hex
    - repository invalidation (complete_processing, update_source)