### PR TITLE
HW-007: Webhook delivery — доставка результатів зовнішнім системам

### DIFF
--- a/src/course_supporter/api/routes/homework.py
+++ b/src/course_supporter/api/routes/homework.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from course_supporter.api.deps import get_arq_redis, get_s3_client, get_session
-from course_supporter.api.schemas import HomeworkSubmitResponse
+from course_supporter.api.schemas import HomeworkSubmitResponse, TenantWebhookResponse
 from course_supporter.api.upload_validation import file_extension
 from course_supporter.api.url_validation import validate_webhook_url
 from course_supporter.auth.context import TenantContext
@@ -41,6 +41,7 @@ router = APIRouter(tags=["homework"])
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
 S3Dep = Annotated[S3Client, Depends(get_s3_client)]
 CheckDep = Annotated[TenantContext, Depends(require_scope(AuthScope.CHECK))]
+PrepDep = Annotated[TenantContext, Depends(require_scope(AuthScope.PREP))]
 ArqDep = Annotated[ArqRedis, Depends(get_arq_redis)]
 
 # 10 MB max file size
@@ -289,3 +290,48 @@ async def submit_homework(
         status="received",
         job_id=job.id,
     )
+
+
+@router.patch(
+    "/tenant/webhook",
+    response_model=TenantWebhookResponse,
+    summary="Set or clear the tenant default webhook URL",
+)
+async def update_tenant_webhook(
+    tenant: PrepDep,
+    session: SessionDep,
+    webhook_url: Annotated[
+        str | None,
+        Form(description="Default webhook URL, or empty/null to clear."),
+    ] = None,
+) -> TenantWebhookResponse:
+    """Update the default webhook URL for the authenticated tenant.
+
+    This URL is used as fallback when a homework submission does not
+    specify its own ``webhook_url``.  Send empty string or omit the
+    field to clear the default.
+    """
+    from course_supporter.storage.orm import Tenant as TenantModel
+
+    # Validate non-empty URL against SSRF
+    if webhook_url:
+        webhook_url = await validate_webhook_url(webhook_url)
+    else:
+        webhook_url = None
+
+    from sqlalchemy import update as sa_update
+
+    await session.execute(
+        sa_update(TenantModel)
+        .where(TenantModel.id == tenant.tenant_id)
+        .values(webhook_url=webhook_url)
+    )
+    await session.commit()
+
+    logger.info(
+        "tenant_webhook_updated",
+        tenant_id=str(tenant.tenant_id),
+        webhook_url=webhook_url,
+    )
+
+    return TenantWebhookResponse(webhook_url=webhook_url)

--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -562,6 +562,14 @@ class HomeworkSubmitResponse(BaseModel):
     )
 
 
+class TenantWebhookResponse(BaseModel):
+    """Response for PATCH /tenant/webhook."""
+
+    webhook_url: str | None = Field(
+        description="Current default webhook URL for the tenant. None if cleared.",
+    )
+
+
 # --- Jobs ---
 
 

