### PR TITLE
fix: prevent greenlet error in snapshot detail endpoints

### DIFF
--- a/src/course_supporter/api/routes/generation.py
+++ b/src/course_supporter/api/routes/generation.py
@@ -239,8 +239,7 @@ def _flat_to_tree(
     for n in flat_nodes:
         # Prevent Pydantic from triggering lazy-load on the ORM
         # children relationship (greenlet error in async context).
-        if hasattr(n, "_sa_instance_state"):
-            set_committed_value(n, "children", [])
+        set_committed_value(n, "children", [])
         resp = StructureNodeResponse.model_validate(n)
         node_map[resp.id] = resp
 

--- a/tests/unit/test_structure_node_tree.py
+++ b/tests/unit/test_structure_node_tree.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import uuid
-from types import SimpleNamespace
 
 from course_supporter.api.routes.generation import _flat_to_tree
 from course_supporter.api.schemas import StructureNodeResponse
-from course_supporter.storage.orm import StructureNodeType
+from course_supporter.storage.orm import StructureNode, StructureNodeType
 
 
 def _make_sn(
@@ -18,37 +17,17 @@ def _make_sn(
     order: int = 0,
     title: str = "Node",
     **kwargs: object,
-) -> SimpleNamespace:
-    """Create a fake StructureNode-like object for testing."""
-    defaults: dict[str, object] = {
-        "id": node_id or uuid.uuid4(),
-        "parent_structurenode_id": parent_id,
-        "node_type": node_type,
-        "order": order,
-        "title": title,
-        "description": None,
-        "learning_goal": None,
-        "expected_knowledge": None,
-        "expected_skills": None,
-        "prerequisites": None,
-        "difficulty": None,
-        "estimated_duration": None,
-        "success_criteria": None,
-        "assessment_method": None,
-        "competencies": None,
-        "key_concepts": None,
-        "common_mistakes": None,
-        "teaching_strategy": None,
-        "activities": None,
-        "teaching_style": None,
-        "deep_dive_references": None,
-        "timecodes": None,
-        "slide_references": None,
-        "web_references": None,
-        "children": [],
-    }
-    defaults.update(kwargs)
-    return SimpleNamespace(**defaults)
+) -> StructureNode:
+    """Create a detached StructureNode ORM instance for testing."""
+    return StructureNode(
+        id=node_id or uuid.uuid4(),
+        structuresnapshot_id=uuid.uuid4(),
+        parent_structurenode_id=parent_id,
+        node_type=node_type,
+        order=order,
+        title=title,
+        **kwargs,  # type: ignore[arg-type]
+    )
 
 
 class TestFlatToTree:


### PR DESCRIPTION
  Два коміти в цій сесії:                                                                                               
  1. 5d00119 — token guard враховує provider default max_output_tokens                                                  
  2. fd3f681 — фікс greenlet error на snapshot detail endpoints (/structure, /snapshots/{id})                           
                                                                                                                        
  Після деплою цього фіксу /structure endpoint повинен повертати згенеровану структуру замість 500.  

set_committed_value on StructureNode.children before Pydantic model_validate to avoid lazy-load in async context. Fixes 500 on GET /nodes/{id}/structure and /snapshots/{id}.