### PR TITLE
feat: enrich module-level fields in LLM structured output

### DIFF
--- a/prompts/architect/v1.yaml
+++ b/prompts/architect/v1.yaml
@@ -60,6 +60,26 @@ system_prompt: |
   - **expected_skills**: detailed skill outcomes for this module
   - **difficulty**: relative difficulty compared to other modules in this course
     ("easy", "medium", "hard")
+  - **prerequisites**: list of prerequisites (concepts or skills the student
+    must already know before starting this module). Empty list if first module
+    or no prerequisites.
+  - **estimated_duration**: estimated time in minutes to complete the module
+    (including watching videos, reading materials, doing exercises)
+  - **success_criteria**: 1-2 sentence description of how to verify the student
+    has successfully completed this module
+  - **assessment_method**: primary method for evaluating student progress in
+    this module. One of: "quiz", "project", "code_review", "peer_review",
+    "self_assessment", "exercise"
+  - **competencies**: list of professional competencies the student develops
+    (e.g., "algorithmic thinking", "debugging", "code reading")
+  - **common_mistakes**: list of typical mistakes students make when learning
+    this module's topics (3-5 items, specific and actionable)
+  - **teaching_strategy**: recommended teaching approach for this module.
+    One of: "lecture", "hands_on", "project_based", "flipped", "blended",
+    "discussion"
+  - **activities**: list of concrete learning activities for the student
+    (e.g., "implement a calculator", "solve 5 exercises on loops",
+    "review a peer's code")
   - **lessons**: list of lessons
 
   ### Lesson level

--- a/prompts/architect/v1_guided.yaml
+++ b/prompts/architect/v1_guided.yaml
@@ -68,6 +68,26 @@ system_prompt: |
   - **expected_skills**: detailed skill outcomes for this module
   - **difficulty**: relative difficulty compared to other modules in this course
     ("easy", "medium", "hard")
+  - **prerequisites**: list of prerequisites (concepts or skills the student
+    must already know before starting this module). Empty list if first module
+    or no prerequisites.
+  - **estimated_duration**: estimated time in minutes to complete the module
+    (including watching videos, reading materials, doing exercises)
+  - **success_criteria**: 1-2 sentence description of how to verify the student
+    has successfully completed this module
+  - **assessment_method**: primary method for evaluating student progress in
+    this module. One of: "quiz", "project", "code_review", "peer_review",
+    "self_assessment", "exercise"
+  - **competencies**: list of professional competencies the student develops
+    (e.g., "algorithmic thinking", "debugging", "code reading")
+  - **common_mistakes**: list of typical mistakes students make when learning
+    this module's topics (3-5 items, specific and actionable)
+  - **teaching_strategy**: recommended teaching approach for this module.
+    One of: "lecture", "hands_on", "project_based", "flipped", "blended",
+    "discussion"
+  - **activities**: list of concrete learning activities for the student
+    (e.g., "implement a calculator", "solve 5 exercises on loops",
+    "review a peer's code")
   - **lessons**: list of lessons
 
   ### Lesson level

--- a/src/course_supporter/models/course.py
+++ b/src/course_supporter/models/course.py
@@ -137,6 +137,12 @@ class LessonOutput(BaseModel):
 
 
 ModuleDifficulty = Literal["easy", "medium", "hard"]
+AssessmentMethod = Literal[
+    "quiz", "project", "code_review", "peer_review", "self_assessment", "exercise"
+]
+TeachingStrategy = Literal[
+    "lecture", "hands_on", "project_based", "flipped", "blended", "discussion"
+]
 
 
 class ModuleOutput(BaseModel):
@@ -152,6 +158,14 @@ class ModuleOutput(BaseModel):
     expected_knowledge: list[str] = Field(default_factory=list)
     expected_skills: list[str] = Field(default_factory=list)
     difficulty: ModuleDifficulty = "medium"
+    prerequisites: list[str] = Field(default_factory=list)
+    estimated_duration: int | None = None
+    success_criteria: str = ""
+    assessment_method: AssessmentMethod = "exercise"
+    competencies: list[str] = Field(default_factory=list)
+    common_mistakes: list[str] = Field(default_factory=list)
+    teaching_strategy: TeachingStrategy = "hands_on"
+    activities: list[str] = Field(default_factory=list)
     lessons: list[LessonOutput] = Field(default_factory=list)
 
 

--- a/src/course_supporter/structure_conversion.py
+++ b/src/course_supporter/structure_conversion.py
@@ -49,6 +49,14 @@ def convert_to_structure_nodes(
                     else None
                 ),
                 difficulty=module.difficulty,
+                prerequisites=module.prerequisites or None,
+                estimated_duration=module.estimated_duration,
+                success_criteria=module.success_criteria or None,
+                assessment_method=module.assessment_method,
+                competencies=module.competencies or None,
+                common_mistakes=module.common_mistakes or None,
+                teaching_strategy=module.teaching_strategy,
+                activities=module.activities or None,
             )
         )
 

--- a/tests/unit/test_structure_conversion.py
+++ b/tests/unit/test_structure_conversion.py
@@ -260,3 +260,60 @@ class TestConvertToStructureNodes:
         nodes = convert_to_structure_nodes(structure, snapshot_id)
         assert nodes[0].expected_knowledge is None
         assert nodes[0].expected_skills is None
+
+    def test_module_enriched_fields(self, snapshot_id: uuid.UUID) -> None:
+        """All new module-level fields are mapped to StructureNode."""
+        structure = CourseStructure(
+            title="C",
+            modules=[
+                ModuleOutput(
+                    title="M",
+                    difficulty="hard",
+                    prerequisites=["Variables", "Functions"],
+                    estimated_duration=90,
+                    success_criteria="Student can build a REST API",
+                    assessment_method="project",
+                    competencies=["API design", "debugging"],
+                    common_mistakes=[
+                        "Forgetting to handle errors",
+                        "Not validating input",
+                    ],
+                    teaching_strategy="project_based",
+                    activities=["Build a TODO API", "Review peer code"],
+                ),
+            ],
+        )
+        nodes = convert_to_structure_nodes(structure, snapshot_id)
+        module = nodes[0]
+
+        assert module.difficulty == "hard"
+        assert module.prerequisites == ["Variables", "Functions"]
+        assert module.estimated_duration == 90
+        assert module.success_criteria == "Student can build a REST API"
+        assert module.assessment_method == "project"
+        assert module.competencies == ["API design", "debugging"]
+        assert module.common_mistakes == [
+            "Forgetting to handle errors",
+            "Not validating input",
+        ]
+        assert module.teaching_strategy == "project_based"
+        assert module.activities == ["Build a TODO API", "Review peer code"]
+
+    def test_module_enriched_fields_defaults(self, snapshot_id: uuid.UUID) -> None:
+        """Module with default values maps None for empty lists, defaults for enums."""
+        structure = CourseStructure(
+            title="C",
+            modules=[ModuleOutput(title="M")],
+        )
+        nodes = convert_to_structure_nodes(structure, snapshot_id)
+        module = nodes[0]
+
+        assert module.difficulty == "medium"
+        assert module.prerequisites is None
+        assert module.estimated_duration is None
+        assert module.success_criteria is None
+        assert module.assessment_method == "exercise"
+        assert module.competencies is None
+        assert module.common_mistakes is None
+        assert module.teaching_strategy == "hands_on"
+        assert module.activities is None


### PR DESCRIPTION
Add 8 new fields to ModuleOutput (prerequisites, estimated_duration, success_criteria, assessment_method, competencies, common_mistakes, teaching_strategy, activities) and map them through structure_conversion to StructureNode ORM. Update both prompt templates with field specs.