### PR TITLE
added: S2-028

### DIFF
--- a/tests/unit/test_material_entry_repository.py
+++ b/tests/unit/test_material_entry_repository.py
@@ -12,6 +12,16 @@ from course_supporter.storage.material_entry_repository import MaterialEntryRepo
 from course_supporter.storage.orm import MaterialEntry
 
 
+@pytest.fixture(autouse=True)
+def _no_cascade_invalidation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable fingerprint cascade invalidation in unit tests."""
+    monkeypatch.setattr(
+        MaterialEntryRepository,
+        "_invalidate_node_chain",
+        AsyncMock(),
+    )
+
+
 def _mock_entry(
     *,
     entry_id: uuid.UUID | None = None,

--- a/tests/unit/test_material_node_repository.py
+++ b/tests/unit/test_material_node_repository.py
@@ -11,6 +11,16 @@ from course_supporter.storage.material_node_repository import MaterialNodeReposi
 from course_supporter.storage.orm import MaterialNode
 
 
+@pytest.fixture(autouse=True)
+def _no_cascade_invalidation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable fingerprint cascade invalidation in unit tests."""
+    monkeypatch.setattr(
+        MaterialNodeRepository,
+        "_invalidate_node_chain",
+        AsyncMock(),
+    )
+
+
 def _mock_node(
     *,
     node_id: uuid.UUID | None = None,


### PR DESCRIPTION
S2-028 — готово. Що зроблено:                                                                                         
                                                                                                                        
  1. material_entry_repository.py — додано _invalidate_node_chain(node_id) helper + виклики в:                          
    - create — нова entry → invalidate node chain                                                                       
    - complete_processing — content changed → invalidate node chain                                                     
    - update_source — source changed → invalidate node chain                                                            
    - delete — entry removed → invalidate node chain
  2. material_node_repository.py — додано _invalidate_node_chain(node_id) helper + виклики в:
    - move — invalidate old parent chain + new parent chain
    - delete — invalidate parent chain before deletion
  3. tests/unit/test_fingerprint.py — 7 нових тестів (37 всього):
    - entry create/complete_processing/update_source/delete → cascade called
    - node move → both parents invalidated
    - node delete → parent invalidated
    - root node delete → _invalidate_node_chain(None) → no-op
  4. test_material_entry_repository.py та test_material_node_repository.py — додано autouse fixture
  _no_cascade_invalidation щоб не зависали існуючі тести.