### PR TITLE
Dev

### DIFF
--- a/prompts/architect/v1.yaml
+++ b/prompts/architect/v1.yaml
@@ -106,6 +106,8 @@ system_prompt: |
   - **web_references**: relevant web URLs with title and description
 
   ### Exercise level
+  - **title**: short, descriptive exercise title (e.g., "Build a Calculator",
+    "Fix the Bug in sort_list")
   - **description**: what the student must do
   - **reference_solution**: model answer or approach (optional)
   - **grading_criteria**: how to evaluate the student's work (optional)

--- a/prompts/architect/v1_guided.yaml
+++ b/prompts/architect/v1_guided.yaml
@@ -114,6 +114,8 @@ system_prompt: |
   - **web_references**: relevant web URLs with title and description
 
   ### Exercise level
+  - **title**: short, descriptive exercise title (e.g., "Build a Calculator",
+    "Fix the Bug in sort_list")
   - **description**: what the student must do
   - **reference_solution**: model answer or approach (optional)
   - **grading_criteria**: how to evaluate the student's work (optional)

--- a/src/course_supporter/models/course.py
+++ b/src/course_supporter/models/course.py
@@ -99,6 +99,7 @@ class ExerciseOutput(BaseModel):
     Maps to ORM Exercise table fields.
     """
 
+    title: str = ""
     description: str
     reference_solution: str | None = None
     grading_criteria: str | None = None

--- a/src/course_supporter/structure_conversion.py
+++ b/src/course_supporter/structure_conversion.py
@@ -118,7 +118,7 @@ def convert_to_structure_nodes(
                         parent_structurenode_id=les_id,
                         node_type=StructureNodeType.EXERCISE,
                         order=ex_idx,
-                        title=f"Exercise {ex_idx + 1}",
+                        title=exercise.title or f"Exercise {ex_idx + 1}",
                         description=exercise.description,
                         difficulty=_map_difficulty_level(exercise.difficulty_level),
                         success_criteria=exercise.grading_criteria,

--- a/tests/unit/test_structure_conversion.py
+++ b/tests/unit/test_structure_conversion.py
@@ -277,6 +277,54 @@ class TestConvertToStructureNodes:
             "Forgetting return statement",
         ]
 
+    def test_exercise_with_title(self, snapshot_id: uuid.UUID) -> None:
+        """Exercise with LLM-generated title uses it instead of fallback."""
+        structure = CourseStructure(
+            title="C",
+            modules=[
+                ModuleOutput(
+                    title="M",
+                    lessons=[
+                        LessonOutput(
+                            title="L",
+                            exercises=[
+                                ExerciseOutput(
+                                    title="Build a Calculator",
+                                    description="Create a CLI calculator",
+                                    difficulty_level=3,
+                                ),
+                            ],
+                        )
+                    ],
+                )
+            ],
+        )
+        nodes = convert_to_structure_nodes(structure, snapshot_id)
+        exercise = next(n for n in nodes if n.node_type == StructureNodeType.EXERCISE)
+        assert exercise.title == "Build a Calculator"
+
+    def test_exercise_without_title_fallback(self, snapshot_id: uuid.UUID) -> None:
+        """Exercise without title falls back to 'Exercise N'."""
+        structure = CourseStructure(
+            title="C",
+            modules=[
+                ModuleOutput(
+                    title="M",
+                    lessons=[
+                        LessonOutput(
+                            title="L",
+                            exercises=[
+                                ExerciseOutput(description="Do something"),
+                            ],
+                        )
+                    ],
+                )
+            ],
+        )
+        nodes = convert_to_structure_nodes(structure, snapshot_id)
+        exercise = next(n for n in nodes if n.node_type == StructureNodeType.EXERCISE)
+        assert exercise.title == "Exercise 1"
+
     def test_unique_ids(self, snapshot_id: uuid.UUID) -> None:
         nodes = convert_to_structure_nodes(_minimal_structure(), snapshot_id)
         ids = [n.id for n in nodes]


### PR DESCRIPTION
feat: enrich StructureNode fields across all hierarchy levels
                                                                                                                        
  Populate previously empty StructureNode fields by extending Pydantic output models, prompt templates, and structure
  conversion mapping for all four hierarchy levels.

  Module level (8 fields):
  - prerequisites, estimated_duration, success_criteria, assessment_method
  - competencies, common_mistakes, teaching_strategy, activities

  Lesson level (3 fields):
  - description, learning_goal, estimated_duration

  Concept level (1 field):
  - common_mistakes — typical student errors per concept

  Exercise level (1 field):
  - title — LLM-generated descriptive name (fallback to "Exercise N")

  Changes:
  - models/course.py — added 13 new fields across ModuleOutput, LessonOutput, ConceptOutput, ExerciseOutput + Literal
  types for assessment_method and teaching_strategy
  - structure_conversion.py — map all new fields from Pydantic models to StructureNode ORM
  - prompts/architect/v1.yaml, v1_guided.yaml — detailed Output Schema descriptions for all new fields
  - tests/unit/test_structure_conversion.py — 12 new tests covering field mapping and defaults