### PR TITLE
PR: Language pipeline + провайдери + cost tracking + log rotation

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,3 +1,20 @@
+# ─── Log rotation defaults ───
+# Caps each container's on-disk log size. Total per service:
+#   app/worker (verbose, DEBUG on E2E): 50MB × 5 = 250MB max
+#   infra (postgres/redis/netdata):     10MB × 3 = 30MB  max
+# Docker keeps max-file rotated files; oldest is dropped when full.
+x-logging-app: &logging-app
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "5"
+
+x-logging-infra: &logging-infra
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   app:
     build:
@@ -6,6 +23,7 @@ services:
     container_name: course-supporter-app
     restart: unless-stopped
     env_file: .env.prod
+    logging: *logging-app
     depends_on:
       postgres-cs:
         condition: service_healthy
@@ -25,6 +43,7 @@ services:
     env_file: .env.prod
     command: ["python", "-m", "arq", "course_supporter.worker.WorkerSettings"]
     expose: []
+    logging: *logging-app
     healthcheck:
       disable: true
     depends_on:
@@ -46,6 +65,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-course_supporter}
     volumes:
       - pgdata-cs:/var/lib/postgresql/data
+    logging: *logging-infra
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-course_supporter}"]
       interval: 10s
@@ -61,6 +81,7 @@ services:
     command: redis-server --appendonly yes --maxmemory 128mb --maxmemory-policy noeviction
     volumes:
       - redis-data:/data
+    logging: *logging-infra
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -87,6 +108,7 @@ services:
     environment:
       - DO_NOT_TRACK=1
       - NETDATA_CLAIM_TOKEN=
+    logging: *logging-infra
     deploy:
       resources:
         limits:

