### PR TITLE
fix: align NodeResponse contract with frontend expectations

### DIFF
--- a/src/course_supporter/api/routes/nodes.py
+++ b/src/course_supporter/api/routes/nodes.py
@@ -85,6 +85,14 @@ def _ve_to_dict(err: MappingValidationError) -> dict[str, str | None]:
     return asdict(err)
 
 
+def _node_response(node: MaterialNode) -> NodeResponse:
+    """Build NodeResponse with computed children_count and materials_count."""
+    resp = NodeResponse.model_validate(node)
+    resp.children_count = len(node.children) if node.children else 0
+    resp.materials_count = len(node.materials) if node.materials else 0
+    return resp
+
+
 async def _require_node_for_tenant(
     session: AsyncSession,
     tenant_id: uuid.UUID,
@@ -170,7 +178,7 @@ async def list_root_nodes(
     roots = await repo.list_roots(tenant.tenant_id, limit=limit, offset=offset)
     total = await repo.count_roots(tenant.tenant_id)
     return NodeListResponse(
-        items=[NodeResponse.model_validate(r) for r in roots],
+        items=[_node_response(r) for r in roots],
         total=total,
         limit=limit,
         offset=offset,
@@ -237,7 +245,7 @@ async def get_node_detail(
     node_id: uuid.UUID,
     tenant: SharedDep,
     session: SessionDep,
-) -> list[NodeWithMaterialsResponse]:
+) -> NodeWithMaterialsResponse:
     """Get the full subtree with materials attached to each node.
 
     Returns the hierarchical view including materials at each level
@@ -247,7 +255,9 @@ async def get_node_detail(
 
     repo = MaterialNodeRepository(session)
     tree_roots = await repo.get_subtree(node_id, include_materials=True)
-    return [NodeWithMaterialsResponse.model_validate(r) for r in tree_roots]
+    if not tree_roots:
+        raise HTTPException(status_code=404, detail="Node not found")
+    return NodeWithMaterialsResponse.model_validate(tree_roots[0])
 
 
 # ── Single node operations ──

--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -273,8 +273,10 @@ class NodeResponse(BaseModel):
 
     id: uuid.UUID = Field(description="Unique node identifier (UUIDv7).")
     tenant_id: uuid.UUID = Field(description="Tenant this node belongs to.")
-    parent_materialnode_id: uuid.UUID | None = Field(
-        description="Parent node ID, or ``null`` for root nodes."
+    parent_id: uuid.UUID | None = Field(
+        default=None,
+        description="Parent node ID, or ``null`` for root nodes.",
+        validation_alias="parent_materialnode_id",
     )
     title: str = Field(description="Node title.")
     description: str | None = Field(description="Optional node description.")
@@ -290,6 +292,14 @@ class NodeResponse(BaseModel):
     order: int = Field(description="0-based position among siblings.")
     node_fingerprint: str | None = Field(
         description="Merkle hash of this node's content. ``null`` if not computed."
+    )
+    children_count: int = Field(
+        default=0,
+        description="Number of direct child nodes.",
+    )
+    materials_count: int = Field(
+        default=0,
+        description="Number of material entries attached to this node.",
     )
     created_at: datetime = Field(description="When this node was created.")
     updated_at: datetime = Field(description="When this node was last modified.")

--- a/src/course_supporter/storage/material_node_repository.py
+++ b/src/course_supporter/storage/material_node_repository.py
@@ -43,12 +43,19 @@ class MaterialNodeRepository:
         limit: int = 50,
         offset: int = 0,
     ) -> list[MaterialNode]:
-        """List root nodes for a tenant, ordered newest first."""
+        """List root nodes for a tenant, ordered newest first.
+
+        Eagerly loads direct children and materials for count computation.
+        """
         stmt = (
             select(MaterialNode)
             .where(
                 MaterialNode.tenant_id == tenant_id,
                 MaterialNode.parent_materialnode_id.is_(None),
+            )
+            .options(
+                selectinload(MaterialNode.children),
+                selectinload(MaterialNode.materials),
             )
             .order_by(MaterialNode.created_at.desc())
             .limit(limit)

--- a/tests/unit/test_api/test_nodes.py
+++ b/tests/unit/test_api/test_nodes.py
@@ -98,7 +98,7 @@ class TestCreateRootNode:
         data = resp.json()
         assert data["id"] == str(node.id)
         assert data["title"] == "Module 1"
-        assert data["parent_materialnode_id"] is None
+        assert data["parent_id"] is None
         assert data["tenant_id"] == str(STUB_TENANT.tenant_id)
         assert "created_at" in data
         assert "updated_at" in data
@@ -139,7 +139,7 @@ class TestCreateChildNode:
                 f"/api/v1/nodes/{parent.id}/children", json={"title": "Child"}
             )
         assert resp.status_code == 201
-        assert resp.json()["parent_materialnode_id"] == str(parent.id)
+        assert resp.json()["parent_id"] == str(parent.id)
 
     async def test_parent_not_found_returns_404(self, client: AsyncClient) -> None:
         """Non-existent parent returns 404."""
@@ -290,7 +290,7 @@ class TestMoveNode:
                 json={"parent_materialnode_id": str(target.id)},
             )
         assert resp.status_code == 200
-        assert resp.json()["parent_materialnode_id"] == str(target.id)
+        assert resp.json()["parent_id"] == str(target.id)
 
     async def test_move_to_root(self, client: AsyncClient) -> None:
         """Node moved to root (parent_materialnode_id=null)."""
@@ -304,7 +304,7 @@ class TestMoveNode:
                 f"/api/v1/nodes/{node.id}/move", json={"parent_materialnode_id": None}
             )
         assert resp.status_code == 200
-        assert resp.json()["parent_materialnode_id"] is None
+        assert resp.json()["parent_id"] is None
 
     async def test_cycle_returns_422(self, client: AsyncClient) -> None:
         """Cycle detection error returns 422."""

--- a/tests/unit/test_s3012_node_based_routing.py
+++ b/tests/unit/test_s3012_node_based_routing.py
@@ -288,7 +288,7 @@ class TestRootNodeAsCourse:
 
         assert resp.status_code == 201
         data = resp.json()
-        assert data["parent_materialnode_id"] is None
+        assert data["parent_id"] is None
         assert data["title"] == "Python Basics"
         assert data["tenant_id"] == str(STUB_TENANT.tenant_id)
 
@@ -321,7 +321,7 @@ class TestRootNodeAsCourse:
         data = resp.json()
         assert data["total"] == 2
         assert len(data["items"]) == 2
-        assert all(item["parent_materialnode_id"] is None for item in data["items"])
+        assert all(item["parent_id"] is None for item in data["items"])
 
     async def test_other_tenant_roots_not_visible(
         self,


### PR DESCRIPTION
- Rename parent_materialnode_id → parent_id (via validation_alias) in NodeResponse
- Add children_count and materials_count computed fields
- Change /nodes/{id}/detail to return single object instead of array
- Eagerly load children and materials in list_roots for count computation