### PR TITLE
  Підсумок S3-010:

### DIFF
--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -819,10 +819,25 @@ class GenerationPlanResponse(BaseModel):
     )
 
 
+class ServiceCallSummary(BaseModel):
+    """LLM metadata from the linked ExternalServiceCall."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID = Field(description="ExternalServiceCall UUID.")
+    provider: str = Field(description="LLM provider name.")
+    model_id: str = Field(description="LLM model identifier used.")
+    prompt_ref: str | None = Field(description="Prompt template reference.")
+    unit_in: int | None = Field(description="Input units (tokens) consumed.")
+    unit_out: int | None = Field(description="Output units (tokens) generated.")
+    cost_usd: float | None = Field(description="Estimated cost in USD.")
+
+
 class SnapshotSummaryResponse(BaseModel):
     """Snapshot metadata without the full structure payload.
 
     Used in list endpoints to keep response size small.
+    LLM metadata is available via the nested ``service_call`` field.
     """
 
     model_config = ConfigDict(from_attributes=True)
@@ -836,11 +851,13 @@ class SnapshotSummaryResponse(BaseModel):
     node_fingerprint: str = Field(
         description="Merkle fingerprint of the target subtree at generation time."
     )
-    prompt_version: str | None = Field(description="Prompt template version used.")
-    model_id: str | None = Field(description="LLM model identifier used.")
-    tokens_in: int | None = Field(description="Input tokens consumed.")
-    tokens_out: int | None = Field(description="Output tokens generated.")
-    cost_usd: float | None = Field(description="Estimated cost in USD.")
+    externalservicecall_id: uuid.UUID | None = Field(
+        description="Linked ExternalServiceCall UUID."
+    )
+    service_call: ServiceCallSummary | None = Field(
+        default=None,
+        description="LLM call metadata (joined from ExternalServiceCall).",
+    )
     created_at: datetime = Field(description="When this snapshot was created.")
 
 

--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -360,6 +360,7 @@ async def arq_generate_structure(
                 return
 
             # Generate via ArchitectAgent
+            from course_supporter.storage.orm import ExternalServiceCall
             from course_supporter.tree_utils import serialize_tree_for_guided
 
             existing_structure = (
@@ -370,18 +371,31 @@ async def arq_generate_structure(
                 context, existing_structure=existing_structure
             )
 
-            # Save snapshot
+            # Persist LLM metadata as ExternalServiceCall
+            esc = ExternalServiceCall(
+                action="course_structuring",
+                strategy=mode,
+                provider=gen_result.response.provider,
+                model_id=gen_result.response.model_id,
+                prompt_ref=gen_result.prompt_version,
+                unit_type="tokens",
+                unit_in=gen_result.response.tokens_in,
+                unit_out=gen_result.response.tokens_out,
+                latency_ms=gen_result.response.latency_ms,
+                cost_usd=gen_result.response.cost_usd,
+                success=True,
+            )
+            session.add(esc)
+            await session.flush()
+
+            # Save snapshot with ESC FK
             snapshot = await snap_repo.create(
                 course_id=cid,
                 node_id=nid,
                 node_fingerprint=fingerprint,
                 mode=mode,
                 structure=gen_result.structure.model_dump(),
-                prompt_version=gen_result.prompt_version,
-                model_id=gen_result.response.model_id,
-                tokens_in=gen_result.response.tokens_in,
-                tokens_out=gen_result.response.tokens_out,
-                cost_usd=gen_result.response.cost_usd,
+                externalservicecall_id=esc.id,
             )
 
             # Job → complete

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -115,7 +115,7 @@ class Course(Base):
     material_nodes: Mapped[list["MaterialNode"]] = relationship(
         back_populates="course", cascade="all, delete-orphan"
     )
-    snapshots: Mapped[list["CourseStructureSnapshot"]] = relationship(
+    snapshots: Mapped[list["StructureSnapshot"]] = relationship(
         back_populates="course", cascade="all, delete-orphan"
     )
 
@@ -377,17 +377,20 @@ class GenerationMode(StrEnum):
     GUIDED = "guided"
 
 
-class CourseStructureSnapshot(Base):
+class StructureSnapshot(Base):
     """Immutable snapshot of a generated course structure.
 
     Tied to a specific (course, node, fingerprint, mode) combination
     for idempotency: re-generating with the same inputs returns the
     existing snapshot instead of calling the LLM again.
 
