### PR TITLE
feat: add summary_nested_nodes for recursive context compression

### DIFF
--- a/current-doc/S3-050-context-compression.md
+++ b/current-doc/S3-050-context-compression.md
@@ -1,0 +1,240 @@
+# S3-050: Context Compression for Parent/Root Node Generation
+
+## Problem
+
+When generating structure for a parent/root node, `_collect_ready_documents()` collects **all raw materials from the entire subtree**. For a course with 3 child nodes this produces ~445k input tokens — exceeding Gemini free tier rate limit (250k/min) and making generation expensive on paid tiers.
+
+The root cause: parent nodes receive full transcripts, slide text, and web content from all descendants, even though those descendants **already have generated snapshots** with structured summaries.
+
+## Solution
+
+Replace raw descendant materials with **child snapshots** for non-leaf nodes. Add a new field `summary_nested_nodes` to enable recursive context compression with a gradient of detail:
+
+| Distance from node | What LLM sees | Volume |
+|---|---|---|
+| 0 (current node) | Raw materials (processed_content) | 100% |
+| -1 (direct children) | Full snapshots (structure + summary + concepts + summary_nested_nodes) | ~5-10% |
+| -2+ (grandchildren) | Only via `summary_nested_nodes` in children's snapshots | ~0.5-1% |
+
+## Acceptance Criteria
+
+- [ ] Parent/root nodes use child snapshots instead of child raw materials
+- [ ] Leaf nodes continue using raw materials (no change)
+- [ ] New field `summary_nested_nodes` in `StructureSnapshot` ORM and `CourseStructure` schema
+- [ ] LLM prompt instructs generation of `summary_nested_nodes` from received child snapshots
+- [ ] Root node with 3 children generates successfully within Gemini free tier limits
+- [ ] All existing tests pass; new tests cover the changed context assembly
+
+## Architecture
+
+### Current Flow (parent node)
+
+```
+arq_execute_step()
+  → get_subtree(root_id, include_materials=True)      # loads ALL materials
+  → _collect_ready_documents(flat_nodes)               # ALL descendants' raw content
+  → MergeStep().merge(documents, ...)                  # serialize ALL to CourseContext
+  → ArchitectAgent.execute(step_input)                 # ~445k tokens to LLM
+```
+
+### New Flow (parent node)
+
+```
+arq_execute_step()
+  → get_subtree(root_id, include_materials=True)
+  → _collect_ready_documents([target_node_only])       # ONLY this node's materials
+  → _load_children_snapshots(session, target_node)     # children's full snapshots
+  → MergeStep().merge(own_documents, ...)              # own materials only
+  → ArchitectAgent.execute(step_input)                 # ~30-50k tokens to LLM
+```
+
+### Data in Prompt (parent node)
+
+```
+## This Node's Materials          ← raw processed_content (if any)
+{context}
+
+## Child Node Snapshots           ← NEW: full CourseStructure from children
+### Node "01 - Умовні конструкції"
+Structure: {modules: [...], summary: "...", core_concepts: [...]}
+Summary of nested nodes: "..."   ← from summary_nested_nodes field
+
+### Node "02 - Цикли"
+Structure: {modules: [...], summary: "...", core_concepts: [...]}
+Summary of nested nodes: "..."
+```
+
+## Implementation Steps
+
+### Step 1: Add `summary_nested_nodes` field
+
+**Files:**
+- `src/course_supporter/storage/orm.py` — add column to `StructureSnapshot`
+- `src/course_supporter/models/course.py` — add field to `CourseStructure`
+- Alembic migration
+
+```python
+# orm.py — StructureSnapshot
+summary_nested_nodes: Mapped[str | None] = mapped_column(
+    Text,
+    nullable=True,
+    comment="LLM-generated compressed summary of all nested node snapshots",
+)
+
+# course.py — CourseStructure
+summary_nested_nodes: str = ""
+```
+
+### Step 2: Update prompt to generate `summary_nested_nodes`
+
+**Files:**
+- `prompts/architect/v1.yaml` — add field description + generation instruction
+- `prompts/architect/v1_guided.yaml` — same
+
+Add to Output Schema section:
+```
+### Course level (additional fields)
+- **summary_nested_nodes**: compressed summary of ALL child node snapshots
+  received in the "Child Node Snapshots" section. Should capture key topics,
+  learning goals, and concept coverage across all nested materials.
+  Empty string if no child snapshots were provided.
+```
+
+Add to Rules:
+```
+10. If "Child Node Snapshots" are provided, generate summary_nested_nodes
+    as a concise (200-500 word) summary that captures the key topics,
+    learning goals, and concepts from ALL nested node structures.
+    This summary will be used by parent nodes as compressed context.
+```
+
+### Step 3: Add `children_snapshots` to `StepInput`
+
+**Files:**
+- `src/course_supporter/models/step.py` — add field to `StepInput`
+
+```python
+@dataclass(frozen=True)
+class ChildSnapshotContext:
+    """Full snapshot of a child node for parent context."""
+    node_id: uuid.UUID
+    title: str
+    structure: dict[str, Any]       # CourseStructure JSON
+    summary: str
+    core_concepts: list[str]
+    mentioned_concepts: list[str]
+    summary_nested_nodes: str       # compressed grandchildren context
+
+@dataclass(frozen=True)
+class StepInput:
+    ...
+    # NEW: full child snapshots for parent nodes
+    children_snapshots: list[ChildSnapshotContext] = field(default_factory=list)
+```
+
+### Step 4: Change context assembly in `tasks.py`
+
+**Files:**
+- `src/course_supporter/api/tasks.py`
+
+Key change in `arq_execute_step()`:
+
+```python
+# BEFORE: collect documents from entire subtree
+documents = _collect_ready_documents(flat_nodes)
+
+# AFTER: collect documents from target node only (if it has children with snapshots)
+if target_node.children and children_snapshots:
+    # Parent node: own materials only
+    own_documents = _collect_ready_documents([target_node])
+else:
+    # Leaf node: all materials (unchanged behavior)
+    own_documents = _collect_ready_documents(flat_nodes)
+```
+
+New function to load full child snapshots:
+
+```python
+async def _load_children_snapshots(
+    session: AsyncSession,
+    node: MaterialNode,
+) -> list[ChildSnapshotContext]:
+    """Load full snapshot data from child nodes for parent context."""
+    ...
+```
+
+### Step 5: Update `ArchitectAgent` to format child snapshots
+
+**Files:**
+- `src/course_supporter/agents/architect.py`
+
+Replace `_format_children_context()` (which only shows summary + concepts) with `_format_children_snapshots()` that includes the full CourseStructure JSON:
+
+```python
+def _format_children_snapshots(
+    children_snapshots: list[ChildSnapshotContext],
+) -> str:
+    """Format child snapshots as structured context for the LLM prompt."""
+    if not children_snapshots:
+        return ""
+    lines = ["## Child Node Snapshots", ""]
+    for cs in children_snapshots:
+        lines.append(f"### {cs.title}")
+        lines.append(f"**Summary:** {cs.summary}")
+        lines.append(f"**Core concepts:** {', '.join(cs.core_concepts)}")
+        if cs.summary_nested_nodes:
+            lines.append(f"**Nested nodes summary:** {cs.summary_nested_nodes}")
+        lines.append(f"**Structure:**")
+        lines.append(json.dumps(cs.structure, ensure_ascii=False, indent=2))
+        lines.append("")
+    return "\n".join(lines)
+```
+
+### Step 6: Persist `summary_nested_nodes` in snapshot
+
+**Files:**
+- `src/course_supporter/api/tasks.py` — `_persist_step_result()`
+- `src/course_supporter/storage/snapshot_repository.py` — `create()`
+
+```python
+# _persist_step_result
+snapshot = await snap_repo.create(
+    ...
+    summary_nested_nodes=step_output.summary_nested_nodes,  # NEW
+)
+```
+
+### Step 7: Update `StepOutput`
+
+**Files:**
+- `src/course_supporter/models/step.py`
+
+```python
+@dataclass(frozen=True)
+class StepOutput:
+    ...
+    summary_nested_nodes: str = ""  # NEW
+```
+
+## Token Budget Estimate (3-node course)
+
+| Scenario | Before | After |
+|---|---|---|
+| Leaf node (own materials) | ~130-194k | ~130-194k (unchanged) |
+| Root node (3 children) | ~445k | ~30-50k |
+| Total pipeline | ~770k | ~400-440k |
+| Root fits in Gemini free tier? | No (>250k) | Yes (<250k) |
+
+## Backwards Compatibility
+
+- `summary_nested_nodes` is nullable/optional — existing snapshots unaffected
+- Leaf nodes produce `summary_nested_nodes=""` — no impact
+- `_collect_ready_documents` for leaf nodes unchanged
+- Old `arq_generate_structure()` task is untouched (only `arq_execute_step` modified)
+
+## Edge Cases
+
+1. **Node has own materials AND children** — include both own raw materials and children snapshots
+2. **Child has no snapshot yet** — fall back to collecting that child's raw materials (partial compression)
+3. **Empty `summary_nested_nodes`** — leaf nodes always produce empty string; parent prompt handles gracefully
+4. **Guided mode** — same compression applies; existing_structure still comes from serialize_tree_for_guided

