### PR TITLE
added: S2-029

### DIFF
--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -182,6 +182,9 @@ class MaterialEntrySummaryResponse(BaseModel):
     error_message: str | None = Field(
         description="Error from the last failed processing attempt, if any."
     )
+    content_fingerprint: str | None = Field(
+        description="SHA-256 of processed content. ``null`` if not computed."
+    )
     created_at: datetime = Field(description="When this entry was created.")
 
 
@@ -241,6 +244,13 @@ class CourseDetailResponse(BaseModel):
     updated_at: datetime
     modules: list[ModuleResponse]
     source_materials: list[SourceMaterialResponse]
+    course_fingerprint: str | None = Field(
+        default=None,
+        description=(
+            "Merkle hash of the entire material tree. "
+            "``null`` if any node fingerprint is missing."
+        ),
+    )
     material_tree: list[NodeWithMaterialsResponse] = Field(
         default_factory=list,
         description=(
@@ -423,6 +433,9 @@ class NodeResponse(BaseModel):
     title: str = Field(description="Node title.")
     description: str | None = Field(description="Optional node description.")
     order: int = Field(description="0-based position among siblings.")
+    node_fingerprint: str | None = Field(
+        description="Merkle hash of this node's content. ``null`` if not computed."
+    )
     created_at: datetime = Field(description="When this node was created.")
     updated_at: datetime = Field(description="When this node was last modified.")
 
@@ -460,6 +473,9 @@ class NodeTreeResponse(BaseModel):
     title: str = Field(description="Node title.")
     description: str | None = Field(description="Optional node description.")
     order: int = Field(description="0-based position among siblings.")
+    node_fingerprint: str | None = Field(
+        description="Merkle hash of this node's content. ``null`` if not computed."
+    )
     children: list[NodeTreeResponse] = Field(
         default_factory=list,
         description="Child nodes, recursively nested. Empty list for leaf nodes.",
@@ -547,6 +563,9 @@ class MaterialEntryResponse(BaseModel):
     )
     error_message: str | None = Field(
         description="Error message from the last failed processing attempt, if any."
+    )
+    content_fingerprint: str | None = Field(
+        description="SHA-256 of processed content. ``null`` if not computed."
     )
     pending_job_id: uuid.UUID | None = Field(
         description="Job ID currently processing this material, or ``null``."

--- a/tests/unit/test_api/test_material_entries.py
+++ b/tests/unit/test_api/test_material_entries.py
@@ -71,6 +71,7 @@ def _mock_entry(
     entry.order = order
     entry.state = state
     entry.error_message = error_message
+    entry.content_fingerprint = None
     entry.pending_job_id = pending_job_id
     entry.job_id = None  # Not an ORM field; prevent MagicMock auto-creation
     entry.created_at = datetime.now(UTC)

--- a/tests/unit/test_api/test_nodes.py
+++ b/tests/unit/test_api/test_nodes.py
@@ -44,6 +44,7 @@ def _mock_node(
     node.title = title
     node.description = description
     node.order = order
+    node.node_fingerprint = None
     node.children = children or []
     node.created_at = datetime.now(UTC)
     node.updated_at = datetime.now(UTC)

--- a/tests/unit/test_scope_enforcement.py
+++ b/tests/unit/test_scope_enforcement.py
@@ -37,6 +37,7 @@ def _make_course_mock() -> MagicMock:
     course.description = None
     course.created_at = datetime.now(UTC)
     course.updated_at = datetime.now(UTC)
+    course.course_fingerprint = None
     return course
 
 


### PR DESCRIPTION
Підсумок S2-029:                                                                                                      
  
  Schemas — додані fingerprint поля:                                                                                    
  - MaterialEntrySummaryResponse — content_fingerprint: str | None          
  - MaterialEntryResponse — content_fingerprint: str | None
  - NodeResponse — node_fingerprint: str | None
  - NodeTreeResponse — node_fingerprint: str | None
  - CourseDetailResponse — course_fingerprint: str | None
  - NodeWithMaterialsResponse — вже мав node_fingerprint (не змінювався)

  Route — GET /courses/{id}:
  - Обчислює course_fingerprint через FingerprintService.ensure_course_fp(tree_roots)
  - Якщо tree порожній або ValueError — повертає null

  Тести — оновлені mock helpers у 4 файлах:
  - test_courses_detail.py — content_fingerprint=None в entry, course_fingerprint=None в course, mock
  FingerprintService.ensure_course_fp
  - test_nodes.py — node_fingerprint=None в node
  - test_material_entries.py — content_fingerprint=None в entry
  - test_scope_enforcement.py — course_fingerprint=None в course
