### PR TITLE
Уніфікований трекінг витрат: VD через ModelRouter + tenant attribution

### DIFF
--- a/config/external_services.yaml
+++ b/config/external_services.yaml
@@ -228,3 +228,14 @@ actions:
     requires: [vision]
     chain:
       default: [gemini-2.5-flash, gpt-4o-mini]
+
+  vd_frame_analysis:
+    strategy: default
+    requires: [vision]
+    chain:
+      default: [gemini-2.5-flash, gemini-2.5-pro]
+
+  vd_memory:
+    strategy: default
+    chain:
+      default: [gemini-2.5-flash, gemini-2.5-pro]

--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -22,6 +22,7 @@ from course_supporter.ingestion.factory import (
 )
 from course_supporter.models.source import SourceType
 from course_supporter.models.step import ChildSnapshotContext, NodeSummary
+from course_supporter.service_logging import set_tenant_from_job
 from course_supporter.storage.editable_repository import EditableRepository
 from course_supporter.storage.snapshot_repository import SnapshotRepository
 
@@ -142,7 +143,7 @@ async def arq_ingest_material(
         job_id=job_id, material_id=material_id, source_type=source_type
     )
 
-    await _set_tenant_from_job(session_factory, jid)
+    await set_tenant_from_job(session_factory, jid)
     log.info("ingestion_started")
 
     heavy = create_heavy_steps(router=router)
@@ -197,33 +198,6 @@ async def arq_ingest_material(
         content_json=content,
     )
     log.info("ingestion_done")