--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -1306,6 +1306,12 @@ async def arq_process_homework(
         submission_id: HomeworkSubmission UUID as string.
     """
     from course_supporter.homework.matcher import TaskMatcher, TaskMatchError
+    from course_supporter.homework.webhook import (
+        build_matched_payload,
+        build_reviewed_payload,
+        deliver_webhook,
+        resolve_webhook_url,
+    )
     from course_supporter.models.safety import CourseContext
     from course_supporter.safety.archive import extract_submission_content
     from course_supporter.safety.checker import SafetyChecker
@@ -1319,6 +1325,7 @@ async def arq_process_homework(
     from course_supporter.storage.material_node_repository import (
         MaterialNodeRepository,
     )
+    from course_supporter.storage.student_repository import StudentRepository
 
     jid = uuid.UUID(job_id)
     sid = uuid.UUID(submission_id)
@@ -1343,6 +1350,13 @@ async def arq_process_homework(
             if submission is None:
                 msg = f"HomeworkSubmission {sid} not found"
                 raise ValueError(msg)
+
+            # Load related entities for webhook delivery
+            from course_supporter.storage.orm import Tenant
+
+            student_repo = StudentRepository(session)
+            student = await student_repo.get_by_id(submission.student_id)
+            tenant = await session.get(Tenant, submission.tenant_id)
 
             # Enrich logger with tenant/student context
             log = log.bind(
@@ -1480,6 +1494,24 @@ async def arq_process_homework(
                     matches_count=len(match_result.matches),
                 )
 
+                # --- HW-007a: Webhook — matched notification ---
+                webhook_url = resolve_webhook_url(submission, tenant)
+                if webhook_url and student:
+                    matched_payload = build_matched_payload(
+                        submission,
+                        student,
+                        matched_task_id=match_result.primary_task_id,
+                        matched_task_title=match_result.matches[0].task_title,
+                        matched_task_type=match_result.matches[0].task_type,
+                    )
+                    await deliver_webhook(
+                        url=webhook_url,
+                        payload=matched_payload,
+                        tenant_id=submission.tenant_id,
+                        session=session,
+                    )
+                    await session.commit()
+
                 # --- HW-006: Mentor review ---
                 await hw_repo.update_status(sid, "reviewing")
                 await session.commit()
@@ -1533,9 +1565,27 @@ async def arq_process_homework(
                     notable=len(review.analysis.notable_solutions),
                 )
 
-                # TODO(HW-007): Webhook delivery
-
+                # --- HW-007b: Webhook — reviewed notification ---
                 await hw_repo.update_status(sid, "completed")
+                await session.commit()
+
+                webhook_url = resolve_webhook_url(submission, tenant)
+                if webhook_url and student:
+                    # Refresh submission to pick up stored review data
+                    await session.refresh(submission)
+                    reviewed_payload = build_reviewed_payload(
+                        submission,
+                        student,
+                    )
+                    delivered = await deliver_webhook(
+                        url=webhook_url,
+                        payload=reviewed_payload,
+                        tenant_id=submission.tenant_id,
+                        session=session,
+                    )
+                    if delivered:
+                        await hw_repo.update_status(sid, "delivered")
+
                 await job_repo.update_status(jid, "complete")
                 await session.commit()
                 log.info("homework_processing_done")

--- a/src/course_supporter/config.py
+++ b/src/course_supporter/config.py
@@ -86,6 +86,10 @@ class Settings(BaseSettings):
     worker_heavy_window_tz: str = "UTC"
     worker_immediate_override: bool = True
 
+    # --- Webhook delivery ---
+    webhook_timeout_seconds: int = 30
+    webhook_max_retries: int = 3
+
     @field_validator("worker_heavy_window_tz")
     @classmethod
     def _validate_timezone(cls, v: str) -> str:

--- a/src/course_supporter/homework/webhook.py
+++ b/src/course_supporter/homework/webhook.py
@@ -1,0 +1,229 @@
+"""Webhook delivery for the homework pipeline.
+
+Delivers two event types to external systems:
+- matched: after task matching (tells which task was identified)
+- reviewed: after Mentor review (delivers score and feedback)
+
+Retry strategy: inline exponential backoff, non-blocking on failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+import structlog
+
+from course_supporter.api.url_validation import validate_webhook_url
+from course_supporter.config import get_settings
+from course_supporter.models.webhook import (
+    MatchedTaskInfo,
+    ReviewSummary,
+    WebhookMatchedPayload,
+    WebhookReviewedPayload,
+)
+from course_supporter.storage.orm import ExternalServiceCall
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from course_supporter.storage.orm import HomeworkSubmission, Student, Tenant
+
+logger = structlog.get_logger()
+
+
+def resolve_webhook_url(
+    submission: HomeworkSubmission,
+    tenant: Tenant | None,
+) -> str | None:
+    """Return the webhook URL for this submission (per-submission or tenant default)."""
+    return submission.webhook_url or (tenant.webhook_url if tenant else None)
+
+
+def build_matched_payload(
+    submission: HomeworkSubmission,
+    student: Student,
+    matched_task_id: uuid.UUID,
+    matched_task_title: str,
+    matched_task_type: str,
+) -> WebhookMatchedPayload:
+    """Build the 'matched' webhook payload from pipeline state."""
+    return WebhookMatchedPayload(
+        submission_id=str(submission.id),
+        student_external_id=student.external_id,
+        matched_task=MatchedTaskInfo(
+            id=str(matched_task_id),
+            title=matched_task_title,
+            node_type=matched_task_type,
+        ),
+        timestamp=datetime.now(UTC),
+    )
+
+
+def build_reviewed_payload(
+    submission: HomeworkSubmission,
+    student: Student,
+) -> WebhookReviewedPayload:
+    """Build the 'reviewed' webhook payload from stored review result."""
+    review_result = submission.review_result or {}
+    analysis = review_result.get("analysis", {})
+
+    return WebhookReviewedPayload(
+        submission_id=str(submission.id),
+        student_external_id=student.external_id,
+        review=ReviewSummary(
+            passed=analysis.get("passed", False),
+            score=analysis.get("score", 0),
+            correctness=analysis.get("correctness", "incorrect"),
+            review_text=submission.review_markdown or "",
+            response_language=submission.response_language or "en",
+        ),
+        timestamp=datetime.now(UTC),
+    )
+
+
+async def deliver_webhook(
+    *,
+    url: str,
+    payload: WebhookMatchedPayload | WebhookReviewedPayload,
+    tenant_id: uuid.UUID,
+    session: AsyncSession,
+) -> bool:
+    """Deliver a webhook payload with retry and audit logging.
+
+    Args:
+        url: Target webhook URL.
+        payload: Pydantic model to POST as JSON.
+        tenant_id: For audit trail.
+        session: DB session for ExternalServiceCall record.
+
+    Returns:
+        True if delivery succeeded (2xx), False otherwise.
+    """
+    settings = get_settings()
+    log = logger.bind(
+        webhook_url=url,
+        event=payload.event,
+        submission_id=payload.submission_id,
+    )
+
+    # SSRF re-validation (tenant default URL bypasses API validation)
+    try:
+        await validate_webhook_url(url)
+    except Exception:
+        log.warning("webhook_ssrf_blocked")
+        _record_attempt(
+            session,
+            tenant_id=tenant_id,
+            event=payload.event,
+            latency_ms=0,
+            success=False,
+            error="SSRF validation failed",
+        )
+        return False
+
+    start = time.monotonic()
+    last_error: str = ""
+
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(float(settings.webhook_timeout_seconds)),
+    ) as client:
+        for attempt in range(settings.webhook_max_retries):
+            try:
+                response = await client.post(
+                    url,
+                    json=payload.model_dump(mode="json"),
+                    headers={"Content-Type": "application/json"},
+                )
+
+                if response.is_success:
+                    latency_ms = int((time.monotonic() - start) * 1000)
+                    log.info(
+                        "webhook_delivered",
+                        status_code=response.status_code,
+                        attempt=attempt + 1,
+                        latency_ms=latency_ms,
+                    )
+                    _record_attempt(
+                        session,
+                        tenant_id=tenant_id,
+                        event=payload.event,
+                        latency_ms=latency_ms,
+                        success=True,
+                    )
+                    return True
+
+                # 4xx (except 429) = permanent failure, no retry
+                if 400 <= response.status_code < 500 and response.status_code != 429:
+                    last_error = f"HTTP {response.status_code}"
+                    log.warning(
+                        "webhook_permanent_failure",
+                        status_code=response.status_code,
+                        attempt=attempt + 1,
+                    )
+                    break
+
+                # 429 / 5xx = transient, retry
+                last_error = f"HTTP {response.status_code}"
+                log.warning(
+                    "webhook_transient_failure",
+                    status_code=response.status_code,
+                    attempt=attempt + 1,
+                )
+
+            except httpx.HTTPError as exc:
+                last_error = f"{type(exc).__name__}: {exc}"
+                log.warning(
+                    "webhook_network_error",
+                    error=last_error,
+                    attempt=attempt + 1,
+                )
+
+            # Exponential backoff before next attempt
+            if attempt < settings.webhook_max_retries - 1:
+                delay = 2**attempt  # 1s, 2s, 4s
+                await asyncio.sleep(delay)
+
+    latency_ms = int((time.monotonic() - start) * 1000)
+    log.error(
+        "webhook_delivery_failed",
+        last_error=last_error,
+        latency_ms=latency_ms,
+    )
+    _record_attempt(
+        session,
+        tenant_id=tenant_id,
+        event=payload.event,
+        latency_ms=latency_ms,
+        success=False,
+        error=last_error,
+    )
+    return False
+
+
+def _record_attempt(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    event: str,
+    latency_ms: int,
+    success: bool,
+    error: str | None = None,
+) -> None:
+    """Create an ExternalServiceCall audit record for a webhook attempt."""
+    session.add(
+        ExternalServiceCall(
+            tenant_id=tenant_id,
+            action=f"webhook_{event}",
+            strategy="exponential_backoff",
+            provider="httpx",
+            model_id="webhook_post",
+            latency_ms=latency_ms,
+            success=success,
+            error_message=error,
+        )
+    )

