### PR TITLE
feat: cost tracking fixes, provider-agnostic VD, Mistral vision fallback

### DIFF
--- a/config/external_services.yaml
+++ b/config/external_services.yaml
@@ -87,6 +87,13 @@ providers:
         unit_type: tokens
         cost_per_1k_in: 0.002
         cost_per_1k_out: 0.006
+      - id: mistral-small-latest
+        capabilities: [vision, structured_output]
+        max_context: 131072
+        max_output_tokens: 8192
+        unit_type: tokens
+        cost_per_1k_in: 0.0001
+        cost_per_1k_out: 0.0003
 
   whisper:
     type: transcription
@@ -227,15 +234,17 @@ actions:
     strategy: default
     requires: [vision]
     chain:
-      default: [gemini-2.5-flash, gpt-4o-mini]
+      default: [gemini-2.5-flash, mistral-small-latest, gpt-4o-mini]
 
   vd_frame_analysis:
     strategy: default
     requires: [vision]
     chain:
-      default: [gemini-2.5-flash, gemini-2.5-pro]
+      default: [gemini-2.5-flash, mistral-small-latest, gpt-4o-mini]
+      quality: [gemini-2.5-pro, gemini-2.5-flash]
+      budget: [mistral-small-latest, gpt-4o-mini]
 
   vd_memory:
     strategy: default
     chain:
-      default: [gemini-2.5-flash, gemini-2.5-pro]
+      default: [gemini-2.5-flash, mistral-small-latest]

--- a/scripts/cost_report.py
+++ b/scripts/cost_report.py
@@ -61,7 +61,8 @@ def print_table(report: CostReport) -> str:
             lines.append(f"{indent}(no data)")
         else:
             header = (
-                f"{indent}{'Group':<30} {'Calls':>6} {'Cost':>10} "
+                f"{indent}{'Group':<30} {'Calls':>6} "
+                f"{'OK':>4} {'Fail':>5} {'Cost':>10} "
                 f"{'Units In':>10} {'Units Out':>11} {'Avg ms':>8}"
             )
             lines.append(header)
@@ -69,10 +70,13 @@ def print_table(report: CostReport) -> str:
             for g in groups:
                 lines.append(
                     f"{indent}{g.group:<30} {g.calls:>6} "
+                    f"{g.successful_calls:>4} {g.failed_calls:>5} "
                     f"${g.cost_usd:>9.4f} {g.units_in:>10} "
                     f"{g.units_out:>11} {g.avg_latency_ms:>8.1f}"
                 )
         lines.append("")
+
+    lines.append(f"Note: {report.note}")
 
     return "\n".join(lines)
 

--- a/src/course_supporter/api/routes/materials.py
+++ b/src/course_supporter/api/routes/materials.py
@@ -449,11 +449,14 @@ async def retry_material(
     tenant: PrepDep,
     session: SessionDep,
     arq: ArqDep,
+    force: bool = False,
 ) -> MaterialEntryCreateResponse:
-    """Retry ingestion for a failed material.
+    """Retry ingestion for a material.
 
-    Only materials in ``error`` state can be retried.
-    Returns 409 if the material is not in ``error`` state.
+    By default only materials in ``error`` state can be retried.
+    Pass ``?force=true`` to re-ingest from any state (e.g. to
+    reprocess a ``ready`` material after pipeline improvements).
+    Returns 409 if the material is not retryable without ``force``.
     """
     entry_repo = MaterialEntryRepository(session)
     node_repo = MaterialNodeRepository(session)
@@ -461,11 +464,12 @@ async def retry_material(
         entry_repo, node_repo, entry_id, tenant.tenant_id
     )
 
-    if entry.state != "error":
+    if not force and entry.state != "error":
         raise HTTPException(
             status_code=409,
             detail=(
-                f"Cannot retry: material is in '{entry.state}' state, expected 'error'."
+                f"Cannot retry: material is in '{entry.state}' state, "
+                f"expected 'error'. Use ?force=true to re-ingest."
             ),
         )
 

--- a/src/course_supporter/llm/providers/openai_compat.py
+++ b/src/course_supporter/llm/providers/openai_compat.py
@@ -3,10 +3,14 @@
 Uses ``instructor`` for structured output: tool/function calling
 with automatic retry on validation errors. This is more reliable
 than embedding JSON schema in the system prompt.
+
+Supports multimodal vision requests: when ``LLMRequest.contents``
+contains ``bytes`` items they are sent as base64 inline images.
 """
 
 from __future__ import annotations
 