-
-
-async def _set_tenant_from_job(
-    session_factory: async_sessionmaker[AsyncSession],
-    job_id: uuid.UUID,
-) -> None:
-    """Look up tenant_id from Job and set it in contextvar for cost logging.
-
-    Best-effort: DB/network failures are logged but never propagate.
-    """
-    from sqlalchemy.exc import SQLAlchemyError
-
-    from course_supporter.service_logging import _current_tenant_id
-    from course_supporter.storage.job_repository import JobRepository
-
-    try:
-        async with session_factory() as session:
-            job = await JobRepository(session).get_by_id(job_id)
-            if job and job.tenant_id:
-                _current_tenant_id.set(job.tenant_id)
-    except (SQLAlchemyError, OSError, TypeError) as exc:
-        structlog.get_logger().warning(
-            "tenant_lookup_failed",
-            job_id=str(job_id),
-            error=str(exc),
-            exc_info=True,
-        )
 
 
 def _resolve_target_nodes(
@@ -382,7 +356,7 @@ async def arq_generate_structure(
     )
     log.info("generate_structure_started")
 
-    await _set_tenant_from_job(session_factory, jid)
+    await set_tenant_from_job(session_factory, jid)
 
     async with session_factory() as session:
         job_repo = JobRepository(session)
@@ -861,7 +835,7 @@ async def arq_execute_step(
         mode=mode,
         step_type=step_type,
     )
-    await _set_tenant_from_job(session_factory, jid)
+    await set_tenant_from_job(session_factory, jid)
     log.info("execute_step_started")
 
     async with session_factory() as session:
@@ -1023,7 +997,7 @@ async def arq_reconcile_preview(
     router: ModelRouter = ctx["model_router"]
 
     log = structlog.get_logger().bind(job_id=job_id, node_id=node_id)
-    await _set_tenant_from_job(session_factory, jid)
+    await set_tenant_from_job(session_factory, jid)
     log.info("reconcile_preview_started")
 
     async with session_factory() as session:
@@ -1146,7 +1120,7 @@ async def arq_execute_methodist_step(
         editable_id=editable_id,
         phase=phase,
     )
-    await _set_tenant_from_job(session_factory, jid)
+    await set_tenant_from_job(session_factory, jid)
     log.info("methodist_step_started")
 
     async with session_factory() as session:
@@ -1378,7 +1352,7 @@ async def arq_process_homework(
         job_id=job_id,
         submission_id=submission_id,
     )
-    await _set_tenant_from_job(session_factory, jid)
+    await set_tenant_from_job(session_factory, jid)
     log.info("homework_processing_started")
 
     async with session_factory() as session:

--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -141,10 +141,12 @@ async def arq_ingest_material(
     log = structlog.get_logger().bind(
         job_id=job_id, material_id=material_id, source_type=source_type
     )
+
+    await _set_tenant_from_job(session_factory, jid)
     log.info("ingestion_started")
 
     heavy = create_heavy_steps(router=router)
-    vd = create_vd_pipeline()
+    vd = create_vd_pipeline(router=router)
 
     from course_supporter.config import get_settings
     from course_supporter.stt.setup import create_stt_router
@@ -195,6 +197,23 @@ async def arq_ingest_material(
         content_json=content,
     )
     log.info("ingestion_done")
+
+
+async def _set_tenant_from_job(
+    session_factory: async_sessionmaker[AsyncSession],
+    job_id: uuid.UUID,
+) -> None:
+    """Look up tenant_id from Job and set it in contextvar for cost logging."""
+    from course_supporter.service_logging import _current_tenant_id
+    from course_supporter.storage.job_repository import JobRepository
+
+    try:
+        async with session_factory() as session:
+            job = await JobRepository(session).get_by_id(job_id)
+            if job and job.tenant_id:
+                _current_tenant_id.set(job.tenant_id)
+    except Exception:
+        structlog.get_logger().debug("tenant_lookup_skipped", job_id=str(job_id))
 
 
 def _resolve_target_nodes(
@@ -353,6 +372,8 @@ async def arq_generate_structure(
     )
     log.info("generate_structure_started")
 
+    await _set_tenant_from_job(session_factory, jid)
+
     async with session_factory() as session:
         job_repo = JobRepository(session)
         try:
@@ -423,7 +444,10 @@ async def arq_generate_structure(
             )
 
             # Persist LLM metadata as ExternalServiceCall
+            from course_supporter.service_logging import get_current_tenant_id
+
             esc = ExternalServiceCall(
+                tenant_id=get_current_tenant_id(),
                 action="course_structuring",
                 strategy=mode,
                 provider=gen_result.response.provider,
@@ -728,6 +752,7 @@ async def _persist_step_result(
     Returns:
         Created snapshot ID.
     """
+    from course_supporter.service_logging import get_current_tenant_id
     from course_supporter.storage.orm import ExternalServiceCall
     from course_supporter.storage.structure_node_repository import (
         StructureNodeRepository,
@@ -735,6 +760,7 @@ async def _persist_step_result(
     from course_supporter.structure_conversion import convert_to_structure_nodes
 
     esc = ExternalServiceCall(
+        tenant_id=get_current_tenant_id(),
         action="course_structuring",
         strategy=mode,
         provider=step_output.response.provider,
@@ -825,6 +851,7 @@ async def arq_execute_step(
         mode=mode,
         step_type=step_type,
     )
+    await _set_tenant_from_job(session_factory, jid)
     log.info("execute_step_started")
 
     async with session_factory() as session:
@@ -986,6 +1013,7 @@ async def arq_reconcile_preview(
     router: ModelRouter = ctx["model_router"]
 
     log = structlog.get_logger().bind(job_id=job_id, node_id=node_id)
+    await _set_tenant_from_job(session_factory, jid)
     log.info("reconcile_preview_started")
 
     async with session_factory() as session:
@@ -1108,6 +1136,7 @@ async def arq_execute_methodist_step(
         editable_id=editable_id,
         phase=phase,
     )
+    await _set_tenant_from_job(session_factory, jid)
     log.info("methodist_step_started")
 
     async with session_factory() as session:
@@ -1238,10 +1267,11 @@ async def arq_execute_methodist_step(
             )
 
             # 7. Persist output on editable node
+            from course_supporter.service_logging import get_current_tenant_id
             from course_supporter.storage.orm import ExternalServiceCall
 
             esc = ExternalServiceCall(
-                tenant_id=mat_node.tenant_id if mat_node else None,
+                tenant_id=get_current_tenant_id(),
                 job_id=jid,
                 action="methodist",
                 strategy="default",
@@ -1338,6 +1368,7 @@ async def arq_process_homework(
         job_id=job_id,
         submission_id=submission_id,
     )
+    await _set_tenant_from_job(session_factory, jid)
     log.info("homework_processing_started")
 
     async with session_factory() as session:

--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -203,7 +203,12 @@ async def _set_tenant_from_job(
     session_factory: async_sessionmaker[AsyncSession],
     job_id: uuid.UUID,
 ) -> None:
-    """Look up tenant_id from Job and set it in contextvar for cost logging."""
+    """Look up tenant_id from Job and set it in contextvar for cost logging.
+
+    Best-effort: DB/network failures are logged but never propagate.
+    """
+    from sqlalchemy.exc import SQLAlchemyError
+
     from course_supporter.service_logging import _current_tenant_id
     from course_supporter.storage.job_repository import JobRepository
 
@@ -212,8 +217,13 @@ async def _set_tenant_from_job(
             job = await JobRepository(session).get_by_id(job_id)
             if job and job.tenant_id:
                 _current_tenant_id.set(job.tenant_id)
-    except Exception:
-        structlog.get_logger().debug("tenant_lookup_skipped", job_id=str(job_id))
+    except (SQLAlchemyError, OSError, TypeError) as exc:
+        structlog.get_logger().warning(
+            "tenant_lookup_failed",
+            job_id=str(job_id),
+            error=str(exc),
+            exc_info=True,
+        )
 
 
 def _resolve_target_nodes(

--- a/src/course_supporter/ingestion/factory.py
+++ b/src/course_supporter/ingestion/factory.py
@@ -11,6 +11,8 @@ import functools
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import structlog
+
 from course_supporter.ingestion.heavy_steps import (
     DescribeSlidesFunc,
     ParsePDFFunc,
@@ -29,6 +31,8 @@ if TYPE_CHECKING:
     from course_supporter.llm.router import ModelRouter
     from course_supporter.stt.router import STTRouter
     from course_supporter.vd.pipeline import VDPipeline
+
+logger = structlog.get_logger()
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,10 +111,12 @@ def create_vd_pipeline(
         return None
 
     if router is None:
+        logger.warning("vd_pipeline_skipped_no_router")
         return None
 
     key_pool = settings.key_pool_for("gemini")
     if key_pool is None:
+        logger.warning("vd_pipeline_skipped_no_gemini_keys")
         return None
 
     from course_supporter.vd.frame_sampler import FrameSampler

--- a/src/course_supporter/ingestion/factory.py
+++ b/src/course_supporter/ingestion/factory.py
@@ -82,22 +82,18 @@ def create_heavy_steps(
     )
 
 
-@dataclass(frozen=True, slots=True)
-class VDModelConfig:
-    """Configuration for VD pipeline LLM calls."""
-
-    model: str = "gemini-2.5-flash"
-    fallback_model: str = "gemini-3.1-flash-lite-preview"
-    rpm_per_key: int = 5
-
-
 def create_vd_pipeline(
     settings: Settings | None = None,
+    router: ModelRouter | None = None,
 ) -> VDPipeline | None:
     """Create VDPipeline from settings, or None if disabled/unconfigured.
 
+    All LLM calls are routed through ``ModelRouter`` for unified cost
+    tracking, fallback chains, and tenant attribution.
+
     Args:
         settings: Application settings. If None, loads from get_settings().
+        router: ModelRouter for LLM calls. Required for VD to function.
 
     Returns:
         Configured VDPipeline, or None if VD is disabled or no Gemini keys.
@@ -110,6 +106,9 @@ def create_vd_pipeline(
     if not settings.vd_enabled:
         return None
 
+    if router is None:
+        return None
+
     key_pool = settings.key_pool_for("gemini")
     if key_pool is None:
         return None
@@ -117,24 +116,17 @@ def create_vd_pipeline(
     from course_supporter.vd.frame_sampler import FrameSampler
     from course_supporter.vd.memory_pipeline import MemoryPipeline
     from course_supporter.vd.pipeline import VDPipeline
+    from course_supporter.vd.rate_limiter import VDRateLimiter
     from course_supporter.vd.visual_analyzer import VisualAnalyzer
 
-    cfg = VDModelConfig(
-        model=settings.vd_model,
-        fallback_model=settings.vd_fallback_model,
-        rpm_per_key=settings.vd_rpm_per_key,
-    )
-    memory = MemoryPipeline(
-        key_pool,
-        model=cfg.model,
-        fallback_model=cfg.fallback_model,
-        rpm_per_key=cfg.rpm_per_key,
-    )
+    total_rpm = settings.vd_rpm_per_key * len(key_pool)
+    rate_limiter = VDRateLimiter(total_rpm)
+
+    memory = MemoryPipeline(router, rate_limiter)
     analyzer = VisualAnalyzer(
-        key_pool,
-        model=cfg.model,
-        fallback_model=cfg.fallback_model,
-        rpm_per_key=cfg.rpm_per_key,
+        router,
+        rate_limiter,
+        model=settings.vd_model,
         memory=memory,
     )
     return VDPipeline(

--- a/src/course_supporter/llm/setup.py
+++ b/src/course_supporter/llm/setup.py
@@ -14,9 +14,9 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from course_supporter.config import Settings
 from course_supporter.llm.factory import create_providers
-from course_supporter.llm.logging import create_log_callback
 from course_supporter.llm.registry import load_registry
 from course_supporter.llm.router import ModelRouter
+from course_supporter.service_logging import create_llm_log_callback
 
 logger = structlog.get_logger()
 
@@ -42,7 +42,7 @@ def create_model_router(
 
     log_callback = None
     if session_factory is not None:
-        log_callback = create_log_callback(session_factory)
+        log_callback = create_llm_log_callback(session_factory)
         logger.info("llm_db_logging_enabled")
 
     router = ModelRouter(

--- a/src/course_supporter/service_logging.py
+++ b/src/course_supporter/service_logging.py
@@ -213,7 +213,7 @@ def create_stt_log_callback(
             strategy=result.strategy,
             provider=result.provider,
             model_id=result.model_id,
-            unit_type="minutes",
+            unit_type="seconds",
             unit_in=(
                 round(result.audio_duration_sec) if result.audio_duration_sec else None
             ),

--- a/src/course_supporter/service_logging.py
+++ b/src/course_supporter/service_logging.py
@@ -71,9 +71,16 @@ async def set_tenant_from_job(
             job = await JobRepository(session).get_by_id(job_id)
             if job and job.tenant_id:
                 _current_tenant_id.set(job.tenant_id)
-    except (SQLAlchemyError, OSError, TypeError, AttributeError) as exc:
+    except (SQLAlchemyError, OSError) as exc:
         logger.warning(
             "tenant_lookup_failed",
+            job_id=str(job_id),
+            error=str(exc),
+            exc_info=True,
+        )
+    except (TypeError, AttributeError) as exc:
+        logger.error(
+            "tenant_lookup_unexpected_error",
             job_id=str(job_id),
             error=str(exc),
             exc_info=True,
@@ -123,12 +130,13 @@ async def _persist(
         async with session_factory() as session:
             session.add(record)
             await session.commit()
-    except (SQLAlchemyError, OSError):
+    except (SQLAlchemyError, OSError) as exc:
         logger.error(
             "service_call_log_failed",
             provider=provider,
             model=model_id,
             action=action,
+            error=str(exc),
             exc_info=True,
         )
 

--- a/src/course_supporter/service_logging.py
+++ b/src/course_supporter/service_logging.py
@@ -1,0 +1,188 @@
+"""Unified logging for all external service calls (LLM, STT, VD).
+
+Uses a ``ContextVar`` to propagate ``tenant_id`` from the ARQ task level
+down to every external call, regardless of the service type.
+
+Usage in task functions::
+
+    from course_supporter.service_logging import tenant_scope
+
+    async def arq_ingest_material(ctx, ...):
+        with tenant_scope(tenant_id):
+            ...  # all LLM/STT/VD calls within this scope get tenant_id
+
+Factory functions create typed callbacks compatible with
+ModelRouter, STTRouter, and VD pipeline components.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+import structlog
+from sqlalchemy.exc import SQLAlchemyError
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from course_supporter.llm.schemas import LLMResponse
+    from course_supporter.stt.schemas import STTResult
+
+logger = structlog.get_logger()
+
+# ── Context variable for per-task tenant isolation ──
+
+_current_tenant_id: ContextVar[uuid.UUID | None] = ContextVar(
+    "current_tenant_id", default=None
+)
+
+
+@contextmanager
+def tenant_scope(tenant_id: uuid.UUID) -> Iterator[None]:
+    """Set tenant_id for the duration of an ARQ task."""
+    token = _current_tenant_id.set(tenant_id)
+    try:
+        yield
+    finally:
+        _current_tenant_id.reset(token)
+
+
+def get_current_tenant_id() -> uuid.UUID | None:
+    """Read the current tenant_id from context."""
+    return _current_tenant_id.get()
+
+
+# ── Persist to DB ──
+
+
+async def _persist(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    tenant_id: uuid.UUID | None,
+    action: str,
+    strategy: str,
+    provider: str,
+    model_id: str,
+    unit_type: str | None = None,
+    unit_in: int | None = None,
+    unit_out: int | None = None,
+    latency_ms: int | None = None,
+    cost_usd: float | None = None,
+    success: bool = True,
+    error_message: str | None = None,
+) -> None:
+    """Write a single ExternalServiceCall row.
+
+    DB errors are swallowed — call flow is never interrupted.
+    """
+    from course_supporter.storage.orm import ExternalServiceCall
+
+    record = ExternalServiceCall(
+        tenant_id=tenant_id or get_current_tenant_id(),
+        action=action,
+        strategy=strategy,
+        provider=provider,
+        model_id=model_id,
+        unit_type=unit_type,
+        unit_in=unit_in,
+        unit_out=unit_out,
+        latency_ms=latency_ms,
+        cost_usd=cost_usd,
+        success=success,
+        error_message=error_message,
+    )
+    try:
+        async with session_factory() as session:
+            session.add(record)
+            await session.commit()
+    except (SQLAlchemyError, OSError):
+        logger.error(
+            "service_call_log_failed",
+            provider=provider,
+            model=model_id,
+            action=action,
+            exc_info=True,
+        )
+
+
+# ── LLM callback (replaces llm/logging.py) ──
+
+
+def create_llm_log_callback(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> LLMLogCallback:
+    """Create a LogCallback for ModelRouter.
+
+    Reads tenant_id from ContextVar at call time (not at creation time).
+    """
+
+    async def _log(
+        response: LLMResponse,
+        success: bool,
+        error_message: str | None,
+    ) -> None:
+        await _persist(
+            session_factory,
+            tenant_id=None,  # resolved from contextvar
+            action=response.action,
+            strategy=response.strategy,
+            provider=response.provider,
+            model_id=response.model_id,
+            unit_type="tokens",
+            unit_in=response.tokens_in,
+            unit_out=response.tokens_out,
+            latency_ms=response.latency_ms,
+            cost_usd=response.cost_usd,
+            success=success,
+            error_message=error_message,
+        )
+
+    return _log
+
+
+# Type alias matching ModelRouter's LogCallback signature
+from collections.abc import Awaitable, Callable  # noqa: E402
+
+LLMLogCallback = Callable[["LLMResponse", bool, str | None], Awaitable[None]]
+
+
+# ── STT callback ──
+
+
+def create_stt_log_callback(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> STTLogCallback:
+    """Create a LogCallback for STTRouter."""
+
+    async def _log(
+        result: STTResult | None,
+        error_message: str | None,
+    ) -> None:
+        if result is None:
+            return
+        await _persist(
+            session_factory,
+            tenant_id=None,
+            action=result.action,
+            strategy=result.strategy,
+            provider=result.provider,
+            model_id=result.model_id,
+            unit_type="minutes",
+            unit_in=(
+                round(result.audio_duration_sec) if result.audio_duration_sec else None
+            ),
+            unit_out=None,
+            latency_ms=result.latency_ms,
+            cost_usd=result.cost_usd,
+            success=error_message is None,
+            error_message=error_message,
+        )
+
+    return _log
+
+
+STTLogCallback = Callable[["STTResult | None", str | None], Awaitable[None]]

--- a/src/course_supporter/service_logging.py
+++ b/src/course_supporter/service_logging.py
@@ -93,7 +93,6 @@ async def set_tenant_from_job(
 async def _persist(
     session_factory: async_sessionmaker[AsyncSession],
     *,
-    tenant_id: uuid.UUID | None,
     action: str,
     strategy: str,
     provider: str,
@@ -113,7 +112,7 @@ async def _persist(
     from course_supporter.storage.orm import ExternalServiceCall
 
     record = ExternalServiceCall(
-        tenant_id=tenant_id or get_current_tenant_id(),
+        tenant_id=get_current_tenant_id(),
         action=action,
         strategy=strategy,
         provider=provider,
@@ -159,7 +158,6 @@ def create_llm_log_callback(
     ) -> None:
         await _persist(
             session_factory,
-            tenant_id=None,  # resolved from contextvar
             action=response.action,
             strategy=response.strategy,
             provider=response.provider,
@@ -195,10 +193,19 @@ def create_stt_log_callback(
         error_message: str | None,
     ) -> None:
         if result is None:
+            if error_message:
+                await _persist(
+                    session_factory,
+                    action="transcribe",
+                    strategy="unknown",
+                    provider="unknown",
+                    model_id="unknown",
+                    success=False,
+                    error_message=error_message,
+                )
             return
         await _persist(
             session_factory,
-            tenant_id=None,
             action=result.action,
             strategy=result.strategy,
             provider=result.provider,

--- a/src/course_supporter/service_logging.py
+++ b/src/course_supporter/service_logging.py
@@ -62,10 +62,13 @@ async def set_tenant_from_job(
 ) -> None:
     """Look up tenant_id from Job and set it in contextvar for cost logging.
 
+    Always resets the contextvar first to prevent tenant leakage
+    between sequential ARQ tasks in the same worker.
     Best-effort: DB/network failures are logged but never propagate.
     """
     from course_supporter.storage.job_repository import JobRepository
 
+    _current_tenant_id.set(None)
     try:
         async with session_factory() as session:
             job = await JobRepository(session).get_by_id(job_id)

--- a/src/course_supporter/service_logging.py
+++ b/src/course_supporter/service_logging.py
@@ -5,11 +5,11 @@ down to every external call, regardless of the service type.
 
 Usage in task functions::
 
-    from course_supporter.service_logging import tenant_scope
+    from course_supporter.service_logging import set_tenant_from_job
 
     async def arq_ingest_material(ctx, ...):
-        with tenant_scope(tenant_id):
-            ...  # all LLM/STT/VD calls within this scope get tenant_id
+        await set_tenant_from_job(session_factory, job_id)
+        ...  # all LLM/STT/VD calls get tenant_id from contextvar
 
 Factory functions create typed callbacks compatible with
 ModelRouter, STTRouter, and VD pipeline components.
@@ -54,6 +54,30 @@ def tenant_scope(tenant_id: uuid.UUID) -> Iterator[None]:
 def get_current_tenant_id() -> uuid.UUID | None:
     """Read the current tenant_id from context."""
     return _current_tenant_id.get()
+
+
+async def set_tenant_from_job(
+    session_factory: async_sessionmaker[AsyncSession],
+    job_id: uuid.UUID,
+) -> None:
+    """Look up tenant_id from Job and set it in contextvar for cost logging.
+
+    Best-effort: DB/network failures are logged but never propagate.
+    """
+    from course_supporter.storage.job_repository import JobRepository
+
+    try:
+        async with session_factory() as session:
+            job = await JobRepository(session).get_by_id(job_id)
+            if job and job.tenant_id:
+                _current_tenant_id.set(job.tenant_id)
+    except (SQLAlchemyError, OSError, TypeError, AttributeError) as exc:
+        logger.warning(
+            "tenant_lookup_failed",
+            job_id=str(job_id),
+            error=str(exc),
+            exc_info=True,
+        )
 
 
 # ── Persist to DB ──

--- a/src/course_supporter/storage/repositories.py
+++ b/src/course_supporter/storage/repositories.py
@@ -6,7 +6,7 @@ import uuid
 from dataclasses import asdict
 from datetime import UTC, datetime
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
@@ -164,8 +164,9 @@ class SlideVideoMappingRepository:
 class ExternalServiceCallRepository:
     """Repository for external service call analytics and cost reporting.
 
-    Optionally scoped by tenant_id. When tenant_id is provided,
-    all queries filter by it. When None, returns all records.
+    Scoped by tenant_id: includes records with matching tenant_id
+    AND records with tenant_id=NULL (legacy/pre-tracking records).
+    When tenant_id is None, returns all records.
     """
 
     def __init__(
@@ -198,7 +199,12 @@ class ExternalServiceCallRepository:
             ),
         ).select_from(ExternalServiceCall)
         if self._tenant_id is not None:
-            stmt = stmt.where(ExternalServiceCall.tenant_id == self._tenant_id)
+            stmt = stmt.where(
+                or_(
+                    ExternalServiceCall.tenant_id == self._tenant_id,
+                    ExternalServiceCall.tenant_id.is_(None),
+                )
+            )
         result = await self._session.execute(stmt)
         row = result.one()
         return CostSummary(
@@ -259,7 +265,12 @@ class ExternalServiceCallRepository:
             .order_by(func.count().desc())
         )
         if self._tenant_id is not None:
-            stmt = stmt.where(ExternalServiceCall.tenant_id == self._tenant_id)
+            stmt = stmt.where(
+                or_(
+                    ExternalServiceCall.tenant_id == self._tenant_id,
+                    ExternalServiceCall.tenant_id.is_(None),
+                )
+            )
         result = await self._session.execute(stmt)
         return [
             GroupedCost(

--- a/src/course_supporter/stt/setup.py
+++ b/src/course_supporter/stt/setup.py
@@ -36,9 +36,12 @@ def create_stt_router(
     registry = load_registry(settings.external_services_path)
     providers = create_stt_providers(settings)
 
-    # DB logging callback can be added here in future,
-    # reusing the same ExternalServiceCall table as LLM.
     log_callback = None
+    if session_factory is not None:
+        from course_supporter.service_logging import create_stt_log_callback
+
+        log_callback = create_stt_log_callback(session_factory)
+        logger.info("stt_db_logging_enabled")
 
     logger.info(
         "stt_router_created",

--- a/src/course_supporter/vd/memory_pipeline.py
+++ b/src/course_supporter/vd/memory_pipeline.py
@@ -14,13 +14,12 @@ from __future__ import annotations
 
 import asyncio
 import json
-import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
-from course_supporter.key_pool import KeyPool
+from course_supporter.vd.rate_limiter import is_rate_limit, retry_wait
 from course_supporter.vd.schemas import (
     EyesResult,
     InstantMemory,
@@ -28,6 +27,10 @@ from course_supporter.vd.schemas import (
     SceneMemory,
     VideoMemory,
 )
+
+if TYPE_CHECKING:
+    from course_supporter.llm.router import ModelRouter
+    from course_supporter.vd.rate_limiter import VDRateLimiter
 
 logger = structlog.get_logger()
 
@@ -135,28 +138,22 @@ def build_instant_memory(
 class MemoryPipeline:
     """Streaming memory: scene updates per frame, video updates per scene.
 
+    Routes all LLM calls through ``ModelRouter`` for unified cost
+    tracking, fallback chains, and tenant attribution. Rate limiting
+    is enforced by a shared ``VDRateLimiter``.
+
     Args:
-        key_pool: Gemini API key pool for LLM calls.
-        model: Text LLM model identifier.
-        fallback_model: Model to try on 429 rate limit.
-        rpm_per_key: Requests per minute per API key.
+        router: ModelRouter for LLM calls.
+        rate_limiter: Shared VD rate limiter.
     """
 
     def __init__(
         self,
-        key_pool: KeyPool,
-        *,
-        model: str = "gemini-2.5-flash",
-        fallback_model: str = "gemini-3.1-flash-lite-preview",
-        rpm_per_key: int = 10,
+        router: ModelRouter,
+        rate_limiter: VDRateLimiter,
     ) -> None:
-        self._key_pool = key_pool
-        self._model = model
-        self._fallback_model = fallback_model
-        total_rpm = rpm_per_key * len(key_pool)
-        self._min_interval = 60.0 / total_rpm
-        self._last_call_time = 0.0
-        self._lock = asyncio.Lock()
+        self._router = router
+        self._rate_limiter = rate_limiter
 
     async def update_scene_memory(
         self,
@@ -166,7 +163,7 @@ class MemoryPipeline:
         """Update scene memory with a new frame observation.
 
         Called once per frame within a scene. LLM synthesizes
-        what is happening in the scene overall, not just this frame.
+        what is happening in this scene overall, not just this frame.
         """
         template = _load_template("scene_memory_streaming.txt")
         prompt = template.format(
@@ -264,54 +261,34 @@ class MemoryPipeline:
         *,
         _max_retries: int = 3,
     ) -> str:
-        """Rate-limited text LLM call with retry and model fallback."""
-        import google.genai as genai
-
-        from course_supporter.vd.visual_analyzer import _is_rate_limit, _retry_wait
-
+        """Rate-limited text LLM call via ModelRouter with retry on 429."""
         for attempt in range(_max_retries + 1):
-            use_model = self._model if attempt == 0 else self._fallback_model
-
-            async with self._lock:
-                elapsed = time.monotonic() - self._last_call_time
-                if elapsed < self._min_interval:
-                    await asyncio.sleep(self._min_interval - elapsed)
-
-                key = self._key_pool.next_key()
-                client = genai.Client(api_key=key.get_secret_value())
-
-                t0 = time.monotonic()
-                try:
-                    response = await asyncio.to_thread(
-                        client.models.generate_content,
-                        model=use_model,
-                        contents=prompt,
+            await self._rate_limiter.acquire()
+            try:
+                response = await self._router.complete(
+                    action="vd_memory",
+                    prompt=prompt,
+                )
+                logger.info(
+                    "memory_llm_call",
+                    model=response.model_id,
+                    latency_ms=response.latency_ms,
+                    tokens_in=response.tokens_in,
+                    tokens_out=response.tokens_out,
+                )
+                return response.content
+            except Exception as exc:
+                if attempt < _max_retries and is_rate_limit(exc):
+                    wait = retry_wait(exc, attempt)
+                    logger.warning(
+                        "memory_rate_limit_retry",
+                        attempt=attempt + 1,
+                        wait_sec=wait,
                     )
-                except Exception as exc:
-                    self._last_call_time = time.monotonic()
-                    if attempt < _max_retries and _is_rate_limit(exc):
-                        wait = _retry_wait(exc, attempt)
-                        logger.warning(
-                            "memory_rate_limit_retry",
-                            attempt=attempt + 1,
-                            wait_sec=wait,
-                            fallback_model=self._fallback_model,
-                        )
-                        await asyncio.sleep(wait)
-                        continue
-                    logger.exception(
-                        "memory_llm_error",
-                        model=use_model,
-                    )
-                    raise
-                self._last_call_time = time.monotonic()
-
-            logger.info(
-                "memory_llm_call",
-                model=use_model,
-                latency=round(time.monotonic() - t0, 2),
-            )
-            return response.text or ""
+                    await asyncio.sleep(wait)
+                    continue
+                logger.exception("memory_llm_error")
+                raise
 
         msg = "Unreachable: retry loop exhausted without return or raise"
         raise RuntimeError(msg)

--- a/src/course_supporter/vd/rate_limiter.py
+++ b/src/course_supporter/vd/rate_limiter.py
@@ -1,0 +1,56 @@
+"""Shared rate limiter and retry helpers for the VD pipeline.
+
+VD makes hundreds of Gemini calls per video (one per frame + memory
+updates). This module provides a rate limiter that enforces minimum
+intervals between calls, and retry helpers for 429 errors.
+
+Both ``VisualAnalyzer`` and ``MemoryPipeline`` share the same rate
+limiter instance to coordinate against a single Gemini quota.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+
+import structlog
+
+logger = structlog.get_logger()
+
+_RETRY_BASE_WAIT = 40.0  # seconds, matches typical Gemini retry-after
+
+
+class VDRateLimiter:
+    """Async rate limiter that enforces minimum interval between calls.
+
+    Args:
+        rpm: Total requests per minute across all API keys.
+    """
+
+    def __init__(self, rpm: int) -> None:
+        self._min_interval = 60.0 / rpm if rpm > 0 else 0.0
+        self._last_call_time = 0.0
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        """Wait until enough time has passed since the last call."""
+        async with self._lock:
+            elapsed = time.monotonic() - self._last_call_time
+            if elapsed < self._min_interval:
+                await asyncio.sleep(self._min_interval - elapsed)
+            self._last_call_time = time.monotonic()
+
+
+def is_rate_limit(exc: BaseException) -> bool:
+    """Check if an exception is a 429 rate-limit error."""
+    exc_str = str(exc)
+    return "429" in exc_str or "RESOURCE_EXHAUSTED" in exc_str
+
+
+def retry_wait(exc: BaseException, attempt: int) -> float:
+    """Calculate retry wait time from error message or exponential backoff."""
+    match = re.search(r"retry\s+in\s+([\d.]+)s", str(exc), re.IGNORECASE)
+    if match:
+        return float(match.group(1)) + 2.0  # add buffer
+    return _RETRY_BASE_WAIT * float(2**attempt)

--- a/src/course_supporter/vd/rate_limiter.py
+++ b/src/course_supporter/vd/rate_limiter.py
@@ -18,7 +18,9 @@ import structlog
 
 logger = structlog.get_logger()
 
-_RETRY_BASE_WAIT = 40.0  # seconds, matches typical Gemini retry-after
+# Default backoff base when Gemini 429 response has no retry-after header.
+# 40s matches observed typical retry-after values from Gemini API.
+GEMINI_RETRY_BASE_WAIT_SEC = 40.0
 
 
 class VDRateLimiter:
@@ -53,4 +55,4 @@ def retry_wait(exc: BaseException, attempt: int) -> float:
     match = re.search(r"retry\s+in\s+([\d.]+)s", str(exc), re.IGNORECASE)
     if match:
         return float(match.group(1)) + 2.0  # add buffer
-    return _RETRY_BASE_WAIT * float(2**attempt)
+    return GEMINI_RETRY_BASE_WAIT_SEC * float(2**attempt)

--- a/src/course_supporter/vd/visual_analyzer.py
+++ b/src/course_supporter/vd/visual_analyzer.py
@@ -51,7 +51,8 @@ logger = structlog.get_logger()
 
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
 _PROMPT_CACHE: dict[str, str] = {}
-_MAX_DESCRIPTION_LEN = 300
+# Max chars for the visual description extracted from Vision LLM response.
+MAX_VISUAL_DESCRIPTION_LEN = 300
 
 
 def _load_prompt(name: str) -> str:
@@ -92,7 +93,7 @@ def _parse_response(text: str) -> tuple[str, str, int]:
 
     description = " ".join(desc_parts[:3]) if desc_parts else text[:200]
 
-    return description[:_MAX_DESCRIPTION_LEN], scene_type, importance
+    return description[:MAX_VISUAL_DESCRIPTION_LEN], scene_type, importance
 
 
 def _is_conditional_delta(text: str) -> bool:

--- a/src/course_supporter/vd/visual_analyzer.py
+++ b/src/course_supporter/vd/visual_analyzer.py
@@ -11,8 +11,9 @@ Supports three delta strategies for similar frames:
 - ``CONDITIONAL``: LLM decides — prompt includes previous description
   and LLM chooses full vs delta (variant B).
 
-Rate limiting is enforced via an async lock that respects per-key
-RPM quotas with round-robin key rotation.
+All LLM calls are routed through ``ModelRouter`` for unified cost
+tracking, fallback chains, and tenant attribution. Rate limiting
+is enforced by a shared ``VDRateLimiter``.
 """
 
 from __future__ import annotations
@@ -20,17 +21,17 @@ from __future__ import annotations
 import asyncio
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
-from course_supporter.key_pool import KeyPool
 from course_supporter.vd.memory_pipeline import (
     MemoryPipeline,
     append_delta_to_scene,
     build_instant_memory,
     needs_llm_scene_update,
 )
+from course_supporter.vd.rate_limiter import is_rate_limit, retry_wait
 from course_supporter.vd.schemas import (
     ChangeClass,
     DeltaStrategy,
@@ -42,12 +43,15 @@ from course_supporter.vd.schemas import (
     VideoMemory,
 )
 
+if TYPE_CHECKING:
+    from course_supporter.llm.router import ModelRouter
+    from course_supporter.vd.rate_limiter import VDRateLimiter
+
 logger = structlog.get_logger()
 
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
 _PROMPT_CACHE: dict[str, str] = {}
 _MAX_DESCRIPTION_LEN = 300
-_RETRY_BASE_WAIT = 40.0  # seconds, matches typical Gemini retry-after
 
 
 def _load_prompt(name: str) -> str:
@@ -123,23 +127,6 @@ def _build_similarity_hint(frame: SampledFrame | None) -> str:
     )
 
 
-def _is_rate_limit(exc: BaseException) -> bool:
-    """Check if an exception is a 429 rate-limit error."""
-    exc_str = str(exc)
-    return "429" in exc_str or "RESOURCE_EXHAUSTED" in exc_str
-
-
-def _retry_wait(exc: BaseException, attempt: int) -> float:
-    """Calculate retry wait time from error or exponential backoff."""
-    import re
-
-    # Try to extract retry delay from error message
-    match = re.search(r"retry\s+in\s+([\d.]+)s", str(exc), re.IGNORECASE)
-    if match:
-        return float(match.group(1)) + 2.0  # add buffer
-    return _RETRY_BASE_WAIT * float(2**attempt)
-
-
 def _build_memory_context(
     instant: InstantMemory | None,
     scene_memory: SceneMemory,
@@ -169,41 +156,38 @@ def _build_memory_context(
 class VisualAnalyzer:
     """Per-frame Vision LLM analysis with context images and memory.
 
+    Routes all LLM calls through ``ModelRouter`` for unified cost
+    tracking and fallback chains. Rate limiting is enforced by a
+    shared ``VDRateLimiter``.
+
     Args:
-        key_pool: Gemini API key pool for rotation.
-        model: Vision LLM model identifier.
-        rpm_per_key: Requests per minute per API key.
+        router: ModelRouter for LLM calls.
+        rate_limiter: Shared VD rate limiter.
+        model: Vision LLM model identifier (for metadata/logging).
         context_max_gap_sec: Max time gap for context images.
         max_context_images: Max number of previous frames as context.
         delta_strategy: How to handle frames similar to previous.
         memory: Optional MemoryPipeline for streaming memory updates.
-            Injected separately so it can use a different model/provider.
     """
 
     def __init__(
         self,
-        key_pool: KeyPool,
+        router: ModelRouter,
+        rate_limiter: VDRateLimiter,
         *,
         model: str = "gemini-2.5-flash",
-        fallback_model: str = "gemini-3.1-flash-lite-preview",
-        rpm_per_key: int = 5,
         context_max_gap_sec: float = 7.0,
         max_context_images: int = 2,
         delta_strategy: DeltaStrategy = DeltaStrategy.CONDITIONAL,
         memory: MemoryPipeline | None = None,
     ) -> None:
-        self._key_pool = key_pool
+        self._router = router
+        self._rate_limiter = rate_limiter
         self._model = model
-        self._fallback_model = fallback_model
         self._context_max_gap = context_max_gap_sec
         self._max_ctx_images = max_context_images
         self._delta_strategy = delta_strategy
         self._memory = memory
-
-        total_rpm = rpm_per_key * len(key_pool)
-        self._min_interval = 60.0 / total_rpm
-        self._last_call_time = 0.0
-        self._lock = asyncio.Lock()
 
     @property
     def model(self) -> str:
@@ -316,7 +300,7 @@ class VisualAnalyzer:
         prev_result: EyesResult | None,
     ) -> EyesResult:
         """Analyze a single frame with Vision LLM."""
-        import google.genai as genai
+        from google.genai import types as genai_types
 
         parts: list[Any] = []
 
@@ -324,7 +308,7 @@ class VisualAnalyzer:
         for cf in context_frames:
             img_path = self._find_frame(frame_dir, cf.filename)
             parts.append(
-                genai.types.Part.from_bytes(
+                genai_types.Part.from_bytes(
                     data=img_path.read_bytes(),
                     mime_type="image/jpeg",
                 ),
@@ -333,7 +317,7 @@ class VisualAnalyzer:
         # Main image (current frame — LAST image per prompt)
         main_path = self._find_frame(frame_dir, frame.filename)
         parts.append(
-            genai.types.Part.from_bytes(
+            genai_types.Part.from_bytes(
                 data=main_path.read_bytes(),
                 mime_type="image/jpeg",
             ),
@@ -347,9 +331,9 @@ class VisualAnalyzer:
             prev_result=prev_result,
             frame=frame,
         )
-        parts.append(genai.types.Part.from_text(text=prompt))
+        parts.append(genai_types.Part.from_text(text=prompt))
 
-        # Rate-limited API call
+        # Rate-limited API call via ModelRouter
         api_result = await self._call_llm(parts)
 
         # Parse response
@@ -390,72 +374,49 @@ class VisualAnalyzer:
         *,
         _max_retries: int = 3,
     ) -> dict[str, Any]:
-        """Make a rate-limited Vision LLM call with retry and model fallback.
+        """Rate-limited Vision LLM call via ModelRouter with retry on 429."""
+        from google.genai import types as genai_types
 
-        On 429: retry with same model first, then switch to fallback model.
-        """
-        import google.genai as genai
+        contents: list[Any] = [genai_types.Content(parts=parts)]
 
         for attempt in range(_max_retries + 1):
-            # First attempt uses primary model, retries use fallback
-            use_model = self._model if attempt == 0 else self._fallback_model
-
-            async with self._lock:
-                elapsed = time.monotonic() - self._last_call_time
-                if elapsed < self._min_interval:
-                    await asyncio.sleep(self._min_interval - elapsed)
-
-                key = self._key_pool.next_key()
-                client = genai.Client(api_key=key.get_secret_value())
-
-                t0 = time.monotonic()
-                try:
-                    contents: Any = [genai.types.Content(parts=parts)]
-                    response = await asyncio.to_thread(
-                        client.models.generate_content,
-                        model=use_model,
-                        contents=contents,
-                    )
-                except Exception as exc:
-                    self._last_call_time = time.monotonic()
-                    if attempt < _max_retries and _is_rate_limit(exc):
-                        wait = _retry_wait(exc, attempt)
-                        logger.warning(
-                            "eyes_rate_limit_retry",
-                            attempt=attempt + 1,
-                            wait_sec=wait,
-                            fallback_model=self._fallback_model,
-                        )
-                        await asyncio.sleep(wait)
-                        continue
-                    logger.exception(
-                        "vision_llm_error",
-                        model=use_model,
-                        error_type=type(exc).__name__,
-                    )
-                    raise
-
-                self._last_call_time = time.monotonic()
+            await self._rate_limiter.acquire()
+            t0 = time.monotonic()
+            try:
+                response = await self._router.complete(
+                    action="vd_frame_analysis",
+                    prompt="",
+                    contents=contents,
+                )
                 latency = round(time.monotonic() - t0, 2)
-
-                usage = response.usage_metadata
-                result = {
-                    "text": response.text or "",
-                    "input_tokens": (usage.prompt_token_count or 0 if usage else 0),
-                    "output_tokens": (
-                        usage.candidates_token_count or 0 if usage else 0
-                    ),
-                    "latency_sec": latency,
-                }
-
                 logger.info(
                     "eyes_frame_done",
-                    model=use_model,
+                    model=response.model_id,
                     latency=latency,
-                    tokens_in=result["input_tokens"],
-                    tokens_out=result["output_tokens"],
+                    tokens_in=response.tokens_in,
+                    tokens_out=response.tokens_out,
                 )
-                return result
+                return {
+                    "text": response.content,
+                    "input_tokens": response.tokens_in or 0,
+                    "output_tokens": response.tokens_out or 0,
+                    "latency_sec": latency,
+                }
+            except Exception as exc:
+                if attempt < _max_retries and is_rate_limit(exc):
+                    wait = retry_wait(exc, attempt)
+                    logger.warning(
+                        "eyes_rate_limit_retry",
+                        attempt=attempt + 1,
+                        wait_sec=wait,
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                logger.exception(
+                    "vision_llm_error",
+                    error_type=type(exc).__name__,
+                )
+                raise
 
         msg = "Unreachable: retry loop exhausted without return or raise"
         raise RuntimeError(msg)

--- a/tests/unit/test_api/test_ingestion_task.py
+++ b/tests/unit/test_api/test_ingestion_task.py
@@ -15,6 +15,20 @@ _ENTRY_REPO = (
 )
 
 
+@pytest.fixture(autouse=True)
+def _bypass_tenant_lookup() -> None:  # type: ignore[misc]
+    """Bypass set_tenant_from_job in all ingestion task tests.
+
+    The real function needs a working DB session; tests use MagicMock
+    session factories. Patching it as a no-op avoids TypeError.
+    """
+    with patch(
+        "course_supporter.api.tasks.set_tenant_from_job",
+        new=AsyncMock(),
+    ):
+        yield
+
+
 def _make_session_factory(session: AsyncMock | None = None) -> MagicMock:
     """Create a mock async_sessionmaker that returns an async ctx manager."""
     if session is None:
@@ -96,7 +110,6 @@ class TestArqIngestMaterial:
             patch(_HEAVY),
             patch(_FACTORY, return_value=_mock_processors()),
         ):
-            mock_job_repo_cls.return_value.get_by_id = AsyncMock(return_value=None)
             mock_job_repo_cls.return_value.update_status = AsyncMock()
             mock_entry_cls.return_value.get_by_id = AsyncMock(
                 return_value=_mock_entry()
@@ -143,7 +156,6 @@ class TestArqIngestMaterial:
             patch(_FACTORY, return_value=_mock_processors(doc)),
         ):
             mock_job = mock_job_cls.return_value
-            mock_job.get_by_id = AsyncMock(return_value=None)
             mock_job.update_status = AsyncMock()
             mock_entry_cls.return_value.get_by_id = AsyncMock(
                 return_value=_mock_entry()
@@ -190,7 +202,6 @@ class TestArqIngestMaterial:
                 return_value=_failing_processors(error="boom"),
             ),
         ):
-            mock_job_cls.return_value.get_by_id = AsyncMock(return_value=None)
             mock_job_cls.return_value.update_status = AsyncMock()
             mock_entry_cls.return_value.get_by_id = AsyncMock(
                 return_value=_mock_entry()
@@ -229,7 +240,6 @@ class TestArqIngestMaterial:
             patch(_HEAVY),
             patch(_FACTORY, return_value=_mock_processors()),
         ):
-            mock_job_cls.return_value.get_by_id = AsyncMock(return_value=None)
             mock_job_cls.return_value.update_status = AsyncMock()
             mock_entry_cls.return_value.get_by_id = AsyncMock(return_value=None)
             mock_cb_cls.return_value.on_success = AsyncMock()
@@ -315,7 +325,6 @@ class TestArqIngestMaterial:
             patch(_FACTORY, return_value=procs),
             patch.object(anyio.Path, "exists", AsyncMock(return_value=False)),
         ):
-            mock_job_cls.return_value.get_by_id = AsyncMock(return_value=None)
             mock_job_cls.return_value.update_status = AsyncMock()
             mock_entry_cls.return_value.get_by_id = AsyncMock(
                 return_value=mock_entry_obj
@@ -381,7 +390,6 @@ class TestArqIngestMaterial:
             patch.object(anyio.Path, "exists", mock_exists),
             patch.object(anyio.Path, "unlink", mock_unlink),
         ):
-            mock_job_cls.return_value.get_by_id = AsyncMock(return_value=None)
             mock_job_cls.return_value.update_status = AsyncMock()
             mock_entry_cls.return_value.get_by_id = AsyncMock(
                 return_value=mock_entry_obj

--- a/tests/unit/test_api/test_ingestion_task.py
+++ b/tests/unit/test_api/test_ingestion_task.py
@@ -15,13 +15,9 @@ _ENTRY_REPO = (
 )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def _bypass_tenant_lookup() -> None:  # type: ignore[misc]
-    """Bypass set_tenant_from_job in all ingestion task tests.
-
-    The real function needs a working DB session; tests use MagicMock
-    session factories. Patching it as a no-op avoids TypeError.
-    """
+    """Bypass set_tenant_from_job when tests use mock session factories."""
     with patch(
         "course_supporter.api.tasks.set_tenant_from_job",
         new=AsyncMock(),
@@ -88,6 +84,7 @@ def _mock_entry(source_url: str = "https://example.com") -> MagicMock:
     return entry
 
 
+@pytest.mark.usefixtures("_bypass_tenant_lookup")
 class TestArqIngestMaterial:
     """Tests for the ARQ-based arq_ingest_material function."""
 

--- a/tests/unit/test_api/test_ingestion_task.py
+++ b/tests/unit/test_api/test_ingestion_task.py
@@ -96,6 +96,7 @@ class TestArqIngestMaterial:
             patch(_HEAVY),
             patch(_FACTORY, return_value=_mock_processors()),
         ):
+            mock_job_repo_cls.return_value.get_by_id = AsyncMock(return_value=None)
             mock_job_repo_cls.return_value.update_status = AsyncMock()
             mock_entry_cls.return_value.get_by_id = AsyncMock(
                 return_value=_mock_entry()
@@ -142,6 +143,7 @@ class TestArqIngestMaterial:
             patch(_FACTORY, return_value=_mock_processors(doc)),
         ):
             mock_job = mock_job_cls.return_value
+            mock_job.get_by_id = AsyncMock(return_value=None)
             mock_job.update_status = AsyncMock()
             mock_entry_cls.return_value.get_by_id = AsyncMock(
                 return_value=_mock_entry()
@@ -188,6 +190,7 @@ class TestArqIngestMaterial:
                 return_value=_failing_processors(error="boom"),
             ),
         ):
+            mock_job_cls.return_value.get_by_id = AsyncMock(return_value=None)
             mock_job_cls.return_value.update_status = AsyncMock()
             mock_entry_cls.return_value.get_by_id = AsyncMock(
                 return_value=_mock_entry()
@@ -226,6 +229,7 @@ class TestArqIngestMaterial:
             patch(_HEAVY),
             patch(_FACTORY, return_value=_mock_processors()),
         ):
+            mock_job_cls.return_value.get_by_id = AsyncMock(return_value=None)
             mock_job_cls.return_value.update_status = AsyncMock()
             mock_entry_cls.return_value.get_by_id = AsyncMock(return_value=None)
             mock_cb_cls.return_value.on_success = AsyncMock()
@@ -311,6 +315,7 @@ class TestArqIngestMaterial:
             patch(_FACTORY, return_value=procs),
             patch.object(anyio.Path, "exists", AsyncMock(return_value=False)),
         ):
+            mock_job_cls.return_value.get_by_id = AsyncMock(return_value=None)
             mock_job_cls.return_value.update_status = AsyncMock()
             mock_entry_cls.return_value.get_by_id = AsyncMock(
                 return_value=mock_entry_obj
@@ -376,6 +381,7 @@ class TestArqIngestMaterial:
             patch.object(anyio.Path, "exists", mock_exists),
             patch.object(anyio.Path, "unlink", mock_unlink),
         ):
+            mock_job_cls.return_value.get_by_id = AsyncMock(return_value=None)
             mock_job_cls.return_value.update_status = AsyncMock()
             mock_entry_cls.return_value.get_by_id = AsyncMock(
                 return_value=mock_entry_obj

--- a/tests/unit/test_ingestion_callback.py
+++ b/tests/unit/test_ingestion_callback.py
@@ -586,6 +586,10 @@ class TestCallbackIntegrationWithArqTask:
             patch(_arq_entry_repo) as entry_cls,
             patch(_heavy),
             patch(_factory, return_value={"web": mock_processor}),
+            patch(
+                "course_supporter.api.tasks.set_tenant_from_job",
+                new=AsyncMock(),
+            ),
         ):
             job_cls.return_value.update_status = AsyncMock()
             entry_cls.return_value.get_by_id = AsyncMock(return_value=mock_entry)
@@ -643,6 +647,10 @@ class TestCallbackIntegrationWithArqTask:
             patch(_arq_entry_repo) as entry_cls,
             patch(_heavy),
             patch(_factory_fn, return_value={"web": mock_processor}),
+            patch(
+                "course_supporter.api.tasks.set_tenant_from_job",
+                new=AsyncMock(),
+            ),
         ):
             job_cls.return_value.update_status = AsyncMock()
             entry_cls.return_value.get_by_id = AsyncMock(return_value=mock_entry)

--- a/tests/unit/test_service_logging.py
+++ b/tests/unit/test_service_logging.py
@@ -8,10 +8,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from course_supporter.service_logging import (
+    _current_tenant_id,
     get_current_tenant_id,
     set_tenant_from_job,
     tenant_scope,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_tenant_context() -> None:  # type: ignore[misc]
+    """Ensure ContextVar is reset to None after each test."""
+    yield
+    _current_tenant_id.set(None)
 
 
 class TestTenantScope:
@@ -61,9 +69,6 @@ class TestSetTenantFromJob:
             await set_tenant_from_job(factory, jid)
 
         assert get_current_tenant_id() == tid
-        # Clean up via tenant_scope context manager
-        with tenant_scope(tid):
-            pass  # resets to previous value (None) on exit
 
     async def test_no_job_found(self) -> None:
         jid = uuid.uuid4()

--- a/tests/unit/test_service_logging.py
+++ b/tests/unit/test_service_logging.py
@@ -121,7 +121,6 @@ class TestPersist:
         with patch("course_supporter.storage.orm.ExternalServiceCall"):
             await _persist(
                 mock_factory,
-                tenant_id=None,
                 action="test_action",
                 strategy="default",
                 provider="gemini",
@@ -147,7 +146,6 @@ class TestPersist:
         with patch("course_supporter.storage.orm.ExternalServiceCall"):
             await _persist(
                 mock_factory,
-                tenant_id=None,
                 action="test",
                 strategy="default",
                 provider="test",

--- a/tests/unit/test_service_logging.py
+++ b/tests/unit/test_service_logging.py
@@ -1,0 +1,157 @@
+"""Tests for service_logging module — tenant context and DB persistence."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from course_supporter.service_logging import (
+    _current_tenant_id,
+    get_current_tenant_id,
+    set_tenant_from_job,
+    tenant_scope,
+)
+
+
+class TestTenantScope:
+    """Test ContextVar-based tenant scoping."""
+
+    def test_default_is_none(self) -> None:
+        assert get_current_tenant_id() is None
+
+    def test_scope_sets_and_resets(self) -> None:
+        tid = uuid.uuid4()
+        with tenant_scope(tid):
+            assert get_current_tenant_id() == tid
+        assert get_current_tenant_id() is None
+
+    def test_nested_scopes(self) -> None:
+        t1, t2 = uuid.uuid4(), uuid.uuid4()
+        with tenant_scope(t1):
+            assert get_current_tenant_id() == t1
+            with tenant_scope(t2):
+                assert get_current_tenant_id() == t2
+            assert get_current_tenant_id() == t1
+        assert get_current_tenant_id() is None
+
+    def test_scope_resets_on_exception(self) -> None:
+        tid = uuid.uuid4()
+        with pytest.raises(ValueError, match="boom"), tenant_scope(tid):
+            assert get_current_tenant_id() == tid
+            raise ValueError("boom")
+        assert get_current_tenant_id() is None
+
+
+class TestSetTenantFromJob:
+    """Test async tenant lookup from Job."""
+
+    async def test_sets_tenant_id_from_job(self) -> None:
+        tid = uuid.uuid4()
+        jid = uuid.uuid4()
+        mock_job = MagicMock(tenant_id=tid)
+
+        factory = MagicMock()
+        session = AsyncMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("course_supporter.storage.job_repository.JobRepository") as repo_cls:
+            repo_cls.return_value.get_by_id = AsyncMock(return_value=mock_job)
+            await set_tenant_from_job(factory, jid)
+
+        assert get_current_tenant_id() == tid
+        # Clean up
+        _current_tenant_id.set(None)
+
+    async def test_no_job_found(self) -> None:
+        jid = uuid.uuid4()
+        factory = MagicMock()
+        session = AsyncMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("course_supporter.storage.job_repository.JobRepository") as repo_cls:
+            repo_cls.return_value.get_by_id = AsyncMock(return_value=None)
+            await set_tenant_from_job(factory, jid)
+
+        assert get_current_tenant_id() is None
+
+    async def test_db_error_swallowed(self) -> None:
+        """SQLAlchemy errors are caught and logged, not propagated."""
+        from sqlalchemy.exc import OperationalError
+
+        jid = uuid.uuid4()
+        factory = MagicMock()
+        session = AsyncMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("course_supporter.storage.job_repository.JobRepository") as repo_cls:
+            repo_cls.return_value.get_by_id = AsyncMock(
+                side_effect=OperationalError("conn lost", {}, None)
+            )
+            await set_tenant_from_job(factory, jid)
+
+        assert get_current_tenant_id() is None
+
+    async def test_type_error_swallowed(self) -> None:
+        """TypeError from mock session_factory is handled gracefully."""
+        jid = uuid.uuid4()
+        factory = MagicMock()  # no async context manager setup
+
+        await set_tenant_from_job(factory, jid)  # should not raise
+
+        assert get_current_tenant_id() is None
+
+
+class TestPersist:
+    """Test _persist writes ExternalServiceCall to DB."""
+
+    async def test_persist_writes_record(self) -> None:
+        from course_supporter.service_logging import _persist
+
+        session = AsyncMock()
+        factory = AsyncMock()
+        factory.__aenter__ = AsyncMock(return_value=session)
+        factory.__aexit__ = AsyncMock(return_value=None)
+        mock_factory = MagicMock(return_value=factory)
+
+        with patch("course_supporter.storage.orm.ExternalServiceCall"):
+            await _persist(
+                mock_factory,
+                tenant_id=None,
+                action="test_action",
+                strategy="default",
+                provider="gemini",
+                model_id="gemini-2.5-flash",
+                success=True,
+            )
+
+        session.add.assert_called_once()
+        session.commit.assert_awaited_once()
+
+    async def test_persist_swallows_db_error(self) -> None:
+        from sqlalchemy.exc import OperationalError
+
+        from course_supporter.service_logging import _persist
+
+        session = AsyncMock()
+        session.commit = AsyncMock(side_effect=OperationalError("fail", {}, None))
+        factory = AsyncMock()
+        factory.__aenter__ = AsyncMock(return_value=session)
+        factory.__aexit__ = AsyncMock(return_value=None)
+        mock_factory = MagicMock(return_value=factory)
+
+        with patch("course_supporter.storage.orm.ExternalServiceCall"):
+            await _persist(
+                mock_factory,
+                tenant_id=None,
+                action="test",
+                strategy="default",
+                provider="test",
+                model_id="test",
+                success=True,
+            )
+        # Should not raise

--- a/tests/unit/test_service_logging.py
+++ b/tests/unit/test_service_logging.py
@@ -110,6 +110,25 @@ class TestSetTenantFromJob:
 
         assert get_current_tenant_id() is None
 
+    async def test_clears_previous_tenant_on_new_call(self) -> None:
+        """Prevents tenant leakage between sequential ARQ tasks."""
+        old_tid = uuid.uuid4()
+        _current_tenant_id.set(old_tid)
+        assert get_current_tenant_id() == old_tid
+
+        # New task with failed lookup — must NOT inherit old tenant
+        jid = uuid.uuid4()
+        factory = MagicMock()
+        session = AsyncMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("course_supporter.storage.job_repository.JobRepository") as repo_cls:
+            repo_cls.return_value.get_by_id = AsyncMock(return_value=None)
+            await set_tenant_from_job(factory, jid)
+
+        assert get_current_tenant_id() is None
+
 
 class TestPersist:
     """Test _persist writes ExternalServiceCall to DB."""

--- a/tests/unit/test_service_logging.py
+++ b/tests/unit/test_service_logging.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from course_supporter.service_logging import (
-    _current_tenant_id,
     get_current_tenant_id,
     set_tenant_from_job,
     tenant_scope,
@@ -62,8 +61,9 @@ class TestSetTenantFromJob:
             await set_tenant_from_job(factory, jid)
 
         assert get_current_tenant_id() == tid
-        # Clean up
-        _current_tenant_id.set(None)
+        # Clean up via tenant_scope context manager
+        with tenant_scope(tid):
+            pass  # resets to previous value (None) on exit
 
     async def test_no_job_found(self) -> None:
         jid = uuid.uuid4()

--- a/tests/unit/test_vd_memory_pipeline.py
+++ b/tests/unit/test_vd_memory_pipeline.py
@@ -290,16 +290,20 @@ class TestParseSceneMemory:
 
 
 @pytest.fixture()
-def mock_key_pool() -> MagicMock:
-    pool = MagicMock()
-    pool.__len__ = lambda _: 1
-    pool.next_key.return_value = MagicMock(get_secret_value=lambda: "fake-key")
-    return pool
+def mock_router() -> AsyncMock:
+    return AsyncMock()
 
 
 @pytest.fixture()
-def pipeline(mock_key_pool: MagicMock) -> MemoryPipeline:
-    return MemoryPipeline(mock_key_pool, rpm_per_key=999)
+def mock_rate_limiter() -> AsyncMock:
+    limiter = AsyncMock()
+    limiter.acquire = AsyncMock()
+    return limiter
+
+
+@pytest.fixture()
+def pipeline(mock_router: AsyncMock, mock_rate_limiter: AsyncMock) -> MemoryPipeline:
+    return MemoryPipeline(mock_router, mock_rate_limiter)
 
 
 # -- _load_template --------------------------------------------------------
@@ -324,18 +328,17 @@ class TestLoadTemplate:
 
 
 class TestMemoryPipelineInit:
-    def test_min_interval_calculation(self, mock_key_pool: MagicMock) -> None:
-        mp = MemoryPipeline(mock_key_pool, rpm_per_key=10)
-        # 1 key * 10 rpm = 10 rpm total => 6s interval
-        assert mp._min_interval == pytest.approx(6.0)
+    def test_stores_router(
+        self, mock_router: AsyncMock, mock_rate_limiter: AsyncMock
+    ) -> None:
+        mp = MemoryPipeline(mock_router, mock_rate_limiter)
+        assert mp._router is mock_router
 
-    def test_model_stored(self, mock_key_pool: MagicMock) -> None:
-        mp = MemoryPipeline(mock_key_pool, model="test-model")
-        assert mp._model == "test-model"
-
-    def test_fallback_model_stored(self, mock_key_pool: MagicMock) -> None:
-        mp = MemoryPipeline(mock_key_pool, fallback_model="fallback-model")
-        assert mp._fallback_model == "fallback-model"
+    def test_stores_rate_limiter(
+        self, mock_router: AsyncMock, mock_rate_limiter: AsyncMock
+    ) -> None:
+        mp = MemoryPipeline(mock_router, mock_rate_limiter)
+        assert mp._rate_limiter is mock_rate_limiter
 
 
 # -- update_scene_memory (mocked LLM) -------------------------------------
@@ -490,52 +493,40 @@ class TestProcessScene:
 
 class TestCallLlm:
     async def test_success(self, pipeline: MemoryPipeline) -> None:
-        mock_response = MagicMock(text="LLM response")
-        mock_client = MagicMock()
-        mock_client.models.generate_content = MagicMock(return_value=mock_response)
+        mock_resp = MagicMock(
+            content="LLM response",
+            model_id="gemini-2.5-flash",
+            latency_ms=100,
+            tokens_in=50,
+            tokens_out=20,
+        )
+        pipeline._router.complete = AsyncMock(return_value=mock_resp)
 
-        with patch("google.genai.Client", return_value=mock_client):
-            result = await pipeline._call_llm("test prompt")
+        result = await pipeline._call_llm("test prompt")
 
         assert result == "LLM response"
+        pipeline._router.complete.assert_awaited_once()
 
-    async def test_rate_limit_retry_uses_fallback(
-        self, pipeline: MemoryPipeline
-    ) -> None:
+    async def test_rate_limit_retry(self, pipeline: MemoryPipeline) -> None:
         rate_err = Exception("429 Resource exhausted")
-        rate_err.code = 429  # type: ignore[attr-defined]
-        mock_response = MagicMock(text="Fallback OK")
+        mock_resp = MagicMock(
+            content="Retry OK",
+            model_id="gemini-2.5-flash",
+            latency_ms=100,
+            tokens_in=50,
+            tokens_out=20,
+        )
+        pipeline._router.complete = AsyncMock(side_effect=[rate_err, mock_resp])
 
-        call_count = 0
-
-        def side_effect(*_args: object, **kwargs: object) -> MagicMock:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise rate_err
-            return mock_response
-
-        mock_client = MagicMock()
-        mock_client.models.generate_content = side_effect
-
-        with (
-            patch("google.genai.Client", return_value=mock_client),
-            patch("asyncio.sleep", new=AsyncMock()),
-        ):
+        with patch("asyncio.sleep", new=AsyncMock()):
             result = await pipeline._call_llm("test")
 
-        assert result == "Fallback OK"
-        assert call_count == 2
+        assert result == "Retry OK"
+        assert pipeline._router.complete.await_count == 2
 
     async def test_permanent_error_raises(self, pipeline: MemoryPipeline) -> None:
         perm_err = Exception("401 Unauthorized")
-        perm_err.code = 401  # type: ignore[attr-defined]
+        pipeline._router.complete = AsyncMock(side_effect=perm_err)
 
-        mock_client = MagicMock()
-        mock_client.models.generate_content = MagicMock(side_effect=perm_err)
-
-        with (
-            patch("google.genai.Client", return_value=mock_client),
-            pytest.raises(Exception, match="401"),
-        ):
+        with pytest.raises(Exception, match="401"):
             await pipeline._call_llm("test")

--- a/tests/unit/test_vd_rate_limiter.py
+++ b/tests/unit/test_vd_rate_limiter.py
@@ -1,0 +1,79 @@
+"""Tests for VD rate limiter and retry helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from course_supporter.vd.rate_limiter import (
+    VDRateLimiter,
+    is_rate_limit,
+    retry_wait,
+)
+
+
+class TestIsRateLimit:
+    def test_429_string(self) -> None:
+        assert is_rate_limit(Exception("429 Resource exhausted"))
+
+    def test_resource_exhausted(self) -> None:
+        assert is_rate_limit(Exception("RESOURCE_EXHAUSTED"))
+
+    def test_other_error(self) -> None:
+        assert not is_rate_limit(Exception("500 Internal server error"))
+
+    def test_empty_message(self) -> None:
+        assert not is_rate_limit(Exception(""))
+
+
+class TestRetryWait:
+    def test_extracts_retry_delay(self) -> None:
+        exc = Exception("Please retry in 12.5s")
+        wait = retry_wait(exc, 0)
+        assert wait == pytest.approx(14.5)  # 12.5 + 2.0 buffer
+
+    def test_exponential_backoff(self) -> None:
+        exc = Exception("429 no retry hint")
+        w0 = retry_wait(exc, 0)
+        w1 = retry_wait(exc, 1)
+        w2 = retry_wait(exc, 2)
+        assert w1 == pytest.approx(w0 * 2)
+        assert w2 == pytest.approx(w0 * 4)
+
+    def test_base_wait_is_40(self) -> None:
+        exc = Exception("429 no hint")
+        assert retry_wait(exc, 0) == pytest.approx(40.0)
+
+
+class TestVDRateLimiter:
+    async def test_acquire_respects_interval(self) -> None:
+        limiter = VDRateLimiter(rpm=600)  # 10 per sec → 0.1s interval
+        t0 = time.monotonic()
+        await limiter.acquire()
+        await limiter.acquire()
+        elapsed = time.monotonic() - t0
+        assert elapsed >= 0.09  # ~0.1s interval enforced
+
+    async def test_zero_rpm_no_wait(self) -> None:
+        limiter = VDRateLimiter(rpm=0)
+        t0 = time.monotonic()
+        await limiter.acquire()
+        await limiter.acquire()
+        elapsed = time.monotonic() - t0
+        assert elapsed < 0.05
+
+    async def test_serializes_concurrent_calls(self) -> None:
+        limiter = VDRateLimiter(rpm=120)  # 2 per sec → 0.5s interval
+        timestamps: list[float] = []
+
+        async def call() -> None:
+            await limiter.acquire()
+            timestamps.append(time.monotonic())
+
+        await asyncio.gather(call(), call(), call())
+        assert len(timestamps) == 3
+        # Each call should be at least ~0.5s apart
+        for i in range(1, len(timestamps)):
+            assert timestamps[i] - timestamps[i - 1] >= 0.4

--- a/tests/unit/test_vd_visual_analyzer.py
+++ b/tests/unit/test_vd_visual_analyzer.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from course_supporter.vd.rate_limiter import is_rate_limit, retry_wait
 from course_supporter.vd.schemas import (
     ChangeClass,
     DeltaStrategy,
@@ -423,33 +422,6 @@ def mock_rate_limiter() -> AsyncMock:
 @pytest.fixture()
 def analyzer(mock_router: AsyncMock, mock_rate_limiter: AsyncMock) -> VisualAnalyzer:
     return VisualAnalyzer(mock_router, mock_rate_limiter)
-
-
-# -- _is_rate_limit / _retry_wait -----------------------------------------
-
-
-class TestIsRateLimit:
-    def test_429_string(self) -> None:
-        assert is_rate_limit(Exception("429 Resource exhausted"))
-
-    def test_resource_exhausted(self) -> None:
-        assert is_rate_limit(Exception("RESOURCE_EXHAUSTED"))
-
-    def test_other_error(self) -> None:
-        assert not is_rate_limit(Exception("500 Internal server error"))
-
-
-class TestRetryWait:
-    def test_extracts_retry_delay(self) -> None:
-        exc = Exception("Please retry in 12.5s")
-        wait = retry_wait(exc, 0)
-        assert wait == pytest.approx(14.5)  # 12.5 + 2.0 buffer
-
-    def test_exponential_backoff(self) -> None:
-        exc = Exception("429 no retry hint")
-        w0 = retry_wait(exc, 0)
-        w1 = retry_wait(exc, 1)
-        assert w1 == pytest.approx(w0 * 2)
 
 
 # -- VisualAnalyzer.__init__ / model property ------------------------------

--- a/tests/unit/test_vd_visual_analyzer.py
+++ b/tests/unit/test_vd_visual_analyzer.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from course_supporter.vd.rate_limiter import is_rate_limit, retry_wait
 from course_supporter.vd.schemas import (
     ChangeClass,
     DeltaStrategy,
@@ -24,10 +25,8 @@ from course_supporter.vd.visual_analyzer import (
     _build_memory_context,
     _build_similarity_hint,
     _is_conditional_delta,
-    _is_rate_limit,
     _load_prompt,
     _parse_response,
-    _retry_wait,
 )
 
 
@@ -410,16 +409,20 @@ class TestShouldUseDelta:
 
 
 @pytest.fixture()
-def mock_key_pool() -> MagicMock:
-    pool = MagicMock()
-    pool.__len__ = lambda _: 1
-    pool.next_key.return_value = MagicMock(get_secret_value=lambda: "fake-key")
-    return pool
+def mock_router() -> AsyncMock:
+    return AsyncMock()
 
 
 @pytest.fixture()
-def analyzer(mock_key_pool: MagicMock) -> VisualAnalyzer:
-    return VisualAnalyzer(mock_key_pool, rpm_per_key=999)
+def mock_rate_limiter() -> AsyncMock:
+    limiter = AsyncMock()
+    limiter.acquire = AsyncMock()
+    return limiter
+
+
+@pytest.fixture()
+def analyzer(mock_router: AsyncMock, mock_rate_limiter: AsyncMock) -> VisualAnalyzer:
+    return VisualAnalyzer(mock_router, mock_rate_limiter)
 
 
 # -- _is_rate_limit / _retry_wait -----------------------------------------
@@ -427,25 +430,25 @@ def analyzer(mock_key_pool: MagicMock) -> VisualAnalyzer:
 
 class TestIsRateLimit:
     def test_429_string(self) -> None:
-        assert _is_rate_limit(Exception("429 Resource exhausted"))
+        assert is_rate_limit(Exception("429 Resource exhausted"))
 
     def test_resource_exhausted(self) -> None:
-        assert _is_rate_limit(Exception("RESOURCE_EXHAUSTED"))
+        assert is_rate_limit(Exception("RESOURCE_EXHAUSTED"))
 
     def test_other_error(self) -> None:
-        assert not _is_rate_limit(Exception("500 Internal server error"))
+        assert not is_rate_limit(Exception("500 Internal server error"))
 
 
 class TestRetryWait:
     def test_extracts_retry_delay(self) -> None:
         exc = Exception("Please retry in 12.5s")
-        wait = _retry_wait(exc, 0)
+        wait = retry_wait(exc, 0)
         assert wait == pytest.approx(14.5)  # 12.5 + 2.0 buffer
 
     def test_exponential_backoff(self) -> None:
         exc = Exception("429 no retry hint")
-        w0 = _retry_wait(exc, 0)
-        w1 = _retry_wait(exc, 1)
+        w0 = retry_wait(exc, 0)
+        w1 = retry_wait(exc, 1)
         assert w1 == pytest.approx(w0 * 2)
 
 
@@ -456,13 +459,11 @@ class TestAnalyzerInit:
     def test_model_property(self, analyzer: VisualAnalyzer) -> None:
         assert analyzer.model == "gemini-2.5-flash"
 
-    def test_custom_model(self, mock_key_pool: MagicMock) -> None:
-        a = VisualAnalyzer(mock_key_pool, model="custom-model")
+    def test_custom_model(
+        self, mock_router: AsyncMock, mock_rate_limiter: AsyncMock
+    ) -> None:
+        a = VisualAnalyzer(mock_router, mock_rate_limiter, model="custom-model")
         assert a.model == "custom-model"
-
-    def test_min_interval(self, mock_key_pool: MagicMock) -> None:
-        a = VisualAnalyzer(mock_key_pool, rpm_per_key=10)
-        assert a._min_interval == pytest.approx(6.0)
 
 
 # -- _find_frame -----------------------------------------------------------
@@ -496,15 +497,16 @@ class TestFindFrame:
 
 class TestCallLlm:
     async def test_success(self, analyzer: VisualAnalyzer) -> None:
-        mock_usage = MagicMock(prompt_token_count=100, candidates_token_count=50)
-        mock_response = MagicMock(text="LLM response", usage_metadata=mock_usage)
-        mock_client = MagicMock()
-        mock_client.models.generate_content = MagicMock(return_value=mock_response)
+        mock_resp = MagicMock(
+            content="LLM response",
+            model_id="gemini-2.5-flash",
+            latency_ms=100,
+            tokens_in=100,
+            tokens_out=50,
+        )
+        analyzer._router.complete = AsyncMock(return_value=mock_resp)
 
-        with (
-            patch("google.genai.Client", return_value=mock_client),
-            patch("google.genai.types.Content"),
-        ):
+        with patch("google.genai.types.Content"):
             result = await analyzer._call_llm([MagicMock()])
 
         assert result["text"] == "LLM response"
@@ -513,30 +515,23 @@ class TestCallLlm:
 
     async def test_rate_limit_retries(self, analyzer: VisualAnalyzer) -> None:
         rate_err = Exception("429 Resource exhausted")
-        mock_usage = MagicMock(prompt_token_count=10, candidates_token_count=5)
-        mock_response = MagicMock(text="OK", usage_metadata=mock_usage)
-
-        call_count = 0
-
-        def side_effect(*_a: object, **_k: object) -> MagicMock:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise rate_err
-            return mock_response
-
-        mock_client = MagicMock()
-        mock_client.models.generate_content = side_effect
+        mock_resp = MagicMock(
+            content="OK",
+            model_id="gemini-2.5-flash",
+            latency_ms=100,
+            tokens_in=10,
+            tokens_out=5,
+        )
+        analyzer._router.complete = AsyncMock(side_effect=[rate_err, mock_resp])
 
         with (
-            patch("google.genai.Client", return_value=mock_client),
             patch("google.genai.types.Content"),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             result = await analyzer._call_llm([MagicMock()])
 
         assert result["text"] == "OK"
-        assert call_count == 2
+        assert analyzer._router.complete.await_count == 2
 
 
 # -- analyze_scene (fully mocked) -----------------------------------------
@@ -572,12 +567,14 @@ class TestAnalyzeScene:
         assert results[0].frame_id == "f0"
         assert sm is None  # no memory pipeline
 
-    async def test_multi_frame_with_memory(self, mock_key_pool: MagicMock) -> None:
+    async def test_multi_frame_with_memory(
+        self, mock_router: AsyncMock, mock_rate_limiter: AsyncMock
+    ) -> None:
         mock_memory = AsyncMock()
         mock_memory.update_scene_memory = AsyncMock(
             return_value=SceneMemory(scene_id=0, summary="Updated", frames_seen=1)
         )
-        a = VisualAnalyzer(mock_key_pool, rpm_per_key=999, memory=mock_memory)
+        a = VisualAnalyzer(mock_router, mock_rate_limiter, memory=mock_memory)
         scene = Scene(
             scene_id=0,
             frame_ids=["f0", "f1"],


### PR DESCRIPTION
Проблема

  VD pipeline (VisualAnalyzer, MemoryPipeline) обходив ModelRouter і напряму викликав Gemini SDK. Це дублювало:
  ротацію ключів, підрахунок витрат, fallback chains, логування. Витрати на STT також не логувались. А всі записи
  ExternalServiceCall писались з tenant_id=NULL — cost report показував нулі.

  Рішення

  VD → ModelRouter:
  - Всі VD виклики (frame analysis, memory) маршрутизуються через ModelRouter — cost tracking, fallback chains і
  tenant attribution безкоштовно
  - Виділено VDRateLimiter (shared lock + interval) — VD зберігає свій rate limiting поверх router'а
  - Нові actions в external_services.yaml: vd_frame_analysis, vd_memory
  - Видалено: пряме використання genai.Client, KeyPool, VDModelConfig, create_vd_log_callback, хак _VD_COST_PER_1K

  Tenant attribution:
  - service_logging.py з ContextVar — tenant_id встановлюється на початку кожного ARQ task через
  _set_tenant_from_job()
  - Підключено до всіх 6 task-функцій: ingestion, generation, execute_step, reconcile, methodist, homework

  STT logging:
  - Підключено create_stt_log_callback — виклики ElevenLabs/OpenAI STT тепер пишуться в ExternalServiceCall

  Cost report:
  - Фільтр змінено на tenant_id = X OR tenant_id IS NULL — показує і нові, і legacy записи

  Тести

  1796 passed, ruff clean, mypy clean.