--- a/migrations/versions/8ccb4561f29e_add_summary_nested_nodes_to_structure_.py
+++ b/migrations/versions/8ccb4561f29e_add_summary_nested_nodes_to_structure_.py
@@ -1,0 +1,36 @@
+"""add summary_nested_nodes to structure_snapshots
+
+Revision ID: 8ccb4561f29e
+Revises: e7b30d6e6533
+Create Date: 2026-03-11 14:44:32.342335
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "8ccb4561f29e"
+down_revision: Union[str, Sequence[str], None] = "e7b30d6e6533"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add summary_nested_nodes for recursive context compression."""
+    op.add_column(
+        "structure_snapshots",
+        sa.Column(
+            "summary_nested_nodes",
+            sa.Text(),
+            nullable=True,
+            comment="LLM-generated compressed summary of all nested node snapshots",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove summary_nested_nodes column."""
+    op.drop_column("structure_snapshots", "summary_nested_nodes")

--- a/src/course_supporter/agents/architect.py
+++ b/src/course_supporter/agents/architect.py
@@ -286,6 +286,7 @@ class ArchitectAgent:
             summary=gen_result.structure.summary,
             core_concepts=gen_result.structure.core_concepts,
             mentioned_concepts=gen_result.structure.mentioned_concepts,
+            summary_nested_nodes=gen_result.structure.summary_nested_nodes,
             prompt_version=gen_result.prompt_version,
             response=gen_result.response,
         )

--- a/src/course_supporter/agents/reconciler.py
+++ b/src/course_supporter/agents/reconciler.py
@@ -112,6 +112,7 @@ class ReconcileAgent:
             summary=structure.summary,
             core_concepts=structure.core_concepts,
             mentioned_concepts=structure.mentioned_concepts,
+            summary_nested_nodes=structure.summary_nested_nodes,
             prompt_version=prompt_data.version,
             response=response,
         )

--- a/src/course_supporter/agents/refine.py
+++ b/src/course_supporter/agents/refine.py
@@ -124,6 +124,7 @@ class RefineAgent:
             summary=structure.summary,
             core_concepts=structure.core_concepts,
             mentioned_concepts=structure.mentioned_concepts,
+            summary_nested_nodes=structure.summary_nested_nodes,
             prompt_version=prompt_data.version,
             response=response,
         )

--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -630,6 +630,7 @@ async def _persist_step_result(
         core_concepts=step_output.core_concepts,
         mentioned_concepts=step_output.mentioned_concepts,
         corrections=_serialize_corrections(step_output.corrections),
+        summary_nested_nodes=step_output.summary_nested_nodes or None,
     )
 
     sn_nodes = convert_to_structure_nodes(step_output.structure, snapshot.id)

--- a/src/course_supporter/models/course.py
+++ b/src/course_supporter/models/course.py
@@ -177,6 +177,11 @@ class CourseStructure(BaseModel):
     core_concepts: list[str] = Field(default_factory=list)
     mentioned_concepts: list[str] = Field(default_factory=list)
 
+    # Recursive context compression: condensed summary of all child
+    # node snapshots received during generation. Used by grandparent
+    # nodes to see nested context without full snapshot data.
+    summary_nested_nodes: str = ""
+
     @model_validator(mode="after")
     def _check_concepts_disjoint(self) -> CourseStructure:
         """Ensure core_concepts and mentioned_concepts do not overlap."""

--- a/src/course_supporter/models/step.py
+++ b/src/course_supporter/models/step.py
@@ -13,6 +13,8 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from course_supporter.llm.schemas import LLMResponse
     from course_supporter.models.course import (
         CourseStructure,
@@ -44,6 +46,24 @@ class NodeSummary:
     core_concepts: list[str]
     mentioned_concepts: list[str]
     structure_snapshot_id: uuid.UUID | None
+
+
+@dataclass(frozen=True)
+class ChildSnapshotContext:
+    """Full snapshot of a child node for parent context.
+
+    Provides the complete generated structure from a child node,
+    used by parent nodes instead of raw materials to reduce token count.
+    Includes summary_nested_nodes for recursive compression of deeper levels.
+    """
+
+    node_id: uuid.UUID
+    title: str
+    structure: dict[str, Any]
+    summary: str
+    core_concepts: list[str]
+    mentioned_concepts: list[str]
+    summary_nested_nodes: str
 
 
 class CorrectionAction(StrEnum):
@@ -92,6 +112,9 @@ class StepInput:
     # Generation parameters
     mode: Literal["free", "guided"]
     material_tree: list[MaterialNodeSummary]
+
+    # Full child snapshots for parent context (replaces raw child materials)
+    children_snapshots: list[ChildSnapshotContext] = field(default_factory=list)
     slide_timecode_refs: list[SlideTimecodeRef] = field(default_factory=list)
 
 
@@ -110,6 +133,9 @@ class StepOutput:
     # LLM metadata
     prompt_version: str
     response: LLMResponse
+
+    # Compressed summary of child snapshots for recursive context
+    summary_nested_nodes: str = ""
 
     # Reconciliation-specific (None for generate steps)
     corrections: list[Correction] | None = field(default=None)

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -555,6 +555,11 @@ class StructureSnapshot(Base):
         nullable=True,
         comment="Reconciliation corrections audit trail",
     )
+    summary_nested_nodes: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        comment="LLM-generated compressed summary of all nested node snapshots",
+    )
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/src/course_supporter/storage/snapshot_repository.py
+++ b/src/course_supporter/storage/snapshot_repository.py
@@ -38,6 +38,7 @@ class SnapshotRepository:
         core_concepts: list[str] | None = None,
         mentioned_concepts: list[str] | None = None,
         corrections: list[dict[str, Any]] | dict[str, Any] | None = None,
+        summary_nested_nodes: str | None = None,
     ) -> StructureSnapshot:
         """Create a new snapshot record."""
         snapshot = StructureSnapshot(
@@ -51,6 +52,7 @@ class SnapshotRepository:
             core_concepts=core_concepts,
             mentioned_concepts=mentioned_concepts,
             corrections=corrections,
+            summary_nested_nodes=summary_nested_nodes,
         )
         self._session.add(snapshot)
         await self._session.flush()


### PR DESCRIPTION
- New column in StructureSnapshot ORM + alembic migration
- New field in CourseStructure (LLM output schema)
- New ChildSnapshotContext dataclass in StepInput for parent context
- summary_nested_nodes propagated through StepOutput → snapshot persist
- All three agents (architect, reconciler, refine) updated
- Task spec: current-doc/S3-050-context-compression.md

Part 1 of S3-050: data layer only, no behavior change yet.