### PR TITLE
PR: deploy-time fixes — DeepSeek max_tokens, VD timeout, PENDING transition, tracebacks

### DIFF
--- a/config/external_services.yaml
+++ b/config/external_services.yaml
@@ -72,7 +72,11 @@ providers:
       - id: deepseek-chat
         capabilities: [structured_output]
         max_context: 131072
-        max_output_tokens: 8192
+        # Bumped from 8192 after real material_outline runs on full-length
+        # Ukrainian course videos routinely hit finish_reason="length" at
+        # 8k output tokens, burning 14 min of retries before falling back
+        # to Sonnet. DeepSeek actually supports 16k output.
+        max_output_tokens: 16384
         unit_type: tokens
         cost_per_1k_in: 0.00014
         cost_per_1k_out: 0.00028

--- a/src/course_supporter/api/routes/materials.py
+++ b/src/course_supporter/api/routes/materials.py
@@ -498,6 +498,11 @@ async def retry_material(
         source_type=entry.source_type,
         source_url=entry.source_url,
     )
+    # Flip the material to PENDING synchronously so the UI reflects the
+    # transition immediately, without waiting for the worker to pick up
+    # the ARQ job and call set_pending itself. The worker will call
+    # set_pending again (idempotent) with the same job_id.
+    await entry_repo.set_pending(entry.id, job.id)
     await session.commit()
 
     logger.info(

--- a/src/course_supporter/api/routes/materials.py
+++ b/src/course_supporter/api/routes/materials.py
@@ -498,11 +498,7 @@ async def retry_material(
         source_type=entry.source_type,
         source_url=entry.source_url,
     )
-    # Flip the material to PENDING synchronously so the UI reflects the
-    # transition immediately, without waiting for the worker to pick up
-    # the ARQ job and call set_pending itself. The worker will call
-    # set_pending again (idempotent) with the same job_id.
-    await entry_repo.set_pending(entry.id, job.id)
+    # enqueue_ingestion already flipped the entry to PENDING synchronously.
     await session.commit()
 
     logger.info(

--- a/src/course_supporter/enqueue.py
+++ b/src/course_supporter/enqueue.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from course_supporter.job_priority import JobPriority
 from course_supporter.storage.job_repository import JobRepository
+from course_supporter.storage.material_entry_repository import MaterialEntryRepository
 from course_supporter.storage.orm import Job
 
 
@@ -25,9 +26,18 @@ async def enqueue_ingestion(
     source_url: str,
     priority: JobPriority = JobPriority.NORMAL,
 ) -> Job:
-    """Create a Job record and enqueue ingestion to ARQ.
+    """Create a Job record, enqueue ingestion to ARQ, flip entry to PENDING.
 
     The caller is responsible for committing the session.
+
+    Single source of truth for the RAW/READY/ERROR → PENDING transition:
+    this helper is the one place where a material entry acquires a
+    ``job_id`` and ``pending_since`` prior to processing. That way the
+    UI sees state=pending immediately after the create/retry call returns,
+    without having to wait for the worker to pick up the ARQ task. The
+    worker still calls ``set_pending`` defensively on task entry — it is
+    idempotent and protects against manual/out-of-band enqueues that
+    bypass this helper.
 
     Args:
         redis: ARQ Redis connection pool.
@@ -45,9 +55,10 @@ async def enqueue_ingestion(
     log = structlog.get_logger().bind(
         node_id=str(node_id), material_id=str(material_id)
     )
-    repo = JobRepository(session)
+    job_repo = JobRepository(session)
+    entry_repo = MaterialEntryRepository(session)
 
-    job = await repo.create(
+    job = await job_repo.create(
         tenant_id=tenant_id,
         materialnode_id=node_id,
         job_type="ingest",
@@ -69,7 +80,11 @@ async def enqueue_ingestion(
     )
 
     if arq_job is not None:
-        await repo.set_arq_job_id(job.id, arq_job.job_id)
+        await job_repo.set_arq_job_id(job.id, arq_job.job_id)
+
+    # Synchronously mark the entry as PENDING so the UI reflects the
+    # transition immediately upon return.
+    await entry_repo.set_pending(material_id, job.id)
 
     log.info(
         "job_enqueued",

--- a/src/course_supporter/logging_config.py
+++ b/src/course_supporter/logging_config.py
@@ -44,6 +44,11 @@ def configure_logging(
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.StackInfoRenderer(),
+        # Render full tracebacks when ``logger.exception()`` or
+        # ``exc_info=True`` is used. Without this, logs only show
+        # ``exc_info: true`` flag without the actual Python traceback,
+        # which makes debugging production failures nearly impossible.
+        structlog.processors.format_exc_info,
         structlog.processors.UnicodeDecoder(),
         _redact_sensitive_keys,
     ]

--- a/src/course_supporter/vd/frame_sampler.py
+++ b/src/course_supporter/vd/frame_sampler.py
@@ -73,7 +73,7 @@ async def _ffmpeg_extract_fps(
     fps: float,
     output_dir: Path,
     *,
-    timeout_sec: float = 300.0,
+    timeout_sec: float = 900.0,
 ) -> list[Path]:
     """Extract frames at fixed *fps* into *output_dir* via FFmpeg.
 


### PR DESCRIPTION
  Набір production-фіксів виявлених під час E2E тестування першого відео після попереднього деплою. Потрібні перед retry решти 4 відео.

  ---
  1. DeepSeek max_output_tokens: 8192 → 16384

  Проблема: material_outline для повноформатного українського скрінкасту (71 STT chunk, ~10k output tokens, 15 секцій
  lossless-restructured narration) упирався в 8k ліміт. DeepSeek повертав finish_reason="length", instructor робив 2 retry з тою самою
  помилкою, потім роутер падав на Claude Sonnet fallback.

  Наслідки для першого тесту:
  - 14 хв витрачено на retry storm (10:55 → 11:10)
  - $0.21 зайвих на Claude Sonnet замість майже безкоштовного DeepSeek
  - Загальна тривалість ingestion: 23 хв замість очікуваних ~10 хв

  Фікс: піднято до 16384 у external_services.yaml (це документований максимум DeepSeek). DeepSeek тепер зможе вкладатись у один виклик
  без retry + без fallback.

  ---
  2. VD ffmpeg timeout: 300s → 900s

  Проблема: _ffmpeg_extract_fps мав 5-хвилинний таймаут. При паралельному виконанні зі STT-ffmpeg на продовому сервері вилучення кадрів
  для довгого відео не встигало — весь VD pipeline віддавав vd_pipeline_failed_stt_only і відео оброблялось лише як STT (без візуального
   аналізу).

  Фікс: піднято до 900s (15 хв). Все ще строго менше за ARQ job timeout, тому не створює нових ризиків зависання.

  ---
  3. Синхронний перехід у PENDING у retry endpoint

  Проблема: POST /materials/{id}/retry створював Job row, ставив ARQ task у чергу, повертав відповідь — але НЕ чіпав entry.job_id.set_pending() викликався всередині worker'а, секунди пізніше коли він підхоплював задачу. Через це UI, зробивши refresh одразу після retry-кліку, бачив state=ready і здавалось наче нічого не сталось.

  Фікс: endpoint тепер сам викликає entry_repo.set_pending() перед повертанням. Стан перемикається на PENDING ще до response — UI одразу бачить "Обробка". Повторний виклик з worker'а ідемпотентний (той самий job_id).

  ---
  4. Повні traceback'и через structlog.processors.format_exc_info

  Проблема: logger.exception() і logger.*(..., exc_info=True) логували прапорець "exc_info": true без власне Python traceback. У минулій сесії це зробило діагностику VD-hang'у і outline-hang'у майже неможливою — довелось грепати низькорівневі Error/Exception  повідомлення по всьому output.

  Фікс: додано structlog.processors.format_exc_info у шар processors. JSON-рендерер тепер серіалізує traceback у ключ "exception",  console-рендерер виводить його візуально. Усі майбутні прод-фейли будуть одразу з повним стек-трейсом.

  ---
  Test plan

  - 1826 unit tests pass, mypy clean, ruff clean
  - Merge → deploy
  - Retry наступного відео (019d7b1d-f571-7c21-97ee-2d4a1ca026cf — "1.1.3 Імена"):
    - DeepSeek завершує material_outline без retry та без fallback на Sonnet
    - UI одразу показує "Обробка" після force-retry (без F5)
    - Якщо щось падає — повний traceback у логах воркера
  - VD pipeline проходить frame extraction (або падає з traceback замість німого timeout)
  - Після підтвердження — retry решти 3 відео (019d7b9b, 019d7d79, 019d7d80)