### PR TITLE
style: brand colors for MkDocs and Swagger UI

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,19 @@
+/* Course Supporter — Brand Colors */
+
+/* Deep Tech Blue */
+:root,
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: #1A237E;
+  --md-primary-fg-color--light: #3949AB;
+  --md-primary-fg-color--dark: #0D1642;
+  --md-accent-fg-color: #FFD600;
+  --md-accent-fg-color--transparent: rgba(255, 214, 0, 0.1);
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #1A237E;
+  --md-primary-fg-color--light: #3949AB;
+  --md-primary-fg-color--dark: #0D1642;
+  --md-accent-fg-color: #FFD600;
+  --md-accent-fg-color--transparent: rgba(255, 214, 0, 0.1);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,26 +6,32 @@ repo_name: course-supporter
 
 theme:
   name: material
-  language: en
+  language: uk
   palette:
     - scheme: default
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: yellow
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - scheme: slate
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: yellow
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
+  font:
+    text: Inter
+    code: Roboto Mono
   features:
     - navigation.sections
     - navigation.expand
     - navigation.top
     - content.code.copy
     - toc.follow
+
+extra_css:
+  - stylesheets/extra.css
 
 plugins:
   - search

--- a/src/course_supporter/api/app.py
+++ b/src/course_supporter/api/app.py
@@ -1,6 +1,7 @@
 """FastAPI application with lifespan management."""
 
 import asyncio
+import pathlib
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -11,7 +12,9 @@ from arq.connections import RedisSettings
 from botocore.exceptions import ClientError
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.openapi.docs import get_swagger_ui_html
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 
@@ -96,7 +99,32 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
     debug=settings.is_dev,
+    docs_url=None,
 )
+
+app.mount(
+    "/static",
+    StaticFiles(
+        directory=str(pathlib.Path(__file__).parent / "static"),
+    ),
+    name="static",
+)
+
+
+@app.get("/docs", include_in_schema=False)
+async def custom_swagger_ui() -> HTMLResponse:
+    """Swagger UI with branded CSS."""
+    return get_swagger_ui_html(
+        openapi_url=app.openapi_url or "/openapi.json",
+        title=f"{app.title} — API Docs",
+        swagger_css_url="/static/swagger.css",
+        swagger_ui_parameters={
+            "docExpansion": "list",
+            "defaultModelsExpandDepth": 0,
+            "syntaxHighlight.theme": "monokai",
+        },
+    )
+
 
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(

--- a/src/course_supporter/api/static/swagger.css
+++ b/src/course_supporter/api/static/swagger.css
@@ -1,0 +1,45 @@
+/* Course Supporter — Swagger UI Brand Styles */
+
+/* Header bar */
+.swagger-ui .topbar {
+  background-color: #1A237E;
+}
+
+/* Page background */
+body {
+  background-color: #F5F7F9;
+}
+
+/* Font override */
+.swagger-ui {
+  font-family: "Inter", "Roboto", -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+/* "Try it out" button */
+.swagger-ui .btn.try-out__btn {
+  background-color: #FFD600;
+  color: #000;
+  border-color: #FFD600;
+}
+
+.swagger-ui .btn.try-out__btn:hover {
+  background-color: #FFEA00;
+  border-color: #FFEA00;
+}
+
+/* Execute button */
+.swagger-ui .btn.execute {
+  background-color: #1A237E;
+  color: #fff;
+  border-color: #1A237E;
+}
+
+.swagger-ui .btn.execute:hover {
+  background-color: #3949AB;
+  border-color: #3949AB;
+}
+
+/* Links */
+.swagger-ui a {
+  color: #1A237E;
+}


### PR DESCRIPTION
MkDocs Material:
- Primary: Deep Tech Blue (#1A237E), Accent: AI Electric Yellow (#FFD600)
- Font: Inter (text), Roboto Mono (code), language: uk
- Custom CSS via docs/stylesheets/extra.css

Swagger UI:
- Custom /docs endpoint with branded CSS (swagger_css_url)
- Topbar #1A237E, background #F5F7F9, "Try it out" #FFD600
- Static files mount at /static