### PR TITLE
fix: handle both StreamingBody and raw ClientResponse in S3 download

### DIFF
--- a/src/course_supporter/storage/s3.py
+++ b/src/course_supporter/storage/s3.py
@@ -336,17 +336,19 @@ class S3Client:
                 # raw aiohttp ClientResponse (some S3 providers) has
                 # content.iter_chunked().  Support both.
                 if hasattr(stream, "iter_chunks"):
-                    chunks = stream.iter_chunks(DOWNLOAD_CHUNK_SIZE)
-                elif hasattr(stream, "content"):
-                    chunks = stream.content.iter_chunked(DOWNLOAD_CHUNK_SIZE)
-                else:
-                    # Last resort: read everything at once.
-                    await fh.write(await stream.read())
-                    chunks = None
-
-                if chunks is not None:
-                    async for chunk in chunks:
+                    async for chunk in stream.iter_chunks(DOWNLOAD_CHUNK_SIZE):
                         await fh.write(chunk)
+                elif hasattr(stream, "content"):
+                    async for chunk in stream.content.iter_chunked(
+                        DOWNLOAD_CHUNK_SIZE,
+                    ):
+                        await fh.write(chunk)
+                else:
+                    msg = (
+                        f"Unsupported S3 stream type: {type(stream).__name__}. "
+                        "Expected StreamingBody or aiohttp ClientResponse."
+                    )
+                    raise TypeError(msg)
         except Exception:
             # Clean up only self-created temp files on download failure.
             # Caller-provided dest is left for the caller to manage.


### PR DESCRIPTION
On some S3 providers (Backblaze B2) response["Body"] is a raw aiohttp ClientResponse instead of aiobotocore StreamingBody. Add fallback: try iter_chunks() (StreamingBody), then content.iter_chunked() (aiohttp ClientResponse), then read() as last resort.