### PR TITLE
feat: use instructor for structured output in OpenAI-compat providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,9 @@ minio_data/
 .idea/
 .keys-issued-to-users
 
+# Course material videos (uploaded for E2E testing)
+*.mp4
+
 # VD Spike — large media files
 current-doc/vd-spike/sample.mp4
 current-doc/vd-spike/sample2.mp4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "google-genai>=1.12",
     "anthropic>=0.49",
     "openai>=1.68",
+    "instructor>=1.7",
     # Database
     "sqlalchemy[asyncio]>=2.0.37",
     "psycopg[binary]>=3.2",
@@ -179,6 +180,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "imagehash.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "instructor.*"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/course_supporter/llm/providers/base.py
+++ b/src/course_supporter/llm/providers/base.py
@@ -26,15 +26,18 @@ class StructuredOutputError(Exception):
         provider: str,
         raw_content: str,
         schema_name: str,
-        cause: ValidationError,
+        cause: ValidationError | Exception,
     ) -> None:
         self.provider = provider
         self.raw_content = raw_content
         self.schema_name = schema_name
-        error_summary = "; ".join(
-            f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}"
-            for e in cause.errors()[:5]
-        )
+        if isinstance(cause, ValidationError):
+            error_summary = "; ".join(
+                f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}"
+                for e in cause.errors()[:5]
+            )
+        else:
+            error_summary = str(cause)[:500]
         super().__init__(
             f"{provider}: failed to parse response as {schema_name}: {error_summary}"
         )

--- a/src/course_supporter/llm/providers/openai_compat.py
+++ b/src/course_supporter/llm/providers/openai_compat.py
@@ -63,7 +63,7 @@ class OpenAICompatProvider(LLMProvider):
     async def complete(self, request: LLMRequest) -> LLMResponse:
         """Generate text completion via OpenAI-compatible API."""
         model = request.model or self._default_model
-        messages: list[dict[str, str]] = []
+        messages: list[ChatCompletionMessageParam] = []
         if request.system_prompt:
             messages.append({"role": "system", "content": request.system_prompt})
         messages.append({"role": "user", "content": request.prompt})
@@ -72,7 +72,7 @@ class OpenAICompatProvider(LLMProvider):
         with self._measure_latency() as timer:
             response = await client.chat.completions.create(
                 model=model,
-                messages=messages,  # type: ignore[arg-type]
+                messages=messages,
                 temperature=request.temperature,
                 max_tokens=request.max_tokens,
             )

--- a/src/course_supporter/llm/providers/openai_compat.py
+++ b/src/course_supporter/llm/providers/openai_compat.py
@@ -1,21 +1,30 @@
-"""OpenAI-compatible provider (OpenAI + DeepSeek)."""
+"""OpenAI-compatible provider (OpenAI + DeepSeek + Mistral).
+
+Uses ``instructor`` for structured output: tool/function calling
+with automatic retry on validation errors. This is more reliable
+than embedding JSON schema in the system prompt.
+"""
 
 import itertools
-import json
 from collections.abc import Iterator, Sequence
 from typing import Any
 
+import instructor
 import openai
+from instructor.exceptions import InstructorRetryException
 from pydantic import BaseModel
 
-from course_supporter.llm.providers.base import LLMProvider
+from course_supporter.llm.providers.base import LLMProvider, StructuredOutputError
 from course_supporter.llm.schemas import LLMRequest, LLMResponse
 
 
 class OpenAICompatProvider(LLMProvider):
-    """Provider for OpenAI API and compatible services (DeepSeek).
+    """Provider for OpenAI API and compatible services (DeepSeek, Mistral).
 
