### PR TITLE
fix: refresh ORM objects after commit in editable endpoints to preven…

### DIFF
--- a/src/course_supporter/api/routes/editable.py
+++ b/src/course_supporter/api/routes/editable.py
@@ -137,6 +137,7 @@ async def update_editable_node(
 
     updated = await repo.update_fields(editable_id, fields)
     await session.commit()
+    await session.refresh(updated)
 
     return _orm_to_response(updated)
 
@@ -170,6 +171,9 @@ async def init_editable_tree(
         preserve_edited=body.preserve_edited,
     )
     await session.commit()
+
+    # Re-fetch the tree after commit to avoid MissingGreenlet on expired ORM objects
+    editables = await repo.get_tree(node_id)
 
     source_snapshot_id = editables[0].source_snapshot_id if editables else None
 


### PR DESCRIPTION
Після session.commit() SQLAlchemy expires всі атрибути ORM об'єктів. В PATCH endpoint              
  _orm_to_response(updated) намагався читати expired атрибути, що тригерило lazy load поза async контекстом →           
  MissingGreenlet. Аналогічно в POST /init. Фікс: session.refresh() для одиничного об'єкта, repo.get_tree() для списку.

…t MissingGreenlet

After session.commit(), SQLAlchemy expires all ORM attributes. Accessing them in _orm_to_response triggers lazy loading outside the async context, causing MissingGreenlet errors. Fix by refreshing/re-fetching after commit.