+import base64
 import itertools
 from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any
@@ -17,6 +21,29 @@ from pydantic import BaseModel
 
 from course_supporter.llm.providers.base import LLMProvider, StructuredOutputError
 from course_supporter.llm.schemas import LLMRequest, LLMResponse
+
+
+def _build_vision_content(
+    images: list[bytes],
+    prompt: str,
+) -> list[dict[str, Any]]:
+    """Build OpenAI vision content parts from raw image bytes + text.
+
+    Each bytes item becomes an inline base64 image_url part.
+    The prompt is appended as a text part.
+    """
+    parts: list[dict[str, Any]] = []
+    for img in images:
+        b64 = base64.b64encode(img).decode("ascii")
+        parts.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{b64}"},
+            }
+        )
+    parts.append({"type": "text", "text": prompt})
+    return parts
+
 
 if TYPE_CHECKING:
     import instructor
@@ -84,12 +111,23 @@ class OpenAICompatProvider(LLMProvider):
         return next(self._instructor_cycle)  # type: ignore[arg-type]
 
     async def complete(self, request: LLMRequest) -> LLMResponse:
-        """Generate text completion via OpenAI-compatible API."""
+        """Generate text completion via OpenAI-compatible API.
+
+        When ``request.contents`` contains bytes items, a multimodal
+        vision message is built with inline base64 images.
+        """
         model = request.model or self._default_model
         messages: list[ChatCompletionMessageParam] = []
         if request.system_prompt:
             messages.append({"role": "system", "content": request.system_prompt})
-        messages.append({"role": "user", "content": request.prompt})
+
+        # Vision path: contents has image bytes
+        image_items = [c for c in (request.contents or []) if isinstance(c, bytes)]
+        if image_items:
+            parts = _build_vision_content(image_items, request.prompt)
+            messages.append({"role": "user", "content": parts})  # type: ignore[arg-type,misc]
+        else:
+            messages.append({"role": "user", "content": request.prompt})
 
         client = self._next_client()
         with self._measure_latency() as timer:

--- a/src/course_supporter/llm/registry.py
+++ b/src/course_supporter/llm/registry.py
@@ -32,6 +32,7 @@ class ProviderModelConfig(BaseModel):
     unit_type: str = "tokens"
     cost_per_1k_in: float = 0.0
     cost_per_1k_out: float = 0.0
+    cost_per_minute: float | None = None
     local: bool = False
 
 
@@ -81,6 +82,7 @@ class ModelConfig(BaseModel):
     max_output_tokens: int | None = None
     unit_type: str = "tokens"
     cost_per_1k: CostPer1K = CostPer1K(input=0.0, output=0.0)
+    cost_per_minute: float | None = None
     local: bool = False
 
     def estimate_cost(self, tokens_in: int, tokens_out: int) -> float:
@@ -133,6 +135,7 @@ class ModelRegistryConfig(BaseModel):
                         input=pm.cost_per_1k_in,
                         output=pm.cost_per_1k_out,
                     ),
+                    cost_per_minute=pm.cost_per_minute,
                     local=pm.local,
                 )
 

--- a/src/course_supporter/llm/router.py
+++ b/src/course_supporter/llm/router.py
@@ -392,11 +392,10 @@ class ModelRouter:
 
         response.action = action
         response.strategy = strategy