-    DeepSeek uses the same API format with a different base_url.
+    Uses the same OpenAI SDK with different ``base_url`` per provider.
+    Structured output uses ``instructor`` for tool-based schema
+    enforcement with automatic validation retry.
+
     When multiple API keys are provided, SDK clients are
     pre-created and rotated in round-robin order per request.
     """
@@ -36,9 +45,19 @@ class OpenAICompatProvider(LLMProvider):
         self._client_cycle: Iterator[openai.AsyncOpenAI] = itertools.cycle(
             self._clients
         )
+        self._instructor_clients = tuple(
+            instructor.from_openai(openai.AsyncOpenAI(api_key=k, base_url=base_url))
+            for k in api_keys
+        )
+        self._instructor_cycle: Iterator[instructor.AsyncInstructor] = itertools.cycle(
+            self._instructor_clients
+        )
 
     def _next_client(self) -> openai.AsyncOpenAI:
         return next(self._client_cycle)
+
+    def _next_instructor_client(self) -> instructor.AsyncInstructor:
+        return next(self._instructor_cycle)
 
     async def complete(self, request: LLMRequest) -> LLMResponse:
         """Generate text completion via OpenAI-compatible API."""
@@ -52,10 +71,6 @@ class OpenAICompatProvider(LLMProvider):
         with self._measure_latency() as timer:
             response = await client.chat.completions.create(
                 model=model,
-                # OpenAI SDK expects union of typed message params
-                # (ChatCompletionSystemMessageParam | ...), but accepts
-                # plain dicts at runtime. Using dicts keeps code simple
-                # and avoids coupling to SDK-specific message types.
                 messages=messages,  # type: ignore[arg-type]
                 temperature=request.temperature,
                 max_tokens=request.max_tokens,
@@ -77,41 +92,49 @@ class OpenAICompatProvider(LLMProvider):
         request: LLMRequest,
         response_schema: type[BaseModel],
     ) -> tuple[Any, LLMResponse]:
-        """Generate structured output via JSON mode."""
+        """Generate structured output via instructor (tool/function calling).
+
+        Instructor handles schema enforcement via tool definitions and
+        automatic retry with Pydantic validation error feedback.
+        Falls back to StructuredOutputError on persistent failure.
+        """
         model = request.model or self._default_model
         messages: list[dict[str, str]] = []
-        schema_json = json.dumps(
-            response_schema.model_json_schema(), ensure_ascii=False
-        )
-        system = (
-            f"{request.system_prompt or ''}\n\n"
-            f"Respond ONLY with valid JSON matching this schema:\n{schema_json}"
-        )
-        messages.append({"role": "system", "content": system})
+        if request.system_prompt:
+            messages.append({"role": "system", "content": request.system_prompt})
         messages.append({"role": "user", "content": request.prompt})
 
-        client = self._next_client()
+        client = self._next_instructor_client()
         with self._measure_latency() as timer:
-            # call-overload: OpenAI SDK overloads don't match dict-based
-            # messages + dict-based response_format simultaneously, but
-            # both are accepted at runtime per OpenAI API docs.
-            response = await client.chat.completions.create(  # type: ignore[call-overload]
-                model=model,
-                messages=messages,
-                temperature=request.temperature,
-                max_tokens=request.max_tokens,
-                response_format={"type": "json_object"},
-            )
+            try:
+                (
+                    result,
+                    completion,
+                ) = await client.chat.completions.create_with_completion(
+                    model=model,
+                    messages=messages,
+                    response_model=response_schema,
+                    temperature=request.temperature,
+                    max_tokens=request.max_tokens,
+                    max_retries=2,
+                )
+            except InstructorRetryException as exc:
+                raise StructuredOutputError(
+                    provider=self.provider_name,
+                    raw_content=str(exc),
+                    schema_name=response_schema.__name__,
+                    cause=exc,
+                ) from exc
 
-        choice = response.choices[0]
-        usage = response.usage
+        usage = completion.usage
         llm_response = LLMResponse(
-            content=choice.message.content or "",
+            content=completion.choices[0].message.content or ""
+            if completion.choices
+            else "",
             provider=self.provider_name,
             model_id=model,
             tokens_in=usage.prompt_tokens if usage else None,
             tokens_out=usage.completion_tokens if usage else None,
             latency_ms=timer.elapsed_ms,
         )
-        parsed = self._parse_structured(llm_response.content, response_schema)
-        return parsed, llm_response
+        return result, llm_response

--- a/src/course_supporter/llm/providers/openai_compat.py
+++ b/src/course_supporter/llm/providers/openai_compat.py
@@ -12,6 +12,7 @@ from typing import Any
 import instructor
 import openai
 from instructor.exceptions import InstructorRetryException
+from openai.types.chat import ChatCompletionMessageParam
 from pydantic import BaseModel
 
 from course_supporter.llm.providers.base import LLMProvider, StructuredOutputError
@@ -99,7 +100,7 @@ class OpenAICompatProvider(LLMProvider):
         Falls back to StructuredOutputError on persistent failure.
         """
         model = request.model or self._default_model