--- a/migrations/versions/a1b2c3d4e5f6_add_language_fields.py
+++ b/migrations/versions/a1b2c3d4e5f6_add_language_fields.py
@@ -1,0 +1,60 @@
+"""add_language_fields_to_material_entries_and_nodes
+
+Adds:
+- material_nodes.default_language (ISO 639-1, usually set on root/course)
+- material_entries.language (ISO 639-1, overrides course default; also
+  populated from STT auto-detection on first successful transcription)
+
+Revision ID: a1b2c3d4e5f6
+Revises: 606fdf83013b
+Create Date: 2026-04-12 10:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "606fdf83013b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add language columns to material_nodes and material_entries."""
+    op.add_column(
+        "material_nodes",
+        sa.Column(
+            "default_language",
+            sa.String(length=10),
+            nullable=True,
+            comment=(
+                "Default ISO 639-1 language for materials under this subtree. "
+                "Usually set on the root (course) node; inherited by children "
+                "and their materials unless overridden on the material itself."
+            ),
+        ),
+    )
+    op.add_column(
+        "material_entries",
+        sa.Column(
+            "language",
+            sa.String(length=10),
+            nullable=True,
+            comment=(
+                "ISO 639-1 language of the material. NULL = inherit from course "
+                "(root MaterialNode.default_language) or auto-detect at STT "
+                "time. Auto-detected language is cached back to this column on "
+                "first success."
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop language columns."""
+    op.drop_column("material_entries", "language")
+    op.drop_column("material_nodes", "default_language")

--- a/src/course_supporter/api/routes/materials.py
+++ b/src/course_supporter/api/routes/materials.py
@@ -135,6 +135,16 @@ async def create_material(
         str | None,
         Form(description="Override filename (optional, defaults to uploaded name)."),
     ] = None,
+    language: Annotated[
+        str | None,
+        Form(
+            description=(
+                "Optional ISO 639-1 language override. When empty, the course "
+                "default is used and STT falls back to auto-detection."
+            ),
+            pattern=r"^[a-z]{2}$",
+        ),
+    ] = None,
 ) -> MaterialEntryCreateResponse:
     """Add a new material to a tree node.
 
@@ -197,6 +207,7 @@ async def create_material(
         source_url=actual_url,
         filename=actual_filename,
         material_role=material_role,
+        language=language,
     )
 
     job = await enqueue_ingestion(
@@ -320,6 +331,7 @@ async def confirm_upload(
         source_url=s3_url,
         filename=actual_filename,
         material_role=body.material_role,
+        language=body.language,
     )
 
     job = await enqueue_ingestion(

--- a/src/course_supporter/api/routes/nodes.py
+++ b/src/course_supporter/api/routes/nodes.py
@@ -143,6 +143,7 @@ async def create_root_node(
         tenant_id=tenant.tenant_id,
         title=body.title,
         description=body.description,
+        default_language=body.default_language,
     )
     await session.commit()
 
@@ -208,6 +209,7 @@ async def create_child_node(
         parent_materialnode_id=node_id,
         title=body.title,
         description=body.description,
+        default_language=body.default_language,
     )
     await session.commit()
 

--- a/src/course_supporter/api/routes/nodes.py
+++ b/src/course_supporter/api/routes/nodes.py
@@ -287,10 +287,12 @@ async def update_node(
     tenant: PrepDep,
     session: SessionDep,
 ) -> NodeResponse:
-    """Update a node's title and/or description.
+    """Update a node's title, description, and/or default language.
 
     Only fields present in the request body are updated.
-    To clear the description, send ``"description": null``.
+    To clear a field, send it as ``null``. Updating
+    ``default_language`` is a pure DB write — it does not trigger
+    re-ingestion of existing materials.
     """
     await _require_node_for_tenant(session, tenant.tenant_id, node_id)
     repo = MaterialNodeRepository(session)
@@ -301,6 +303,8 @@ async def update_node(
         update_kwargs["title"] = body.title
     if "description" in body.model_fields_set:
         update_kwargs["description"] = body.description
+    if "default_language" in body.model_fields_set:
+        update_kwargs["default_language"] = body.default_language
 
     node = await repo.update(node_id, **update_kwargs)
     await session.commit()

--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -190,6 +190,16 @@ class NodeCreateRequest(BaseModel):
         description="Optional detailed description of the node's purpose.",
         examples=["Overview of the foundational concepts covered in this module."],
     )
+    default_language: str | None = Field(
+        default=None,
+        pattern=r"^[a-z]{2}$",
+        description=(
+            "Optional ISO 639-1 language for materials under this node. "
+            "Usually set on the root/course node; inherited by materials "
+            "unless overridden. Leave empty to rely on STT auto-detection."
+        ),
+        examples=["uk", "en"],
+    )
 
 
 class NodeUpdateRequest(BaseModel):
@@ -288,6 +298,10 @@ class NodeResponse(BaseModel):
     )
     expected_skills: list[str] | None = Field(
         default=None, description="Expected skills items."
+    )
+    default_language: str | None = Field(
+        default=None,
+        description=("Default ISO 639-1 language for materials under this subtree."),
     )
     order: int = Field(description="0-based position among siblings.")
     node_fingerprint: str | None = Field(
@@ -457,6 +471,15 @@ class MaterialEntryCreateRequest(BaseModel):
         description="Original filename for display purposes.",
         examples=["slides.pdf", "lecture-01.mp4"],
     )
+    language: str | None = Field(
+        default=None,
+        pattern=r"^[a-z]{2}$",
+        description=(
+            "Optional ISO 639-1 language override. When absent, the course "
+            "default is used, and STT auto-detection is the final fallback."
+        ),
+        examples=["uk", "en"],
+    )
 
 
 class MaterialEntryUpdateRequest(BaseModel):
@@ -484,6 +507,12 @@ class MaterialEntryResponse(BaseModel):
     )
     source_url: str = Field(description="URL or S3 path to the raw material.")
     filename: str | None = Field(description="Original filename, if available.")
+    language: str | None = Field(
+        default=None,
+        description=(
+            "ISO 639-1 language. ``null`` when unset and not yet auto-detected."
+        ),
+    )
     order: int = Field(description="0-based position among sibling materials.")
     state: str = Field(
         description=(
@@ -522,6 +551,12 @@ class MaterialEntryCreateResponse(BaseModel):
     )
     source_url: str = Field(description="URL or S3 path to the raw material.")
     filename: str | None = Field(description="Original filename, if available.")
+    language: str | None = Field(
+        default=None,
+        description=(
+            "ISO 639-1 language. ``null`` when unset and not yet auto-detected."
+        ),
+    )
     order: int = Field(description="0-based position among sibling materials.")
     state: str = Field(
         description="Derived lifecycle state (will be ``raw`` or ``pending``)."
@@ -923,6 +958,15 @@ class ConfirmUploadRequest(BaseModel):
         default=None,
         max_length=500,
         description="Override filename (defaults to key basename).",
+    )
+    language: str | None = Field(
+        default=None,
+        pattern=r"^[a-z]{2}$",
+        description=(
+            "Optional ISO 639-1 language override. When absent, the course "
+            "default is used, and STT auto-detection is the final fallback."
+        ),
+        examples=["uk", "en"],
     )
 
 

--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -229,6 +229,17 @@ class NodeUpdateRequest(BaseModel):
             "``model_fields_set``."
         ),
     )
+    default_language: str | None = Field(
+        default=None,
+        pattern=r"^[a-z]{2}$",
+        description=(
+            "New default ISO 639-1 language for this subtree. "
+            "Send ``null`` to clear, omit to keep unchanged. "
+            "Setting it is a pure DB write; does NOT trigger re-ingestion of "
+            "existing materials. New uploads and explicit retries will pick it up."
+        ),
+        examples=["uk", "en"],
+    )
 
 
 class NodeMoveRequest(BaseModel):

--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -130,6 +130,9 @@ async def arq_ingest_material(
     from course_supporter.storage.material_entry_repository import (
         MaterialEntryRepository,
     )
+    from course_supporter.storage.material_node_repository import (
+        MaterialNodeRepository,
+    )
 
     check_work_window(JobPriority(priority))
 
@@ -156,14 +159,30 @@ async def arq_ingest_material(
     processors = create_processors(heavy, vd_pipeline=vd, stt_router=stt_router)
     s3: S3Client | None = ctx.get("s3_client")
 
+    detected_language: str | None = None
+
     async with session_factory() as session:
         job_repo = JobRepository(session)
         entry_repo = MaterialEntryRepository(session)
+        node_repo = MaterialNodeRepository(session)
 
         entry = await entry_repo.get_by_id(mid)
         if entry is None:
             log.error("material_entry_not_found", material_id=material_id)
             return
+
+        # Resolve effective language: entry override → course default → None.
+        # When None, STT will auto-detect and return detected_language which
+        # we persist back to the entry after successful ingestion.
+        if entry.language is None:
+            root = await node_repo.get_root_for(entry.materialnode_id)
+            if root is not None and root.default_language:
+                entry.language = root.default_language
+                log.debug(
+                    "language_inherited_from_course",
+                    language=entry.language,
+                    root_id=str(root.id),
+                )
 
         try:
             await job_repo.update_status(jid, "active")
@@ -181,6 +200,7 @@ async def arq_ingest_material(
                 doc = await processor.process(resolved, router=router)
 
             content = doc.model_dump_json()
+            detected_language = doc.metadata.get("detected_language")
 
         except Exception as exc:
             await session.rollback()
@@ -191,6 +211,19 @@ async def arq_ingest_material(
             )
             log.error("ingestion_failed", error=str(exc))
             return
+
+    # Cache auto-detected language back to the entry for future STT calls.
+    if detected_language:
+        async with session_factory() as session:
+            entry_repo = MaterialEntryRepository(session)
+            cached = await entry_repo.get_by_id(mid)
+            if cached is not None and cached.language is None:
+                cached.language = detected_language
+                await session.commit()
+                log.info(
+                    "language_auto_detected_cached",
+                    language=detected_language,
+                )
 
     await callback.on_success(
         job_id=jid,

--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -213,13 +213,14 @@ async def arq_ingest_material(
             return
 
     # Cache auto-detected language back to the entry for future STT calls.
+    # Uses an atomic UPDATE ... WHERE language IS NULL to avoid a race
+    # where a concurrent PATCH may set language between our check and write.
     if detected_language:
         async with session_factory() as session:
             entry_repo = MaterialEntryRepository(session)
-            cached = await entry_repo.get_by_id(mid)
-            if cached is not None and cached.language is None:
-                cached.language = detected_language
-                await session.commit()
+            updated = await entry_repo.set_language_if_unset(mid, detected_language)
+            await session.commit()
+            if updated:
                 log.info(
                     "language_auto_detected_cached",
                     language=detected_language,

--- a/src/course_supporter/ingestion/video.py
+++ b/src/course_supporter/ingestion/video.py
@@ -465,12 +465,16 @@ class VideoProcessor(SourceProcessor):
                 f"VideoProcessor expects 'video', got '{source.source_type}'"
             )
 
-        logger.info("video_processor_start", source_url=source.source_url)
+        logger.info(
+            "video_processor_start",
+            source_url=source.source_url,
+            language=source.language,
+        )
 
         video_path = await self._resolve_local_path(source.source_url)
 
         # Launch STT and VD in parallel
-        stt_task = asyncio.create_task(self._run_stt(video_path))
+        stt_task = asyncio.create_task(self._run_stt(video_path, source.language))
         vd_task: asyncio.Task[list[ContentChunk]] | None = (
             asyncio.create_task(self._run_vd(video_path))
             if self._vd is not None
@@ -478,7 +482,7 @@ class VideoProcessor(SourceProcessor):
         )
 
         # Wait for STT (required)
-        stt_chunks = await stt_task
+        stt_chunks, detected_language = await stt_task
 
         # Wait for VD (optional, graceful degradation)
         vd_chunks: list[ContentChunk] = []
@@ -498,18 +502,23 @@ class VideoProcessor(SourceProcessor):
             stt_chunks=len(stt_chunks),
             vd_chunks=len(vd_chunks),
             strategy=strategy,
+            detected_language=detected_language,
         )
+
+        metadata: dict[str, Any] = {
+            "strategy": strategy,
+            "stt_segments": len(stt_chunks),
+            "vd_scenes": len(vd_chunks),
+        }
+        if detected_language:
+            metadata["detected_language"] = detected_language
 
         return SourceDocument(
             source_type=SourceType.VIDEO,
             source_url=source.source_url,
             title=source.filename or "",
             chunks=stt_chunks + vd_chunks,
-            metadata={
-                "strategy": strategy,
-                "stt_segments": len(stt_chunks),
-                "vd_scenes": len(vd_chunks),
-            },
+            metadata=metadata,
         )
 
     @staticmethod
@@ -534,15 +543,24 @@ class VideoProcessor(SourceProcessor):
             raise ProcessingError(f"Video file not found: {video_path}")
         return video_path
 
-    async def _run_stt(self, video_path: Path) -> list[ContentChunk]:
-        """Extract audio and transcribe via STT Router."""
+    async def _run_stt(
+        self, video_path: Path, language: str | None
+    ) -> tuple[list[ContentChunk], str | None]:
+        """Extract audio and transcribe via STT Router.
+
+        Returns:
+            (chunks, detected_language) tuple. ``detected_language`` is
+            the provider-reported language when ``language`` was None,
+            otherwise None. Upstream persists this back to the material.
+        """
         audio_path = await _extract_audio_ffmpeg(str(video_path))
         try:
             result = await self._stt_router.transcribe(
                 action="transcribe",
                 audio_path=audio_path,
+                language=language,
             )
-            return self._stt_result_to_chunks(result)
+            return self._stt_result_to_chunks(result), result.detected_language
         finally:
             with contextlib.suppress(OSError):
                 await asyncio.to_thread(Path(audio_path).unlink)

--- a/src/course_supporter/logging_config.py
+++ b/src/course_supporter/logging_config.py
@@ -81,3 +81,8 @@ def configure_logging(
     # Quiet noisy libraries
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
     logging.getLogger("aiobotocore").setLevel(logging.WARNING)
+    logging.getLogger("botocore").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+    logging.getLogger("openai").setLevel(logging.WARNING)

--- a/src/course_supporter/storage/material_entry_repository.py
+++ b/src/course_supporter/storage/material_entry_repository.py
@@ -31,6 +31,7 @@ class MaterialEntryRepository:
         source_url: str,
         filename: str | None = None,
         material_role: str = "educational",
+        language: str | None = None,
     ) -> MaterialEntry:
         """Create a new material entry with auto-incremented order.
 
@@ -40,6 +41,9 @@ class MaterialEntryRepository:
             source_url: URL or storage path for the raw material.
             filename: Original filename (for uploads).
             material_role: Role: educational or methodological.
+            language: Optional ISO 639-1 language override. When None,
+                the course default is used and STT falls back to
+                auto-detection (which caches its result back here).
 
         Returns:
             The newly created MaterialEntry.
@@ -51,6 +55,7 @@ class MaterialEntryRepository:
             source_url=source_url,
             filename=filename,
             material_role=material_role,
+            language=language,
             order=next_order,
         )
         self._session.add(entry)

--- a/src/course_supporter/storage/material_entry_repository.py
+++ b/src/course_supporter/storage/material_entry_repository.py
@@ -114,8 +114,10 @@ class MaterialEntryRepository:
             .execution_options(synchronize_session=False)
         )
         result = await self._session.execute(stmt)
-        # rowcount is exposed via CursorResult; cast for mypy strictness.
-        return int(result.rowcount or 0) > 0  # type: ignore[attr-defined]
+        # ``rowcount`` is provided by CursorResult (actual runtime type
+        # for DML execute); SQLAlchemy's static return type is the wider
+        # ``Result`` which does not expose it — hence the ignore.
+        return (result.rowcount or 0) > 0  # type: ignore[attr-defined]
 
     async def set_pending(
         self,

--- a/src/course_supporter/storage/material_entry_repository.py
+++ b/src/course_supporter/storage/material_entry_repository.py
@@ -6,7 +6,7 @@ import hashlib
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from course_supporter.models.source import MaterialRole
@@ -91,6 +91,31 @@ class MaterialEntryRepository:
         stmt = select(MaterialEntry).where(MaterialEntry.source_url == source_url)
         result = await self._session.execute(stmt)
         return result.scalars().first()
+
+    async def set_language_if_unset(
+        self,
+        entry_id: uuid.UUID,
+        language: str,
+    ) -> bool:
+        """Atomically set ``language`` only if it is currently NULL.
+
+        Guards against races where a concurrent PATCH may set the
+        language between our read and write. Returns True if the row
+        was updated, False if it was skipped because the language
+        was already set (or the row does not exist).
+        """
+        stmt = (
+            update(MaterialEntry)
+            .where(
+                MaterialEntry.id == entry_id,
+                MaterialEntry.language.is_(None),
+            )
+            .values(language=language)
+            .execution_options(synchronize_session=False)
+        )
+        result = await self._session.execute(stmt)
+        # rowcount is exposed via CursorResult; cast for mypy strictness.
+        return int(result.rowcount or 0) > 0  # type: ignore[attr-defined]
 
     async def set_pending(
         self,

--- a/src/course_supporter/storage/material_node_repository.py
+++ b/src/course_supporter/storage/material_node_repository.py
@@ -86,6 +86,7 @@ class MaterialNodeRepository:
         title: str,
         parent_materialnode_id: uuid.UUID | None = None,
         description: str | None = None,
+        default_language: str | None = None,
     ) -> MaterialNode:
         """Create a new node with auto-incremented order among siblings.
 
@@ -94,6 +95,8 @@ class MaterialNodeRepository:
             title: Node title.
             parent_materialnode_id: FK to parent node (None for root).
             description: Optional node description.
+            default_language: Optional ISO 639-1 default language for
+                materials under this node (inherited by children).
 
         Returns:
             The newly created MaterialNode.
@@ -104,6 +107,7 @@ class MaterialNodeRepository:
             parent_materialnode_id=parent_materialnode_id,
             title=title,
             description=description,
+            default_language=default_language,
             order=next_order,
         )
         self._session.add(node)
@@ -113,6 +117,38 @@ class MaterialNodeRepository:
     async def get_by_id(self, node_id: uuid.UUID) -> MaterialNode | None:
         """Get a node by primary key."""
         return await self._session.get(MaterialNode, node_id)
+
+    async def get_root_for(self, node_id: uuid.UUID) -> MaterialNode | None:
+        """Walk up the parent chain to find the root (course) node.
+
+        Uses a recursive CTE to traverse ``parent_materialnode_id``
+        links up to the first node whose parent is NULL. Returns None
+        if the starting node does not exist.
+        """
+        # Recursive CTE: start at node_id, climb up via parent FK.
+        ancestor_cte = (
+            select(
+                MaterialNode.id,
+                MaterialNode.parent_materialnode_id,
+            )
+            .where(MaterialNode.id == node_id)
+            .cte(name="ancestors", recursive=True)
+        )
+        ancestor_cte = ancestor_cte.union_all(
+            select(
+                MaterialNode.id,
+                MaterialNode.parent_materialnode_id,
+            ).where(MaterialNode.id == ancestor_cte.c.parent_materialnode_id),
+        )
+        root_id_stmt = (
+            select(ancestor_cte.c.id)
+            .where(ancestor_cte.c.parent_materialnode_id.is_(None))
+            .limit(1)
+        )
+        root_id = (await self._session.execute(root_id_stmt)).scalar_one_or_none()
+        if root_id is None:
+            return None
+        return await self._session.get(MaterialNode, root_id)
 
     async def get_roots(self, tenant_id: uuid.UUID) -> list[MaterialNode]:
         """Get root nodes (parent_materialnode_id=None) for a tenant, ordered."""

--- a/src/course_supporter/storage/material_node_repository.py
+++ b/src/course_supporter/storage/material_node_repository.py
@@ -121,9 +121,14 @@ class MaterialNodeRepository:
     async def get_root_for(self, node_id: uuid.UUID) -> MaterialNode | None:
         """Walk up the parent chain to find the root (course) node.
 
-        Uses a recursive CTE to traverse ``parent_materialnode_id``
-        links up to the first node whose parent is NULL. Returns None
-        if the starting node does not exist.
+        Uses a recursive CTE to traverse ``parent_materialnode_id`` links
+        to the first node whose parent is NULL. Returns None if the
+        starting node does not exist.
+
+        Performance note: a single recursive CTE query is preferred over
+        an iterative loop of round-trips because course trees are shallow
+        in practice (typically 3-7 levels), and a single DB call beats
+        N sequential ``session.get`` calls over the wire.
         """
         # Recursive CTE: start at node_id, climb up via parent FK.
         ancestor_cte = (
@@ -353,6 +358,7 @@ class MaterialNodeRepository:
         *,
         title: str | None = None,
         description: str | None | _Unset = _Unset.TOKEN,
+        default_language: str | None | _Unset = _Unset.TOKEN,
     ) -> MaterialNode:
         """Update node fields.
 
@@ -360,6 +366,8 @@ class MaterialNodeRepository:
             node_id: UUID of the node.
             title: New title (if provided).
             description: New description (None to clear, _Unset to skip).
+            default_language: New default language
+                (None to clear, _Unset to skip).
 
         Returns:
             Updated MaterialNode.
@@ -376,6 +384,8 @@ class MaterialNodeRepository:
             node.title = title
         if not isinstance(description, _Unset):
             node.description = description
+        if not isinstance(default_language, _Unset):
+            node.default_language = default_language
 
         await self._session.flush()
         return node

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -149,6 +149,12 @@ class MaterialNode(Base):
     )
     expected_knowledge: Mapped[list[str] | None] = mapped_column(JSONB)
     expected_skills: Mapped[list[str] | None] = mapped_column(JSONB)
+    default_language: Mapped[str | None] = mapped_column(
+        String(10),
+        comment="Default ISO 639-1 language for materials under this subtree. "
+        "Usually set on the root (course) node; inherited by children and "
+        "their materials unless overridden on the material itself.",
+    )
     order: Mapped[int] = mapped_column(Integer, default=0)
     node_fingerprint: Mapped[str | None] = mapped_column(
         String(64),
@@ -264,6 +270,14 @@ class MaterialEntry(Base):
         comment="SHA-256 of uploaded raw file for integrity detection",
     )
     raw_size_bytes: Mapped[int | None] = mapped_column(Integer)
+
+    # ── Language ──
+    language: Mapped[str | None] = mapped_column(
+        String(10),
+        comment="ISO 639-1 language of the material. NULL = inherit from course "
+        "(root MaterialNode.default_language) or auto-detect at STT time. "
+        "Auto-detected language is cached back to this column on first success.",
+    )
 
     # ── Processed layer ──
     processed_hash: Mapped[str | None] = mapped_column(

--- a/src/course_supporter/stt/providers/deepgram.py
+++ b/src/course_supporter/stt/providers/deepgram.py
@@ -57,6 +57,9 @@ class DeepgramSTTProvider(STTProvider):
         }
         if request.language:
             params["language"] = request.language
+        else:
+            # Auto-detect when caller didn't specify the language.
+            params["detect_language"] = "true"
 
         audio_bytes = await asyncio.to_thread(audio_path.read_bytes)
         client = self._next_client()
@@ -71,7 +74,8 @@ class DeepgramSTTProvider(STTProvider):
         resp.raise_for_status()
         body = resp.json()
 
-        alt = body["results"]["channels"][0]["alternatives"][0]
+        channel = body["results"]["channels"][0]
+        alt = channel["alternatives"][0]
         text: str = alt.get("transcript", "")
         confidence: float | None = alt.get("confidence")
 
@@ -79,12 +83,20 @@ class DeepgramSTTProvider(STTProvider):
         metadata = body.get("metadata", {})
         duration: float | None = metadata.get("duration")
 
+        # Auto-detected language (Deepgram reports this at the channel level).
+        detected: str | None = None
+        if request.language is None:
+            raw_detected = channel.get("detected_language")
+            if isinstance(raw_detected, str) and raw_detected:
+                detected = raw_detected
+
         segments = _build_segments(alt)
 
         return STTResult(
             text=text,
             segments=segments,
             language=request.language,
+            detected_language=detected,
             confidence=confidence,
             provider=self.provider_name,
             model_id=self._default_model,

--- a/src/course_supporter/stt/providers/deepgram.py
+++ b/src/course_supporter/stt/providers/deepgram.py
@@ -49,17 +49,19 @@ class DeepgramSTTProvider(STTProvider):
         audio_path = Path(request.audio_path)
         content_type = guess_content_type(audio_path.suffix)
 
-        params: dict[str, str] = {
+        params: dict[str, str | bool] = {
             "model": self._default_model,
-            "punctuate": "true",
-            "paragraphs": "true",
-            "smart_format": "true",
+            "punctuate": True,
+            "paragraphs": True,
+            "smart_format": True,
         }
         if request.language:
             params["language"] = request.language
         else:
             # Auto-detect when caller didn't specify the language.
-            params["detect_language"] = "true"
+            # httpx encodes True → "true" for query params (lowercase),
+            # matching Deepgram's documented boolean format.
+            params["detect_language"] = True
 
         audio_bytes = await asyncio.to_thread(audio_path.read_bytes)
         client = self._next_client()

--- a/src/course_supporter/stt/providers/elevenlabs.py
+++ b/src/course_supporter/stt/providers/elevenlabs.py
@@ -74,6 +74,8 @@ class ElevenLabsSTTProvider(STTProvider):
 
         # Convert detected ISO 639-3 back to 639-1.
         lang_out = iso639_3_to_1(detected_lang) if detected_lang else None
+        # Only surface as detected_language when caller did not set it.
+        detected_out = lang_out if request.language is None else None
 
         segments = _build_segments(body)
 
@@ -81,6 +83,7 @@ class ElevenLabsSTTProvider(STTProvider):
             text=text,
             segments=segments,
             language=lang_out,
+            detected_language=detected_out,
             provider=self.provider_name,
             model_id=self._default_model,
             latency_ms=timer.elapsed_ms,

--- a/src/course_supporter/stt/providers/openai_stt.py
+++ b/src/course_supporter/stt/providers/openai_stt.py
@@ -72,10 +72,17 @@ class OpenAISTTProvider(STTProvider):
         text: str = result.text if hasattr(result, "text") else str(result)
         segments = _extract_segments(result)
 
+        # whisper-1 verbose_json returns `language`; gpt-4o-mini-transcribe does not.
+        detected_raw = getattr(result, "language", None)
+        detected: str | None = None
+        if request.language is None and isinstance(detected_raw, str) and detected_raw:
+            detected = detected_raw
+
         return STTResult(
             text=text,
             segments=segments,
             language=request.language,
+            detected_language=detected,
             provider=self.provider_name,
             model_id=model,
             latency_ms=timer.elapsed_ms,

--- a/src/course_supporter/stt/schemas.py
+++ b/src/course_supporter/stt/schemas.py
@@ -42,6 +42,14 @@ class STTResult(BaseModel):
     text: str
     segments: list[STTSegment] = Field(default_factory=list)
     language: str | None = None
+    detected_language: str | None = Field(
+        default=None,
+        description=(
+            "ISO 639-1 code reported by the provider when auto-detection "
+            "was used (language=None in request). Upstream code can cache "
+            "this on the material for future STT calls."
+        ),
+    )
     confidence: float | None = None
     provider: str
     model_id: str

--- a/tests/unit/test_api/test_material_entries.py
+++ b/tests/unit/test_api/test_material_entries.py
@@ -62,6 +62,7 @@ def _mock_entry(
     entry.material_role = material_role
     entry.source_url = source_url
     entry.filename = filename
+    entry.language = None
     entry.order = order
     entry.state = state
     entry.error_message = error_message

--- a/tests/unit/test_api/test_materials.py
+++ b/tests/unit/test_api/test_materials.py
@@ -59,6 +59,7 @@ def _mock_entry(
     entry.material_role = "educational"
     entry.source_url = source_url
     entry.filename = filename
+    entry.language = None
     entry.order = 0
     entry.state = state
     entry.error_message = None

--- a/tests/unit/test_api/test_nodes.py
+++ b/tests/unit/test_api/test_nodes.py
@@ -47,6 +47,7 @@ def _mock_node(
     node.learning_goal = None
     node.expected_knowledge = None
     node.expected_skills = None
+    node.default_language = None
     node.children = children or []
     node.created_at = datetime.now(UTC)
     node.updated_at = datetime.now(UTC)

--- a/tests/unit/test_ingestion_callback.py
+++ b/tests/unit/test_ingestion_callback.py
@@ -552,6 +552,9 @@ class TestCallbackIntegrationWithArqTask:
         mid = uuid.uuid4()
         mock_doc = MagicMock()
         mock_doc.model_dump_json.return_value = '{"content": "ok"}'
+        # metadata must be a real dict so .get() returns None (no
+        # detected_language to cache).
+        mock_doc.metadata = {}
 
         mock_processor = MagicMock()
         mock_processor.process = AsyncMock(return_value=mock_doc)

--- a/tests/unit/test_material_node_repository.py
+++ b/tests/unit/test_material_node_repository.py
@@ -164,6 +164,46 @@ class TestGetRootFor:
         session.get.assert_awaited_once()
 
 
+class TestUpdateDefaultLanguage:
+    """MaterialNodeRepository.update handles default_language."""
+
+    async def test_sets_default_language(self) -> None:
+        """Providing default_language sets the attribute."""
+        node = _mock_node()
+        node.default_language = None
+        session = AsyncMock()
+        session.get.return_value = node
+        session.flush = AsyncMock()
+
+        repo = MaterialNodeRepository(session)
+        result = await repo.update(node.id, default_language="uk")
+        assert result.default_language == "uk"
+
+    async def test_clears_default_language_with_none(self) -> None:
+        """Explicit None clears the stored language."""
+        node = _mock_node()
+        node.default_language = "en"
+        session = AsyncMock()
+        session.get.return_value = node
+        session.flush = AsyncMock()
+
+        repo = MaterialNodeRepository(session)
+        result = await repo.update(node.id, default_language=None)
+        assert result.default_language is None
+
+    async def test_omitted_default_language_leaves_field_untouched(self) -> None:
+        """Not passing default_language leaves the field alone."""
+        node = _mock_node()
+        node.default_language = "uk"
+        session = AsyncMock()
+        session.get.return_value = node
+        session.flush = AsyncMock()
+
+        repo = MaterialNodeRepository(session)
+        result = await repo.update(node.id, title="new title")
+        assert result.default_language == "uk"
+
+
 class TestGetTree:
     """MaterialNodeRepository.get_subtree tests."""
 

--- a/tests/unit/test_material_node_repository.py
+++ b/tests/unit/test_material_node_repository.py
@@ -134,6 +134,36 @@ class TestGetById:
         assert result is None
 
 
+class TestGetRootFor:
+    """MaterialNodeRepository.get_root_for tests."""
+
+    async def test_returns_none_when_start_node_absent(self) -> None:
+        """CTE returns no rows → method returns None."""
+        session = AsyncMock()
+        result_row = MagicMock()
+        result_row.scalar_one_or_none = MagicMock(return_value=None)
+        session.execute = AsyncMock(return_value=result_row)
+
+        repo = MaterialNodeRepository(session)
+        assert await repo.get_root_for(uuid.uuid4()) is None
+        session.get.assert_not_called()
+
+    async def test_returns_root_node_when_found(self) -> None:
+        """CTE returns root_id → load root via session.get."""
+        root_id = uuid.uuid4()
+        root_node = _mock_node(node_id=root_id)
+        session = AsyncMock()
+        result_row = MagicMock()
+        result_row.scalar_one_or_none = MagicMock(return_value=root_id)
+        session.execute = AsyncMock(return_value=result_row)
+        session.get = AsyncMock(return_value=root_node)
+
+        repo = MaterialNodeRepository(session)
+        result = await repo.get_root_for(uuid.uuid4())
+        assert result is root_node
+        session.get.assert_awaited_once()
+
+
 class TestGetTree:
     """MaterialNodeRepository.get_subtree tests."""
 

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -139,6 +139,7 @@ class TestRateLimitAPI:
                 node.learning_goal = None
                 node.expected_knowledge = None
                 node.expected_skills = None
+                node.default_language = None
                 node.order = 0
                 node.node_fingerprint = None
                 node.created_at = datetime.now(UTC)

--- a/tests/unit/test_s3012_node_based_routing.py
+++ b/tests/unit/test_s3012_node_based_routing.py
@@ -257,6 +257,7 @@ def _mock_root_node(
     node.learning_goal = None
     node.expected_knowledge = None
     node.expected_skills = None
+    node.default_language = None
     node.children = []
     node.created_at = datetime.now(UTC)
     node.updated_at = datetime.now(UTC)

--- a/tests/unit/test_scope_enforcement.py
+++ b/tests/unit/test_scope_enforcement.py
@@ -39,6 +39,7 @@ def _make_node_mock(tenant_id: uuid.UUID | None = None) -> MagicMock:
     node.learning_goal = None
     node.expected_knowledge = None
     node.expected_skills = None
+    node.default_language = None
     node.order = 0
     node.node_fingerprint = None
     node.created_at = datetime.now(UTC)

--- a/tests/unit/test_stt/test_providers.py
+++ b/tests/unit/test_stt/test_providers.py
@@ -1,5 +1,8 @@
 """Tests for STT provider interface and factory."""
 
+from pathlib import Path
+from typing import Any
+
 import pytest
 
 from course_supporter.stt.providers import STT_PROVIDER_REGISTRY
@@ -87,13 +90,13 @@ class TestDeepgramLanguageAutoDetect:
     """Deepgram must auto-detect language when caller omits it."""
 
     @pytest.fixture()
-    def fake_audio(self, tmp_path):  # type: ignore[no-untyped-def]
+    def fake_audio(self, tmp_path: Path) -> Path:
         p = tmp_path / "sample.wav"
         p.write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
         return p
 
-    def _response_body(self, *, include_detected: bool = True) -> dict:
-        channel: dict = {
+    def _response_body(self, *, include_detected: bool = True) -> dict[str, Any]:
+        channel: dict[str, Any] = {
             "alternatives": [
                 {
                     "transcript": "hello",
@@ -114,8 +117,8 @@ class TestDeepgramLanguageAutoDetect:
         }
 
     async def test_adds_detect_language_when_no_language(
-        self, fake_audio, monkeypatch
-    ) -> None:  # type: ignore[no-untyped-def]
+        self, fake_audio: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """When request.language=None, provider sends detect_language=true."""
         from unittest.mock import AsyncMock
 
@@ -138,14 +141,14 @@ class TestDeepgramLanguageAutoDetect:
 
         call_kwargs = post_mock.await_args.kwargs
         params = call_kwargs["params"]
-        assert params.get("detect_language") == "true"
+        assert params.get("detect_language") is True
         assert "language" not in params
         assert result.detected_language == "uk"
         assert result.language is None
 
     async def test_no_detect_language_when_language_explicit(
-        self, fake_audio, monkeypatch
-    ) -> None:  # type: ignore[no-untyped-def]
+        self, fake_audio: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Explicit request.language → skip detect_language and pass it as-is."""
         from unittest.mock import AsyncMock
 

--- a/tests/unit/test_stt/test_providers.py
+++ b/tests/unit/test_stt/test_providers.py
@@ -81,3 +81,93 @@ class TestSTTProviderFactory:
         providers = create_stt_providers(s)
         assert "deepgram" in providers
         assert isinstance(providers["deepgram"], DeepgramSTTProvider)
+
+
+class TestDeepgramLanguageAutoDetect:
+    """Deepgram must auto-detect language when caller omits it."""
+
+    @pytest.fixture()
+    def fake_audio(self, tmp_path):  # type: ignore[no-untyped-def]
+        p = tmp_path / "sample.wav"
+        p.write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
+        return p
+
+    def _response_body(self, *, include_detected: bool = True) -> dict:
+        channel: dict = {
+            "alternatives": [
+                {
+                    "transcript": "hello",
+                    "confidence": 0.95,
+                    "paragraphs": {
+                        "paragraphs": [
+                            {"sentences": [{"text": "hello", "start": 0.0, "end": 0.5}]}
+                        ]
+                    },
+                }
+            ],
+        }
+        if include_detected:
+            channel["detected_language"] = "uk"
+        return {
+            "results": {"channels": [channel]},
+            "metadata": {"duration": 1.23},
+        }
+
+    async def test_adds_detect_language_when_no_language(
+        self, fake_audio, monkeypatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """When request.language=None, provider sends detect_language=true."""
+        from unittest.mock import AsyncMock
+
+        from course_supporter.stt.providers.deepgram import DeepgramSTTProvider
+        from course_supporter.stt.schemas import STTRequest
+
+        provider = DeepgramSTTProvider(api_keys=["k"])
+        mock_resp = type(
+            "R",
+            (),
+            {"raise_for_status": lambda self: None, "json": lambda self: self._body},
+        )()
+        mock_resp._body = self._response_body()  # type: ignore[attr-defined]
+        post_mock = AsyncMock(return_value=mock_resp)
+        monkeypatch.setattr(provider._clients[0], "post", post_mock)
+
+        result = await provider.transcribe(
+            STTRequest(audio_path=str(fake_audio), language=None)
+        )
+
+        call_kwargs = post_mock.await_args.kwargs
+        params = call_kwargs["params"]
+        assert params.get("detect_language") == "true"
+        assert "language" not in params
+        assert result.detected_language == "uk"
+        assert result.language is None
+
+    async def test_no_detect_language_when_language_explicit(
+        self, fake_audio, monkeypatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Explicit request.language → skip detect_language and pass it as-is."""
+        from unittest.mock import AsyncMock
+
+        from course_supporter.stt.providers.deepgram import DeepgramSTTProvider
+        from course_supporter.stt.schemas import STTRequest
+
+        provider = DeepgramSTTProvider(api_keys=["k"])
+        mock_resp = type(
+            "R",
+            (),
+            {"raise_for_status": lambda self: None, "json": lambda self: self._body},
+        )()
+        mock_resp._body = self._response_body(include_detected=False)  # type: ignore[attr-defined]
+        post_mock = AsyncMock(return_value=mock_resp)
+        monkeypatch.setattr(provider._clients[0], "post", post_mock)
+
+        result = await provider.transcribe(
+            STTRequest(audio_path=str(fake_audio), language="en")
+        )
+
+        params = post_mock.await_args.kwargs["params"]
+        assert params.get("language") == "en"
+        assert "detect_language" not in params
+        assert result.detected_language is None
+        assert result.language == "en"

--- a/tests/unit/test_stt/test_providers.py
+++ b/tests/unit/test_stt/test_providers.py
@@ -120,18 +120,15 @@ class TestDeepgramLanguageAutoDetect:
         self, fake_audio: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """When request.language=None, provider sends detect_language=true."""
-        from unittest.mock import AsyncMock
+        from unittest.mock import AsyncMock, MagicMock
 
         from course_supporter.stt.providers.deepgram import DeepgramSTTProvider
         from course_supporter.stt.schemas import STTRequest
 
         provider = DeepgramSTTProvider(api_keys=["k"])
-        mock_resp = type(
-            "R",
-            (),
-            {"raise_for_status": lambda self: None, "json": lambda self: self._body},
-        )()
-        mock_resp._body = self._response_body()  # type: ignore[attr-defined]
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = self._response_body()
         post_mock = AsyncMock(return_value=mock_resp)
         monkeypatch.setattr(provider._clients[0], "post", post_mock)
 
@@ -150,18 +147,15 @@ class TestDeepgramLanguageAutoDetect:
         self, fake_audio: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Explicit request.language → skip detect_language and pass it as-is."""
-        from unittest.mock import AsyncMock
+        from unittest.mock import AsyncMock, MagicMock
 
         from course_supporter.stt.providers.deepgram import DeepgramSTTProvider
         from course_supporter.stt.schemas import STTRequest
 
         provider = DeepgramSTTProvider(api_keys=["k"])
-        mock_resp = type(
-            "R",
-            (),
-            {"raise_for_status": lambda self: None, "json": lambda self: self._body},
-        )()
-        mock_resp._body = self._response_body(include_detected=False)  # type: ignore[attr-defined]
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = self._response_body(include_detected=False)
         post_mock = AsyncMock(return_value=mock_resp)
         monkeypatch.setattr(provider._clients[0], "post", post_mock)
 

--- a/tests/unit/test_stt/test_providers.py
+++ b/tests/unit/test_stt/test_providers.py
@@ -95,25 +95,42 @@ class TestDeepgramLanguageAutoDetect:
         p.write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
         return p
 
-    def _response_body(self, *, include_detected: bool = True) -> dict[str, Any]:
+    def _response_body(
+        self,
+        *,
+        detected_language: str | None = "uk",
+        transcript: str = "hello",
+        duration: float = 1.23,
+    ) -> dict[str, Any]:
+        """Build a Deepgram-shaped response body.
+
+        Returned as a plain dict (not ``MagicMock``) on purpose: this mirrors
+        Deepgram's real JSON contract so parser changes / API schema drift
+        are caught by the test instead of being silently absorbed by
+        attribute-auto-generating mocks.
+        """
         channel: dict[str, Any] = {
             "alternatives": [
                 {
-                    "transcript": "hello",
+                    "transcript": transcript,
                     "confidence": 0.95,
                     "paragraphs": {
                         "paragraphs": [
-                            {"sentences": [{"text": "hello", "start": 0.0, "end": 0.5}]}
+                            {
+                                "sentences": [
+                                    {"text": transcript, "start": 0.0, "end": 0.5}
+                                ]
+                            }
                         ]
                     },
                 }
             ],
         }
-        if include_detected:
-            channel["detected_language"] = "uk"
+        if detected_language is not None:
+            channel["detected_language"] = detected_language
         return {
             "results": {"channels": [channel]},
-            "metadata": {"duration": 1.23},
+            "metadata": {"duration": duration},
         }
 
     async def test_adds_detect_language_when_no_language(
@@ -155,7 +172,7 @@ class TestDeepgramLanguageAutoDetect:
         provider = DeepgramSTTProvider(api_keys=["k"])
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None
-        mock_resp.json.return_value = self._response_body(include_detected=False)
+        mock_resp.json.return_value = self._response_body(detected_language=None)
         post_mock = AsyncMock(return_value=mock_resp)
         monkeypatch.setattr(provider._clients[0], "post", post_mock)
 


### PR DESCRIPTION
Що змінилось

  Після E2E тесту виявили, що Deepgram мовчки обрізав українські транскрипти до англомовних токенів, vision crash'ив на Gemini rate
  limits, STT мав Unsupported file format баг, а cost report показував $0 на 80% викликів. Все зведено в одному PR.

  ---
  1. Language pipeline (нове)

  Проблема: STT не знав мову матеріалу → Deepgram за замовчуванням обробляв як англійську → українські лекції поверталися як 7 слів
  замість повного транскрипту.

  Рішення — ієрархія розв'язання мови:
  MaterialEntry.language (явний override)
    ↓ fallback
  MaterialNode.default_language (на рівні курсу)
    ↓ fallback
  STT auto-detect (language=None → detect_language=true)
    → результат кешується назад в MaterialEntry.language

  - Міграція a1b2c3d4e5f6: додає material_nodes.default_language + material_entries.language (обидва nullable, ISO 639-1)
  - API: POST /nodes приймає default_language, POST /materials (+ confirm-upload) приймають language
  - Deepgram: передає detect_language=true коли мова не вказана; парсить detected_language з відповіді
  - ElevenLabs / OpenAI STT: виставляють detected_language коли була автодетекція
  - MaterialNodeRepository.get_root_for() — recursive CTE для пошуку root (курсу) від будь-якої ноди
  - arq_ingest_material: резолвить мову перед ingestion, після успіху — кешує detected назад в БД

  ---
  2. Провайдери + VD refactor

  - OpenAI STT filename fix: передаємо (filename, bytes, mime_type) tuple замість голих bytes → фіксить 400 Unsupported file format
  - VD provider-agnostic: VisualAnalyzer більше не залежить від google.genai.types, передає raw image bytes через generic
  ModelRouter.contents
  - OpenAICompatProvider vision support: bytes → base64 image_url parts (працює для OpenAI, Mistral, DeepSeek)
  - mistral-small-latest додано в registry з vision capability ($0.1/1M in)
  - VD chain: gemini-2.5-flash → mistral-small-latest → gpt-4o-mini — тепер не падає при Gemini rate limits

  ---
  3. Cost tracking fixes

  - STT cost_per_minute: додано поле в ModelConfig, парситься з YAML → STT тепер має cost (раніше було $0 завжди)
  - Partial token estimation: _enrich_response рахує cost коли є хоч одне з tokens_in/tokens_out (для vision, де Gemini іноді не
  повертає обидва)
  - Cost report: додано note: "Approximate estimate...", successful_calls/failed_calls per group
  - CLI cost_report.py: нові колонки OK/Fail у таблиці

  ---
  4. Reingest + operational

  - POST /materials/{id}/retry?force=true — дозволяє re-ingest з будь-якого стану (не тільки error). Потрібно для перепроцесування
  матеріалів, які "проскочили" на STT-only fallback
  - docker-compose.prod.yaml: log rotation через YAML anchors
    - app/worker: 50MB × 5 файлів (250MB cap, вистачить для DEBUG під час E2E)
    - postgres/redis/netdata: 10MB × 3 файли (30MB cap)
  - logging_config.py: заглушив DEBUG noise від botocore, urllib3, httpx, httpcore, openai. Раніше 1 S3 HeadBucket = ~20 debug events,
  забивали всі логи

  ---
  Test plan

  - 1823 unit tests pass, mypy clean, ruff clean
  - Merge → deploy
  - Оновити ElevenLabs key (окремо, квоту вичерпано)
  - Створити курс з default_language: "uk" або оновити існуючий
  - Retry 5 відео з ?force=true — перевірити що Deepgram тепер дає повний транскрипт
  - Перевірити що VD fallback на Mistral працює, якщо Gemini rate-limited
  - Cost report: вся ціна атрибутована (STT має cost_usd > 0, vision не $0)