--- a/src/course_supporter/models/webhook.py
+++ b/src/course_supporter/models/webhook.py
@@ -1,0 +1,51 @@
+"""Pydantic schemas for webhook delivery payloads.
+
+Two event types:
+- matched: after task matching, tells the external system which task.
+- reviewed: sent after Mentor review, delivers the final score and feedback.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class MatchedTaskInfo(BaseModel):
+    """Compact task descriptor included in the 'matched' webhook."""
+
+    id: str = Field(description="StructureNodeEditable UUID.")
+    title: str
+    node_type: str = Field(description="exercise, concept, lesson, etc.")
+
+
+class ReviewSummary(BaseModel):
+    """Key review fields included in the 'reviewed' webhook."""
+
+    passed: bool
+    score: int = Field(ge=0, le=100)
+    correctness: Literal["correct", "partially_correct", "incorrect"]
+    review_text: str = Field(description="Markdown review in mentor style.")
+    response_language: str = Field(description="ISO 639-1 code.")
+
+
+class WebhookMatchedPayload(BaseModel):
+    """Payload sent when a submission is matched to a course task."""
+
+    event: Literal["matched"] = "matched"
+    submission_id: str
+    student_external_id: str
+    matched_task: MatchedTaskInfo
+    timestamp: datetime
+
+
+class WebhookReviewedPayload(BaseModel):
+    """Payload sent when a submission review is complete."""
+
+    event: Literal["reviewed"] = "reviewed"
+    submission_id: str
+    student_external_id: str
+    review: ReviewSummary
+    timestamp: datetime

--- a/tests/unit/test_webhook_delivery.py
+++ b/tests/unit/test_webhook_delivery.py
@@ -1,0 +1,376 @@
+"""Tests for webhook delivery module."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from course_supporter.homework.webhook import (
+    build_matched_payload,
+    build_reviewed_payload,
+    deliver_webhook,
+    resolve_webhook_url,
+)
+from course_supporter.models.webhook import (
+    WebhookMatchedPayload,
+    WebhookReviewedPayload,
+)
+
+# --- Helpers ---
+
+
+def _make_submission(
+    *,
+    webhook_url: str | None = "https://example.com/hook",
+    review_result: dict | None = None,
+    review_markdown: str | None = None,
+    response_language: str | None = "uk",
+) -> MagicMock:
+    sub = MagicMock()
+    sub.id = uuid.uuid4()
+    sub.tenant_id = uuid.uuid4()
+    sub.student_id = uuid.uuid4()
+    sub.webhook_url = webhook_url
+    sub.review_result = review_result
+    sub.review_markdown = review_markdown
+    sub.response_language = response_language
+    return sub
+
+
+def _make_student(external_id: str = "student-42") -> MagicMock:
+    s = MagicMock()
+    s.external_id = external_id
+    return s
+
+
+def _make_tenant(webhook_url: str | None = None) -> MagicMock:
+    t = MagicMock()
+    t.webhook_url = webhook_url
+    return t
+
+
+def _sample_review_result() -> dict:
+    return {
+        "analysis": {
+            "passed": True,
+            "score": 85,
+            "correctness": "correct",
+        },
+    }
+
+
+# --- resolve_webhook_url ---
+
+
+class TestResolveWebhookUrl:
+    def test_submission_url_takes_priority(self) -> None:
+        sub = _make_submission(webhook_url="https://sub.example.com")
+        tenant = _make_tenant(webhook_url="https://tenant.example.com")
+        assert resolve_webhook_url(sub, tenant) == "https://sub.example.com"
+
+    def test_falls_back_to_tenant(self) -> None:
+        sub = _make_submission(webhook_url=None)
+        tenant = _make_tenant(webhook_url="https://tenant.example.com")
+        assert resolve_webhook_url(sub, tenant) == "https://tenant.example.com"
+
+    def test_none_when_no_url(self) -> None:
+        sub = _make_submission(webhook_url=None)
+        tenant = _make_tenant(webhook_url=None)
+        assert resolve_webhook_url(sub, tenant) is None
+
+    def test_none_when_no_tenant(self) -> None:
+        sub = _make_submission(webhook_url=None)
+        assert resolve_webhook_url(sub, None) is None
+
+
+# --- Payload builders ---
+
+
+class TestBuildMatchedPayload:
+    def test_builds_correct_payload(self) -> None:
+        sub = _make_submission()
+        student = _make_student("ext-123")
+        task_id = uuid.uuid4()
+
+        payload = build_matched_payload(
+            sub,
+            student,
+            matched_task_id=task_id,
+            matched_task_title="Loop exercise",
+            matched_task_type="exercise",
+        )
+
+        assert payload.event == "matched"
+        assert payload.submission_id == str(sub.id)
+        assert payload.student_external_id == "ext-123"
+        assert payload.matched_task.id == str(task_id)
+        assert payload.matched_task.title == "Loop exercise"
+        assert payload.matched_task.node_type == "exercise"
+        assert isinstance(payload.timestamp, datetime)
+
+
+class TestBuildReviewedPayload:
+    def test_builds_from_review_result(self) -> None:
+        sub = _make_submission(
+            review_result=_sample_review_result(),
+            review_markdown="Рішення правильне.",
+            response_language="uk",
+        )
+        student = _make_student()
+
+        payload = build_reviewed_payload(sub, student)
+
+        assert payload.event == "reviewed"
+        assert payload.review.passed is True
+        assert payload.review.score == 85
+        assert payload.review.correctness == "correct"
+        assert payload.review.review_text == "Рішення правильне."
+        assert payload.review.response_language == "uk"
+
+    def test_defaults_for_missing_review(self) -> None:
+        sub = _make_submission(
+            review_result=None,
+            review_markdown=None,
+            response_language=None,
+        )
+        student = _make_student()
+
+        payload = build_reviewed_payload(sub, student)
+
+        assert payload.review.passed is False
+        assert payload.review.score == 0
+        assert payload.review.review_text == ""
+        assert payload.review.response_language == "en"
+
+
+# --- deliver_webhook ---
+
+
+class TestDeliverWebhook:
+    """Webhook delivery with mocked httpx and SSRF validation."""
+
+    @pytest.fixture()
+    def mock_session(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.fixture()
+    def payload(self) -> WebhookMatchedPayload:
+        return WebhookMatchedPayload(
+            submission_id="sub-1",
+            student_external_id="stu-1",
+            matched_task={"id": "task-1", "title": "Test", "node_type": "exercise"},
+            timestamp=datetime.now(UTC),
+        )
+
+    @patch(
+        "course_supporter.homework.webhook.validate_webhook_url", new_callable=AsyncMock
+    )
+    @patch("course_supporter.homework.webhook.httpx.AsyncClient")
+    async def test_successful_delivery(
+        self,
+        mock_client_cls: MagicMock,
+        mock_validate: AsyncMock,
+        mock_session: MagicMock,
+        payload: WebhookMatchedPayload,
+    ) -> None:
+        mock_validate.return_value = "https://example.com/hook"
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.status_code = 200
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await deliver_webhook(
+            url="https://example.com/hook",
+            payload=payload,
+            tenant_id=uuid.uuid4(),
+            session=mock_session,
+        )
+
+        assert result is True
+        mock_client.post.assert_awaited_once()
+        mock_session.add.assert_called_once()
+        esc = mock_session.add.call_args[0][0]
+        assert esc.success is True
+        assert esc.action == "webhook_matched"
+
+    @patch(
+        "course_supporter.homework.webhook.validate_webhook_url", new_callable=AsyncMock
+    )
+    async def test_ssrf_blocked(
+        self,
+        mock_validate: AsyncMock,
+        mock_session: MagicMock,
+        payload: WebhookMatchedPayload,
+    ) -> None:
+        from fastapi import HTTPException
+
+        mock_validate.side_effect = HTTPException(status_code=422, detail="blocked")
+
+        result = await deliver_webhook(
+            url="http://169.254.169.254/metadata",
+            payload=payload,
+            tenant_id=uuid.uuid4(),
+            session=mock_session,
+        )
+
+        assert result is False
+        mock_session.add.assert_called_once()
+        esc = mock_session.add.call_args[0][0]
+        assert esc.success is False
+
+    @patch(
+        "course_supporter.homework.webhook.validate_webhook_url", new_callable=AsyncMock
+    )
+    @patch("course_supporter.homework.webhook.httpx.AsyncClient")
+    @patch("course_supporter.homework.webhook.asyncio.sleep", new_callable=AsyncMock)
+    async def test_retries_on_server_error(
+        self,
+        mock_sleep: AsyncMock,
+        mock_client_cls: MagicMock,
+        mock_validate: AsyncMock,
+        mock_session: MagicMock,
+        payload: WebhookMatchedPayload,
+    ) -> None:
+        mock_validate.return_value = "https://example.com/hook"
+
+        error_response = MagicMock()
+        error_response.is_success = False
+        error_response.status_code = 500
+
+        success_response = MagicMock()
+        success_response.is_success = True
+        success_response.status_code = 200
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=[error_response, success_response],
+        )
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await deliver_webhook(
+            url="https://example.com/hook",
+            payload=payload,
+            tenant_id=uuid.uuid4(),
+            session=mock_session,
+        )
+
+        assert result is True
+        assert mock_client.post.await_count == 2
+        mock_sleep.assert_awaited_once_with(1)  # 2^0 = 1s backoff
+
+    @patch(
+        "course_supporter.homework.webhook.validate_webhook_url", new_callable=AsyncMock
+    )
+    @patch("course_supporter.homework.webhook.httpx.AsyncClient")
+    async def test_no_retry_on_4xx(
+        self,
+        mock_client_cls: MagicMock,
+        mock_validate: AsyncMock,
+        mock_session: MagicMock,
+        payload: WebhookMatchedPayload,
+    ) -> None:
+        mock_validate.return_value = "https://example.com/hook"
+
+        error_response = MagicMock()
+        error_response.is_success = False
+        error_response.status_code = 404
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=error_response)
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await deliver_webhook(
+            url="https://example.com/hook",
+            payload=payload,
+            tenant_id=uuid.uuid4(),
+            session=mock_session,
+        )
+
+        assert result is False
+        assert mock_client.post.await_count == 1  # no retry
+
+    @patch(
+        "course_supporter.homework.webhook.validate_webhook_url", new_callable=AsyncMock
+    )
+    @patch("course_supporter.homework.webhook.httpx.AsyncClient")
+    @patch("course_supporter.homework.webhook.asyncio.sleep", new_callable=AsyncMock)
+    async def test_network_error_retries(
+        self,
+        mock_sleep: AsyncMock,
+        mock_client_cls: MagicMock,
+        mock_validate: AsyncMock,
+        mock_session: MagicMock,
+        payload: WebhookMatchedPayload,
+    ) -> None:
+        mock_validate.return_value = "https://example.com/hook"
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused"),
+        )
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await deliver_webhook(
+            url="https://example.com/hook",
+            payload=payload,
+            tenant_id=uuid.uuid4(),
+            session=mock_session,
+        )
+
+        assert result is False
+        assert mock_client.post.await_count == 3  # all retries exhausted
+
+    @patch(
+        "course_supporter.homework.webhook.validate_webhook_url", new_callable=AsyncMock
+    )
+    @patch("course_supporter.homework.webhook.httpx.AsyncClient")
+    async def test_reviewed_payload_delivery(
+        self,
+        mock_client_cls: MagicMock,
+        mock_validate: AsyncMock,
+        mock_session: MagicMock,
+    ) -> None:
+        mock_validate.return_value = "https://example.com/hook"
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.status_code = 200
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        reviewed_payload = WebhookReviewedPayload(
+            submission_id="sub-1",
+            student_external_id="stu-1",
+            review={
+                "passed": True,
+                "score": 90,
+                "correctness": "correct",
+                "review_text": "Good job.",
+                "response_language": "en",
+            },
+            timestamp=datetime.now(UTC),
+        )
+
+        result = await deliver_webhook(
+            url="https://example.com/hook",
+            payload=reviewed_payload,
+            tenant_id=uuid.uuid4(),
+            session=mock_session,
+        )
+
+        assert result is True
+        esc = mock_session.add.call_args[0][0]
+        assert esc.action == "webhook_reviewed"