-        messages: list[dict[str, str]] = []
+        messages: list[ChatCompletionMessageParam] = []
         if request.system_prompt:
             messages.append({"role": "system", "content": request.system_prompt})
         messages.append({"role": "user", "content": request.prompt})

--- a/uv.lock
+++ b/uv.lock
@@ -409,6 +409,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "google-genai" },
     { name = "imagehash" },
+    { name = "instructor" },
     { name = "openai" },
     { name = "openai-whisper" },
     { name = "opencv-python-headless" },
@@ -459,6 +460,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.128" },
     { name = "google-genai", specifier = ">=1.12" },
     { name = "imagehash", specifier = ">=4.3" },
+    { name = "instructor", specifier = ">=1.7" },
     { name = "openai", specifier = ">=1.68" },
     { name = "openai-whisper", specifier = ">=20240930" },
     { name = "opencv-python-headless", specifier = ">=4.9" },
@@ -1152,6 +1154,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "instructor"
+version = "1.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "docstring-parser" },
+    { name = "jinja2" },
+    { name = "jiter" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tenacity" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/a4/832cfb15420360e26d2d85bd9d5fe1e4b839d52587574d389bc31284bf6f/instructor-1.15.1.tar.gz", hash = "sha256:c72406469d9025b742e83cf0c13e914b317db2089d08d889944e74fcd659ef94", size = 69948370, upload-time = "2026-04-03T01:51:30.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/c8/36c5d9b80aaf40ba9a7084a8fc18c967db6bf248a4cc8d0f0816b14284be/instructor-1.15.1-py3-none-any.whl", hash = "sha256:be81d17ba2b154a04ab4720808f24f9d6b598f80992f82eaf9cc79006099cf6c", size = 178156, upload-time = "2026-04-03T01:51:23.098Z" },
 ]
 
 [[package]]
@@ -2975,12 +2999,12 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:b39cafff7229699f9d6e172cac74d85fd71b568268e439e08d9c540e54732a3e" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:470de4176007c2700735e003a830828a88d27129032a3add07291da07e2a94e8" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:339e05502b6c839db40e88720cb700f5a3b50cda332284873e851772d41b2c1e" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:840351da59cedb7bcbc51981880050813c19ef6b898a7fecf73a3afc71aff3fe" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c88b1129fd4e14f0f882963c6728315caae35d2f47374d17edeed1edc7697497" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f4bea7dc451267c028593751612ad559299589304e68df54ae7672427893ff2c" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:b39cafff7229699f9d6e172cac74d85fd71b568268e439e08d9c540e54732a3e" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:470de4176007c2700735e003a830828a88d27129032a3add07291da07e2a94e8" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:339e05502b6c839db40e88720cb700f5a3b50cda332284873e851772d41b2c1e" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:840351da59cedb7bcbc51981880050813c19ef6b898a7fecf73a3afc71aff3fe" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c88b1129fd4e14f0f882963c6728315caae35d2f47374d17edeed1edc7697497" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f4bea7dc451267c028593751612ad559299589304e68df54ae7672427893ff2c" },
 ]
 
 [[package]]
