### PR TITLE
ci: add docker cleanup step to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,10 @@ jobs:
               fi
             done
 
+            echo "=== Cleanup ==="
+            docker image prune -af --filter "until=24h"
+            docker builder prune -af --filter "until=24h"
+
             echo "=== Deploy complete: $(date) ==="
 
       - name: Smoke test


### PR DESCRIPTION
Prune old images and build cache (older than 24h) after each deploy to prevent disk space exhaustion on VPS.