+    LLM metadata (model_id, tokens, cost) is stored in the linked
+    ExternalServiceCall record — no duplication in the snapshot.
+
     When ``node_id`` is NULL the snapshot covers the entire course.
     """
 
-    __tablename__ = "course_structure_snapshots"
+    __tablename__ = "structure_snapshots"
     __table_args__ = (
         Index(
             "uq_snapshots_identity",
@@ -406,16 +409,12 @@ class CourseStructureSnapshot(Base):
     node_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("material_nodes.id", ondelete="CASCADE"), index=True
     )
+    externalservicecall_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("external_service_calls.id", ondelete="SET NULL"), index=True
+    )
     node_fingerprint: Mapped[str] = mapped_column(String(64))
     mode: Mapped[GenerationMode] = mapped_column(String(20))
     structure: Mapped[dict[str, Any]] = mapped_column(JSONB)
-
-    # ── LLM metadata ──
-    prompt_version: Mapped[str | None] = mapped_column(String(50))
-    model_id: Mapped[str | None] = mapped_column(String(100))
-    tokens_in: Mapped[int | None] = mapped_column(Integer)
-    tokens_out: Mapped[int | None] = mapped_column(Integer)
-    cost_usd: Mapped[float | None] = mapped_column(Float)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
@@ -424,6 +423,7 @@ class CourseStructureSnapshot(Base):
     # Relationships
     course: Mapped["Course"] = relationship(back_populates="snapshots")
     node: Mapped["MaterialNode | None"] = relationship()
+    service_call: Mapped["ExternalServiceCall | None"] = relationship()
 
 
 # ──────────────────────────────────────────────

--- a/src/course_supporter/storage/snapshot_repository.py
+++ b/src/course_supporter/storage/snapshot_repository.py
@@ -1,4 +1,4 @@
-"""Repository for CourseStructureSnapshot CRUD operations."""
+"""Repository for StructureSnapshot CRUD operations."""
 
 from __future__ import annotations
 
@@ -7,16 +7,17 @@ from typing import Any
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from course_supporter.storage.orm import (
     NIL_UUID,
-    CourseStructureSnapshot,
     GenerationMode,
+    StructureSnapshot,
 )
 
 
 class SnapshotRepository:
-    """Repository for course structure snapshot operations.
+    """Repository for structure snapshot operations.
 
     Not tenant-scoped — tenant isolation is ensured at the API layer
     by verifying course ownership before accessing snapshots.
@@ -33,32 +34,30 @@ class SnapshotRepository:
         node_fingerprint: str,
         mode: GenerationMode | str,
         structure: dict[str, Any],
-        prompt_version: str | None = None,
-        model_id: str | None = None,
-        tokens_in: int | None = None,
-        tokens_out: int | None = None,
-        cost_usd: float | None = None,
-    ) -> CourseStructureSnapshot:
+        externalservicecall_id: uuid.UUID | None = None,
+    ) -> StructureSnapshot:
         """Create a new snapshot record."""
-        snapshot = CourseStructureSnapshot(
+        snapshot = StructureSnapshot(
             course_id=course_id,
             node_id=node_id,
             node_fingerprint=node_fingerprint,
             mode=mode,
             structure=structure,
-            prompt_version=prompt_version,
-            model_id=model_id,
-            tokens_in=tokens_in,
-            tokens_out=tokens_out,
-            cost_usd=cost_usd,
+            externalservicecall_id=externalservicecall_id,
         )
         self._session.add(snapshot)
         await self._session.flush()
         return snapshot
 
-    async def get_by_id(self, snapshot_id: uuid.UUID) -> CourseStructureSnapshot | None:
-        """Get a snapshot by primary key."""
-        return await self._session.get(CourseStructureSnapshot, snapshot_id)
+    async def get_by_id(self, snapshot_id: uuid.UUID) -> StructureSnapshot | None:
+        """Get a snapshot by primary key, eager-loading the service call."""
+        stmt = (
+            select(StructureSnapshot)
+            .options(joinedload(StructureSnapshot.service_call))
+            .where(StructureSnapshot.id == snapshot_id)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
 
     async def find_by_identity(
         self,
@@ -67,18 +66,17 @@ class SnapshotRepository:
         node_id: uuid.UUID | None,
         node_fingerprint: str,
         mode: GenerationMode | str,
-    ) -> CourseStructureSnapshot | None:
+    ) -> StructureSnapshot | None:
         """Find snapshot by the unique identity key.
 
         The identity is (course_id, node_id, node_fingerprint, mode).
         ``node_id=None`` means course-level snapshot.
         """
-        stmt = select(CourseStructureSnapshot).where(
-            CourseStructureSnapshot.course_id == course_id,
-            func.coalesce(CourseStructureSnapshot.node_id, NIL_UUID)
-            == (node_id or NIL_UUID),
-            CourseStructureSnapshot.node_fingerprint == node_fingerprint,
-            CourseStructureSnapshot.mode == mode,
+        stmt = select(StructureSnapshot).where(
+            StructureSnapshot.course_id == course_id,
+            func.coalesce(StructureSnapshot.node_id, NIL_UUID) == (node_id or NIL_UUID),
+            StructureSnapshot.node_fingerprint == node_fingerprint,
+            StructureSnapshot.mode == mode,
         )
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none()
@@ -87,15 +85,16 @@ class SnapshotRepository:
         self,
         course_id: uuid.UUID,
         node_id: uuid.UUID,
-    ) -> CourseStructureSnapshot | None:
+    ) -> StructureSnapshot | None:
         """Get the most recent snapshot for a specific node."""
         stmt = (
-            select(CourseStructureSnapshot)
+            select(StructureSnapshot)
+            .options(joinedload(StructureSnapshot.service_call))
             .where(
-                CourseStructureSnapshot.course_id == course_id,
-                CourseStructureSnapshot.node_id == node_id,
+                StructureSnapshot.course_id == course_id,
+                StructureSnapshot.node_id == node_id,
             )
-            .order_by(CourseStructureSnapshot.created_at.desc())
+            .order_by(StructureSnapshot.created_at.desc())
             .limit(1)
         )
         result = await self._session.execute(stmt)
@@ -104,15 +103,16 @@ class SnapshotRepository:
     async def get_latest_for_course(
         self,
         course_id: uuid.UUID,
-    ) -> CourseStructureSnapshot | None:
+    ) -> StructureSnapshot | None:
         """Get the most recent course-level snapshot (node_id IS NULL)."""
         stmt = (
-            select(CourseStructureSnapshot)
+            select(StructureSnapshot)
+            .options(joinedload(StructureSnapshot.service_call))
             .where(
-                CourseStructureSnapshot.course_id == course_id,
-                CourseStructureSnapshot.node_id.is_(None),
+                StructureSnapshot.course_id == course_id,
+                StructureSnapshot.node_id.is_(None),
             )
-            .order_by(CourseStructureSnapshot.created_at.desc())
+            .order_by(StructureSnapshot.created_at.desc())
             .limit(1)
         )
         result = await self._session.execute(stmt)
@@ -122,8 +122,8 @@ class SnapshotRepository:
         """Count snapshots for a course."""
         stmt = (
             select(func.count())
-            .select_from(CourseStructureSnapshot)
-            .where(CourseStructureSnapshot.course_id == course_id)
+            .select_from(StructureSnapshot)
+            .where(StructureSnapshot.course_id == course_id)
         )
         result = await self._session.execute(stmt)
         return result.scalar_one()
@@ -134,7 +134,7 @@ class SnapshotRepository:
         *,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> list[CourseStructureSnapshot]:
+    ) -> list[StructureSnapshot]:
         """List snapshots for a course, newest first.
 
         Args:
@@ -143,9 +143,10 @@ class SnapshotRepository:
             offset: Rows to skip (DB-level OFFSET).
         """
         stmt = (
-            select(CourseStructureSnapshot)
-            .where(CourseStructureSnapshot.course_id == course_id)
-            .order_by(CourseStructureSnapshot.created_at.desc())
+            select(StructureSnapshot)
+            .options(joinedload(StructureSnapshot.service_call))
+            .where(StructureSnapshot.course_id == course_id)
+            .order_by(StructureSnapshot.created_at.desc())
         )
         if offset is not None:
             stmt = stmt.offset(offset)

--- a/tests/unit/test_api/test_generation_routes.py
+++ b/tests/unit/test_api/test_generation_routes.py
@@ -75,11 +75,16 @@ def _make_snapshot(
     snap.node_id = node_id
     snap.mode = "free"
     snap.node_fingerprint = "a" * 64
-    snap.prompt_version = "v1"
-    snap.model_id = "gemini-2.0-flash"
-    snap.tokens_in = 1000
-    snap.tokens_out = 500
-    snap.cost_usd = 0.01
+    snap.externalservicecall_id = uuid.uuid4()
+    snap.service_call = MagicMock(
+        id=snap.externalservicecall_id,
+        provider="gemini",
+        model_id="gemini-2.0-flash",
+        prompt_ref="v1",
+        unit_in=1000,
+        unit_out=500,
+        cost_usd=0.01,
+    )
     snap.structure = structure or {"title": "Test Course", "modules": []}
     snap.created_at = NOW
     return snap

--- a/tests/unit/test_generate_structure_task.py
+++ b/tests/unit/test_generate_structure_task.py
@@ -76,7 +76,7 @@ def _make_mapping(
 
 
 def _make_snapshot(snapshot_id: uuid.UUID | None = None) -> MagicMock:
-    """Create a mock CourseStructureSnapshot."""
+    """Create a mock StructureSnapshot."""
     snap = MagicMock()
     snap.id = snapshot_id or uuid.uuid4()
     return snap
@@ -459,15 +459,15 @@ class TestMappingsFiltering:
 
 
 class TestLLMMetadata:
-    """LLM metadata passed to snapshot create."""
+    """LLM metadata stored in ExternalServiceCall, linked to snapshot."""
 
     @pytest.mark.asyncio
-    async def test_metadata_in_snapshot(
+    async def test_esc_created_and_linked(
         self,
         job_id: str,
         course_id: str,
     ) -> None:
-        """Snapshot receives model_id, tokens, cost from GenerationResult."""
+        """Snapshot receives externalservicecall_id from created ESC."""
         entry = _make_entry(state="ready")
         root = _make_node(materials=[entry])
 
@@ -477,11 +477,11 @@ class TestLLMMetadata:
         await _run_task(job_id, course_id, deps)
 
         create_kwargs = deps.snap_repo.create.call_args.kwargs
-        assert create_kwargs["model_id"] == "gemini-2.5-flash"
-        assert create_kwargs["tokens_in"] == 100
-        assert create_kwargs["tokens_out"] == 200
-        assert create_kwargs["cost_usd"] == 0.005
-        assert create_kwargs["prompt_version"] == "v1"
+        assert "externalservicecall_id" in create_kwargs
+        # LLM metadata fields should NOT be in snapshot create
+        assert "model_id" not in create_kwargs
+        assert "tokens_in" not in create_kwargs
+        assert "cost_usd" not in create_kwargs
 
 
 class TestModePassthrough:

--- a/tests/unit/test_snapshot_repository.py
+++ b/tests/unit/test_snapshot_repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from unittest.mock import AsyncMock, MagicMock
 
-from course_supporter.storage.orm import CourseStructureSnapshot
+from course_supporter.storage.orm import StructureSnapshot
 from course_supporter.storage.snapshot_repository import SnapshotRepository
 
 
@@ -17,20 +17,18 @@ def _mock_snapshot(
     node_fingerprint: str = "abc123",
     mode: str = "free",
     structure: dict[str, object] | None = None,
+    externalservicecall_id: uuid.UUID | None = None,
 ) -> MagicMock:
-    """Create a mock CourseStructureSnapshot."""
-    snap = MagicMock(spec=CourseStructureSnapshot)
+    """Create a mock StructureSnapshot."""
+    snap = MagicMock(spec=StructureSnapshot)
     snap.id = snapshot_id or uuid.uuid4()
     snap.course_id = course_id or uuid.uuid4()
     snap.node_id = node_id
     snap.node_fingerprint = node_fingerprint
     snap.mode = mode
     snap.structure = structure or {"title": "Test"}
-    snap.prompt_version = None
-    snap.model_id = None
-    snap.tokens_in = None
-    snap.tokens_out = None
-    snap.cost_usd = None
+    snap.externalservicecall_id = externalservicecall_id
+    snap.service_call = None
     return snap
 
 
@@ -45,7 +43,7 @@ class TestCreate:
     """SnapshotRepository.create tests."""
 
     async def test_create_returns_snapshot(self) -> None:
-        """create() returns a CourseStructureSnapshot instance."""
+        """create() returns a StructureSnapshot instance."""
         session = _make_session()
         repo = SnapshotRepository(session)
 
@@ -56,7 +54,7 @@ class TestCreate:
             structure={"title": "Test"},
         )
 
-        assert isinstance(result, CourseStructureSnapshot)
+        assert isinstance(result, StructureSnapshot)
 
     async def test_create_adds_to_session(self) -> None:
         """create() calls session.add()."""
@@ -87,28 +85,21 @@ class TestCreate:
         session.flush.assert_awaited_once()
         session.commit.assert_not_awaited()
 
-    async def test_create_with_llm_metadata(self) -> None:
-        """create() passes LLM metadata fields to the ORM object."""
+    async def test_create_with_esc_fk(self) -> None:
+        """create() passes externalservicecall_id to the ORM object."""
         session = _make_session()
         repo = SnapshotRepository(session)
+        esc_id = uuid.uuid4()
 
         result = await repo.create(
             course_id=uuid.uuid4(),
             node_fingerprint="abc123",
             mode="guided",
             structure={"title": "Test"},
-            prompt_version="v1",
-            model_id="gemini-2.0-flash",
-            tokens_in=500,
-            tokens_out=1200,
-            cost_usd=0.003,
+            externalservicecall_id=esc_id,
         )
 
-        assert result.prompt_version == "v1"
-        assert result.model_id == "gemini-2.0-flash"
-        assert result.tokens_in == 500
-        assert result.tokens_out == 1200
-        assert result.cost_usd == 0.003
+        assert result.externalservicecall_id == esc_id
 
     async def test_create_with_node_id(self) -> None:
         """create() sets node_id for node-level snapshot."""
@@ -148,7 +139,9 @@ class TestGetById:
         """get_by_id() returns snapshot when found."""
         session = _make_session()
         snap = _mock_snapshot()
-        session.get.return_value = snap
+        exec_result = MagicMock()
+        exec_result.scalar_one_or_none.return_value = snap
+        session.execute.return_value = exec_result
         repo = SnapshotRepository(session)
 
         result = await repo.get_by_id(snap.id)
@@ -158,7 +151,9 @@ class TestGetById:
     async def test_get_by_id_not_found(self) -> None:
         """get_by_id() returns None when not found."""
         session = _make_session()
-        session.get.return_value = None
+        exec_result = MagicMock()
+        exec_result.scalar_one_or_none.return_value = None
+        session.execute.return_value = exec_result
         repo = SnapshotRepository(session)
 
         result = await repo.get_by_id(uuid.uuid4())


### PR DESCRIPTION
  - CourseStructureSnapshot → StructureSnapshot, table structure_snapshots
  - Видалено 5 LLM metadata колонок (prompt_version, model_id, tokens_in, tokens_out, cost_usd)
  - Додано externalservicecall_id FK → ExternalServiceCall
  - arq_generate_structure тепер створює ESC + Snapshot пару
  - API response через nested ServiceCallSummary (joinedload)
  - Міграція з data migration (створює ESC для існуючих snapshots)
  - course_id та mode збережено (потрібні для queries/idempotency, видалення відкладено)