@@ -3000,27 +3024,27 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-linux_aarch64.whl", hash = "sha256:fd215f3d0f681905c5b56b0630a3d666900a37fcc3ca5b937f95275c66f9fd9c" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:170a0623108055be5199370335cf9b41ba6875b3cb6f086db4aee583331a4899" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e51994492cdb76edce29da88de3672a3022f9ef0ffd90345436948d4992be2c7" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8d316e5bf121f1eab1147e49ad0511a9d92e4c45cc357d1ab0bee440da71a095" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:b719da5af01b59126ac13eefd6ba3dd12d002dc0e8e79b8b365e55267a8189d3" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:b67d91326e4ed9eccbd6b7d84ed7ffa43f93103aa3f0b24145f3001f3b11b714" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-linux_aarch64.whl", hash = "sha256:5af75e5f49de21b0bdf7672bc27139bd285f9e8dbcabe2d617a2eb656514ac36" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-linux_s390x.whl", hash = "sha256:ba51ef01a510baf8fff576174f702c47e1aa54389a9f1fba323bb1a5003ff0bf" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:0fedcb1a77e8f2aaf7bfd21591bf6d1e0b207473268c9be16b17cb7783253969" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:106dd1930cb30a4a337366ba3f9b25318ebf940f51fd46f789281dd9e736bdc4" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:eb1bde1ce198f05c8770017de27e001d404499cf552aaaa014569eff56ca25c0" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-linux_aarch64.whl", hash = "sha256:ea2bcc9d1fca66974a71d4bf9a502539283f35d61fcab5a799b4e120846f1e02" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:f8294fd2fc6dd8f4435a891a0122307a043b14b21f0dac1bca63c85bfb59e586" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a28fdbcfa2fbacffec81300f24dd1bed2b0ccfdbed107a823cff12bc1db070f6" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aada8afc068add586464b2a55adb7cc9091eec55caf5320447204741cb6a0604" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:2adc71fe471e98a608723bfc837f7e1929885ebb912c693597711e139c1cda41" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-linux_aarch64.whl", hash = "sha256:9412bd37b70f5ebd1205242c4ba4cabae35a605947f2b30806d5c9b467936db9" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:e71c476517c33e7db69825a9ff46c7f47a723ec4dac5b2481cff4246d1c632be" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:23882f8d882460aca809882fc42f5e343bf07585274f929ced00177d1be1eb67" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4fcd8b4cc2ae20f2b7749fb275349c55432393868778c2d50a08e81d5ee5591e" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:ffc8da9a1341092d6a90cb5b1c1a33cd61abf0fb43f0cd88443c27fa372c26ae" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-linux_aarch64.whl", hash = "sha256:fd215f3d0f681905c5b56b0630a3d666900a37fcc3ca5b937f95275c66f9fd9c" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:170a0623108055be5199370335cf9b41ba6875b3cb6f086db4aee583331a4899" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e51994492cdb76edce29da88de3672a3022f9ef0ffd90345436948d4992be2c7" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8d316e5bf121f1eab1147e49ad0511a9d92e4c45cc357d1ab0bee440da71a095" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:b719da5af01b59126ac13eefd6ba3dd12d002dc0e8e79b8b365e55267a8189d3" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:b67d91326e4ed9eccbd6b7d84ed7ffa43f93103aa3f0b24145f3001f3b11b714" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-linux_aarch64.whl", hash = "sha256:5af75e5f49de21b0bdf7672bc27139bd285f9e8dbcabe2d617a2eb656514ac36" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-linux_s390x.whl", hash = "sha256:ba51ef01a510baf8fff576174f702c47e1aa54389a9f1fba323bb1a5003ff0bf" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:0fedcb1a77e8f2aaf7bfd21591bf6d1e0b207473268c9be16b17cb7783253969" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:106dd1930cb30a4a337366ba3f9b25318ebf940f51fd46f789281dd9e736bdc4" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:eb1bde1ce198f05c8770017de27e001d404499cf552aaaa014569eff56ca25c0" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-linux_aarch64.whl", hash = "sha256:ea2bcc9d1fca66974a71d4bf9a502539283f35d61fcab5a799b4e120846f1e02" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:f8294fd2fc6dd8f4435a891a0122307a043b14b21f0dac1bca63c85bfb59e586" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a28fdbcfa2fbacffec81300f24dd1bed2b0ccfdbed107a823cff12bc1db070f6" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aada8afc068add586464b2a55adb7cc9091eec55caf5320447204741cb6a0604" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:2adc71fe471e98a608723bfc837f7e1929885ebb912c693597711e139c1cda41" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-linux_aarch64.whl", hash = "sha256:9412bd37b70f5ebd1205242c4ba4cabae35a605947f2b30806d5c9b467936db9" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:e71c476517c33e7db69825a9ff46c7f47a723ec4dac5b2481cff4246d1c632be" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:23882f8d882460aca809882fc42f5e343bf07585274f929ced00177d1be1eb67" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4fcd8b4cc2ae20f2b7749fb275349c55432393868778c2d50a08e81d5ee5591e" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:ffc8da9a1341092d6a90cb5b1c1a33cd61abf0fb43f0cd88443c27fa372c26ae" },
 ]
 
 [[package]]


### PR DESCRIPTION

  - instructor>=1.7 додано
  - OpenAICompatProvider.complete_structured() тепер використовує instructor.from_openai() +
  create_with_completion(response_model=...) замість schema-в-промпті
  - DeepSeek/Mistral/OpenAI отримують schema через tool/function calling + auto-retry з feedback
  - *.mp4 в .gitignore