### PR DESCRIPTION
Зміни

  Webhook events

  Два типи нотифікацій, що доставляються на webhook_url зовнішньої системи:

  - matched — після task matching. Payload: submission_id, student_external_id, matched task (id, title, type). Дозволяє зовнішній системі
  показати студенту "роботу прийнято, визначено завдання X".
  - reviewed — після Mentor review. Payload: submission_id, student_external_id, review (passed, score, correctness, review_text,
  response_language). Фінальний результат рев'ю.

  Delivery та retry

  - HTTP POST через httpx.AsyncClient з configurable timeout (default 30s)
  - Exponential backoff: до 3 спроб (1s, 2s, 4s між ними)
  - 2xx = успіх, 4xx (крім 429) = permanent failure (без retry), 429/5xx = transient (retry)
  - Network errors (timeout, connection refused) — retry
  - Webhook failure не ламає pipeline — submission залишається в статусі completed

  SSRF захист

  - Re-validation URL при доставці через існуючий validate_webhook_url() — бо tenant default URL не проходить API validation при submit
  - Блокування приватних IP, localhost, metadata endpoints

  Audit trail

  - ExternalServiceCall запис для кожної спроби доставки (action=webhook_matched/webhook_reviewed, latency_ms, success, error_message)

  Status lifecycle

  - Успішна доставка reviewed → статус completed → delivered, встановлюється webhook_delivered_at
  - Невдала доставка → статус залишається completed, помилка логується
  - Відсутній webhook_url → тихий skip

  Pipeline (повний)

  POST /homework/submit → 202
    → Safety check (regex → LLM)
    → Task matching (LLM)
    → Webhook #1: matched ← NEW
    → Mentor review (analysis → humanize)
    → Webhook #2: reviewed ← NEW
    → Status: delivered

  Конфігурація

  - WEBHOOK_TIMEOUT_SECONDS (default 30)
  - WEBHOOK_MAX_RETRIES (default 3)

  Тести

  +13 нових тестів (1798 total): resolve URL fallback, payload builders, successful delivery, SSRF block, retry on 5xx, no retry on 4xx, network
  error retry, reviewed payload.