-        if response.tokens_in is not None and response.tokens_out is not None:
-            response.cost_usd = model_cfg.estimate_cost(
-                response.tokens_in,
-                response.tokens_out,
-            )
+        tokens_in = response.tokens_in or 0
+        tokens_out = response.tokens_out or 0
+        if tokens_in or tokens_out:
+            response.cost_usd = model_cfg.estimate_cost(tokens_in, tokens_out)
 
     @staticmethod
     def _set_strategy_path(result: _RouterResult, strategy_path: str) -> None:

--- a/src/course_supporter/models/reports.py
+++ b/src/course_supporter/models/reports.py
@@ -20,6 +20,8 @@ class GroupedCost(BaseModel):
 
     group: str
     calls: int
+    successful_calls: int
+    failed_calls: int
     cost_usd: float
     units_in: int
     units_out: int
@@ -29,6 +31,10 @@ class GroupedCost(BaseModel):
 class CostReport(BaseModel):
     """Full cost report with summary and breakdowns."""
 
+    note: str = (
+        "Approximate estimate. "
+        "Actual costs may differ due to provider billing specifics."
+    )
     summary: CostSummary
     by_action: list[GroupedCost]
     by_provider: list[GroupedCost]

--- a/src/course_supporter/storage/repositories.py
+++ b/src/course_supporter/storage/repositories.py
@@ -247,6 +247,12 @@ class ExternalServiceCallRepository:
             select(
                 group_column.label("group"),
                 func.count().label("calls"),
+                func.count()
+                .filter(ExternalServiceCall.success.is_(True))
+                .label("successful_calls"),
+                func.count()
+                .filter(ExternalServiceCall.success.is_(False))
+                .label("failed_calls"),
                 func.coalesce(func.sum(ExternalServiceCall.cost_usd), 0.0).label(
                     "cost_usd"
                 ),
@@ -276,6 +282,8 @@ class ExternalServiceCallRepository:
             GroupedCost(
                 group=row.group,
                 calls=row.calls,
+                successful_calls=row.successful_calls,
+                failed_calls=row.failed_calls,
                 cost_usd=float(row.cost_usd),
                 units_in=int(row.units_in),
                 units_out=int(row.units_out),

--- a/src/course_supporter/stt/providers/openai_stt.py
+++ b/src/course_supporter/stt/providers/openai_stt.py
@@ -13,6 +13,15 @@ from course_supporter.stt.schemas import STTRequest, STTResult, STTSegment
 
 logger = structlog.get_logger()
 
+_MIME_BY_EXT: dict[str, str] = {
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".flac": "audio/flac",
+    ".ogg": "audio/ogg",
+    ".m4a": "audio/mp4",
+    ".webm": "audio/webm",
+}
+
 
 class OpenAISTTProvider(STTProvider):
     """OpenAI transcription via official SDK.
@@ -48,12 +57,14 @@ class OpenAISTTProvider(STTProvider):
         response_format = "verbose_json" if model.startswith("whisper") else "json"
 
         audio_bytes = await asyncio.to_thread(audio_path.read_bytes)
+        suffix = audio_path.suffix or ".wav"
+        mime = _MIME_BY_EXT.get(suffix, "audio/wav")
 
         client = self._next_client()
         with self._measure_latency() as timer:
             result = await client.audio.transcriptions.create(  # type: ignore[call-overload]
                 model=model,
-                file=audio_bytes,
+                file=(f"audio{suffix}", audio_bytes, mime),
                 language=request.language or "",
                 response_format=response_format,
             )

--- a/src/course_supporter/vd/visual_analyzer.py
+++ b/src/course_supporter/vd/visual_analyzer.py
@@ -301,28 +301,16 @@ class VisualAnalyzer:
         prev_result: EyesResult | None,
     ) -> EyesResult:
         """Analyze a single frame with Vision LLM."""
-        from google.genai import types as genai_types
-
-        parts: list[Any] = []
+        images: list[bytes] = []
 
         # Context images (previous frames, oldest first)
         for cf in context_frames:
             img_path = self._find_frame(frame_dir, cf.filename)
-            parts.append(
-                genai_types.Part.from_bytes(
-                    data=img_path.read_bytes(),
-                    mime_type="image/jpeg",
-                ),
-            )
+            images.append(img_path.read_bytes())
 
         # Main image (current frame — LAST image per prompt)
         main_path = self._find_frame(frame_dir, frame.filename)
-        parts.append(
-            genai_types.Part.from_bytes(
-                data=main_path.read_bytes(),
-                mime_type="image/jpeg",
-            ),
-        )
+        images.append(main_path.read_bytes())
 
         # Build prompt text based on strategy
         prompt = self._build_prompt(
@@ -332,10 +320,9 @@ class VisualAnalyzer:
             prev_result=prev_result,
             frame=frame,
         )
-        parts.append(genai_types.Part.from_text(text=prompt))
 
         # Rate-limited API call via ModelRouter
-        api_result = await self._call_llm(parts)
+        api_result = await self._call_llm(images, prompt=prompt)
 
         # Parse response
         response_text = api_result["text"]
@@ -371,23 +358,20 @@ class VisualAnalyzer:
 
     async def _call_llm(
         self,
-        parts: list[Any],
+        images: list[bytes],
         *,
+        prompt: str,
         _max_retries: int = 3,
     ) -> dict[str, Any]:
         """Rate-limited Vision LLM call via ModelRouter with retry on 429."""
-        from google.genai import types as genai_types
-
-        contents: list[Any] = [genai_types.Content(parts=parts)]
-
         for attempt in range(_max_retries + 1):
             await self._rate_limiter.acquire()
             t0 = time.monotonic()
             try:
                 response = await self._router.complete(
                     action="vd_frame_analysis",
-                    prompt="",
-                    contents=contents,
+                    prompt=prompt,
+                    contents=images,
                 )
                 latency = round(time.monotonic() - t0, 2)
                 logger.info(

--- a/tests/unit/test_cost_report.py
+++ b/tests/unit/test_cost_report.py
@@ -111,6 +111,8 @@ class TestExternalServiceCallRepositoryGrouped:
                 {
                     "group": "architect",
                     "calls": 3,
+                    "successful_calls": 2,
+                    "failed_calls": 1,
                     "cost_usd": 0.01,
                     "units_in": 3000,
                     "units_out": 1500,
@@ -119,6 +121,8 @@ class TestExternalServiceCallRepositoryGrouped:
                 {
                     "group": "summarize",
                     "calls": 2,
+                    "successful_calls": 2,
+                    "failed_calls": 0,
                     "cost_usd": 0.005,
                     "units_in": 2000,
                     "units_out": 500,
@@ -134,7 +138,11 @@ class TestExternalServiceCallRepositoryGrouped:
         assert len(groups) == 2
         assert groups[0].group == "architect"
         assert groups[0].calls == 3
+        assert groups[0].successful_calls == 2
+        assert groups[0].failed_calls == 1
         assert groups[1].group == "summarize"
+        assert groups[1].successful_calls == 2
+        assert groups[1].failed_calls == 0
 
     async def test_get_by_provider_groups(self) -> None:
         """GROUP BY provider returns correct groups."""
@@ -145,6 +153,8 @@ class TestExternalServiceCallRepositoryGrouped:
                 {
                     "group": "gemini",
                     "calls": 4,
+                    "successful_calls": 3,
+                    "failed_calls": 1,
                     "cost_usd": 0.008,
                     "units_in": 4000,
                     "units_out": 1800,
@@ -170,6 +180,8 @@ class TestExternalServiceCallRepositoryGrouped:
                 {
                     "group": "gemini-2.0-flash",
                     "calls": 3,
+                    "successful_calls": 3,
+                    "failed_calls": 0,
                     "cost_usd": 0.006,
                     "units_in": 3000,
                     "units_out": 1500,
@@ -206,6 +218,8 @@ class TestCostReportAPI:
                 GroupedCost(
                     group="architect",
                     calls=2,
+                    successful_calls=2,
+                    failed_calls=0,
                     cost_usd=0.005,
                     units_in=1000,
                     units_out=500,
@@ -289,6 +303,7 @@ class TestCostReportAPI:
         assert report.summary.total_calls == 2
         assert len(report.by_action) == 1
         assert report.by_action[0].group == "architect"
+        assert "Approximate" in report.note
 
 
 class TestCostReportCLI:
@@ -312,6 +327,8 @@ class TestCostReportCLI:
                 GroupedCost(
                     group="architect",
                     calls=3,
+                    successful_calls=2,
+                    failed_calls=1,
                     cost_usd=0.0075,
                     units_in=3000,
                     units_out=1500,
@@ -326,6 +343,7 @@ class TestCostReportCLI:
         assert "3000" in table
         assert "architect" in table
         assert "By Action" in table
+        assert "Approximate" in table
 
     def test_cli_json_output(self) -> None:
         """CostReport serializes to valid JSON."""

--- a/tests/unit/test_llm/test_registry.py
+++ b/tests/unit/test_llm/test_registry.py
@@ -87,6 +87,14 @@ class TestModelConfig:
         )
         assert m.estimate_cost(0, 0) == 0.0
 
+    def test_cost_per_minute_default_none(self) -> None:
+        m = ModelConfig(provider="test")
+        assert m.cost_per_minute is None
+
+    def test_cost_per_minute_set(self) -> None:
+        m = ModelConfig(provider="stt", cost_per_minute=0.0037)
+        assert m.cost_per_minute == pytest.approx(0.0037)
+
 
 class TestRegistryValidation:
     def test_valid_config_loads(self, valid_config: dict) -> None:
@@ -114,6 +122,29 @@ class TestRegistryValidation:
         m = cfg.models["model-a"]
         assert m.cost_per_1k.input == pytest.approx(0.001)
         assert m.cost_per_1k.output == pytest.approx(0.002)
+
+    def test_cost_per_minute_parsed(self, valid_config: dict) -> None:
+        """STT models with cost_per_minute get it propagated to ModelConfig."""
+        valid_config["providers"]["stt_provider"] = {
+            "type": "stt",
+            "models": [
+                {
+                    "id": "stt-model",
+                    "unit_type": "minutes",
+                    "cost_per_minute": 0.0037,
+                },
+            ],
+        }
+        valid_config["actions"]["transcribe"] = {
+            "chain": {"default": ["stt-model"]},
+        }
+        cfg = ModelRegistryConfig.model_validate(valid_config)
+        assert cfg.models["stt-model"].cost_per_minute == pytest.approx(0.0037)
+
+    def test_cost_per_minute_absent(self, valid_config: dict) -> None:
+        """LLM models without cost_per_minute have None."""
+        cfg = ModelRegistryConfig.model_validate(valid_config)
+        assert cfg.models["model-a"].cost_per_minute is None
 
     def test_unknown_model_in_chain(self, valid_config: dict) -> None:
         valid_config["actions"]["analyze"]["chain"]["default"] = ["nonexistent"]

--- a/tests/unit/test_llm/test_router.py
+++ b/tests/unit/test_llm/test_router.py
@@ -217,7 +217,7 @@ class TestCostEnrichment:
         assert r.cost_usd is not None
         assert r.cost_usd > 0
 
-    async def test_cost_none_when_tokens_missing(self) -> None:
+    async def test_cost_none_when_both_tokens_missing(self) -> None:
         resp = _resp()
         resp.tokens_in = None
         resp.tokens_out = None
@@ -226,6 +226,30 @@ class TestCostEnrichment:
             _registry(),
         ).complete("act", "hi")
         assert r.cost_usd is None
+
+    async def test_cost_estimated_with_partial_tokens_in(self) -> None:
+        """Cost calculated when only tokens_in is available (e.g. vision)."""
+        resp = _resp()
+        resp.tokens_in = 2000
+        resp.tokens_out = None
+        r = await ModelRouter(
+            {"p_a": _ok_provider(resp)},
+            _registry(),
+        ).complete("act", "hi")
+        assert r.cost_usd is not None
+        assert r.cost_usd > 0
+
+    async def test_cost_estimated_with_partial_tokens_out(self) -> None:
+        """Cost calculated when only tokens_out is available."""
+        resp = _resp()
+        resp.tokens_in = None
+        resp.tokens_out = 500
+        r = await ModelRouter(
+            {"p_a": _ok_provider(resp)},
+            _registry(),
+        ).complete("act", "hi")
+        assert r.cost_usd is not None
+        assert r.cost_usd > 0
 
 
 class TestLogCallback:

--- a/tests/unit/test_stt/test_router.py
+++ b/tests/unit/test_stt/test_router.py
@@ -61,6 +61,21 @@ class TestSTTRouterHappyPath:
         assert result.action == "transcribe"
         assert result.strategy == "quality"
 
+    async def test_cost_calculated_from_cost_per_minute(self) -> None:
+        """STT cost is computed from cost_per_minute when available."""
+        stt_result = _make_result()
+        stt_result.audio_duration_sec = 120.0  # 2 minutes
+        provider = _make_provider(result=stt_result)
+        cfg = _make_model_cfg()
+        cfg.cost_per_minute = 0.006  # $0.006/min
+        registry = _make_registry([cfg])
+
+        router = STTRouter({"test": provider}, registry)
+        result = await router.transcribe("transcribe", "/tmp/a.mp3")
+
+        assert result.cost_usd is not None
+        assert result.cost_usd == pytest.approx(0.012, abs=1e-6)  # 2 min x $0.006
+
 
 class TestSTTRouterFallback:
     async def test_fallback_within_chain(self) -> None:

--- a/tests/unit/test_vd_visual_analyzer.py
+++ b/tests/unit/test_vd_visual_analyzer.py
@@ -478,8 +478,7 @@ class TestCallLlm:
         )
         analyzer._router.complete = AsyncMock(return_value=mock_resp)
 
-        with patch("google.genai.types.Content"):
-            result = await analyzer._call_llm([MagicMock()])
+        result = await analyzer._call_llm([b"fake-image"], prompt="describe")
 
         assert result["text"] == "LLM response"
         assert result["input_tokens"] == 100
@@ -496,11 +495,8 @@ class TestCallLlm:
         )
         analyzer._router.complete = AsyncMock(side_effect=[rate_err, mock_resp])
 
-        with (
-            patch("google.genai.types.Content"),
-            patch("asyncio.sleep", new=AsyncMock()),
-        ):
-            result = await analyzer._call_llm([MagicMock()])
+        with patch("asyncio.sleep", new=AsyncMock()):
+            result = await analyzer._call_llm([b"fake-image"], prompt="describe")
 
         assert result["text"] == "OK"
         assert analyzer._router.complete.await_count == 2


### PR DESCRIPTION
- Fix STT cost tracking: add cost_per_minute to ModelConfig, parse from YAML
- Fix partial token estimation: calculate cost when only tokens_in or tokens_out available
- Cost report: add "approximate estimate" note, success/fail breakdown per group
- Fix OpenAI STT "Unsupported file format": pass (filename, bytes, mime) tuple
- Refactor VD to generic vision: remove google.genai dependency from VisualAnalyzer, pass raw image bytes through ModelRouter contents
- Add vision support to OpenAICompatProvider: base64 inline images for OpenAI/Mistral
- Add mistral-small-latest with vision capability ($0.1/1M in)
- VD fallback chain: gemini-2.5-flash → mistral-small-latest → gpt-4o-mini
- Add ?force=true to POST /materials/{id}/retry for re-ingestion from any state