### PR TITLE
fix: DeepSeek max_tokens revert + Gemini raw-bytes vision handler

### DIFF
--- a/config/external_services.yaml
+++ b/config/external_services.yaml
@@ -72,11 +72,14 @@ providers:
       - id: deepseek-chat
         capabilities: [structured_output]
         max_context: 131072
-        # Bumped from 8192 after real material_outline runs on full-length
-        # Ukrainian course videos routinely hit finish_reason="length" at
-        # 8k output tokens, burning 14 min of retries before falling back
-        # to Sonnet. DeepSeek actually supports 16k output.
-        max_output_tokens: 16384
+        # DeepSeek-chat hard-caps max_tokens at 8192 (HTTP 400 otherwise —
+        # verified empirically on 2026-04-13 after an incorrect bump to
+        # 16384 caused every material_outline call to return
+        # 'Invalid max_tokens value, the valid range of max_tokens is
+        # [1, 8192]'). For long transcripts that exceed 8k output we rely
+        # on the fallback chain (Claude Sonnet) — the proper fix is the
+        # long-video chunking project.
+        max_output_tokens: 8192
         unit_type: tokens
         cost_per_1k_in: 0.00014
         cost_per_1k_out: 0.00028

--- a/src/course_supporter/llm/providers/gemini.py
+++ b/src/course_supporter/llm/providers/gemini.py
@@ -12,6 +12,48 @@ from course_supporter.llm.providers.base import LLMProvider
 from course_supporter.llm.schemas import LLMRequest, LLMResponse
 
 
+def _build_contents(request: LLMRequest) -> str | list[Any]:
+    """Build ``contents`` payload for Gemini SDK from an LLMRequest.
+
+    The router / VD pipeline passes images as raw ``bytes`` in
+    ``request.contents`` and the text instruction in ``request.prompt``
+    (provider-agnostic format, also used by OpenAI-compat providers).
+
+    Gemini's SDK, however, validates the ``contents`` argument against
+    ``Content`` / ``Part`` / ``File`` / ``Image`` / ``str`` shapes and
+    rejects a bare ``list[bytes]`` with 25-plus Pydantic validation
+    errors. This helper converts our generic format into the exact
+    SDK-accepted shape:
+
+    - text-only (no contents): pass the prompt string directly
+    - already-shaped contents (Content / Part / str items): pass through
+    - raw bytes + prompt: wrap bytes in ``Part.from_bytes`` (image/jpeg)
+      and append the prompt as a text part, all inside one ``Content``
+    """
+    contents = request.contents
+    if not contents:
+        return request.prompt
+
+    # If caller already built SDK-native items (strings, Content, Part,
+    # File, Image, dict), pass through unchanged to preserve existing
+    # callers (e.g. video.py uses types.Content directly for video URIs).
+    if all(not isinstance(c, (bytes, bytearray)) for c in contents):
+        return contents
+
+    parts: list[Any] = []
+    for item in contents:
+        if isinstance(item, (bytes, bytearray)):
+            parts.append(
+                types.Part.from_bytes(data=bytes(item), mime_type="image/jpeg")
+            )
+        else:
+            # Unknown item type inside a mixed list — trust SDK to handle it.
+            parts.append(item)
+    if request.prompt:
+        parts.append(types.Part.from_text(text=request.prompt))
+    return [types.Content(parts=parts)]
+
+
 class GeminiProvider(LLMProvider):
     """Gemini provider using google-genai SDK.
 
@@ -42,9 +84,7 @@ class GeminiProvider(LLMProvider):
             system_instruction=request.system_prompt,
         )
 
-        contents: str | list[Any] = (
-            request.contents if request.contents else request.prompt
-        )
+        contents = _build_contents(request)
 
         client = self._next_client()
         with self._measure_latency() as timer:
@@ -79,9 +119,7 @@ class GeminiProvider(LLMProvider):
             response_schema=response_schema,
         )
 
-        contents: str | list[Any] = (
-            request.contents if request.contents else request.prompt
-        )
+        contents = _build_contents(request)
 
         client = self._next_client()
         with self._measure_latency() as timer:

--- a/src/course_supporter/llm/providers/gemini.py
+++ b/src/course_supporter/llm/providers/gemini.py
@@ -65,8 +65,16 @@ def _build_contents(request: LLMRequest) -> str | list[Any]:
     if not contents:
         return request.prompt
 
-    has_bytes = any(isinstance(c, (bytes, bytearray)) for c in contents)
-    has_non_bytes = any(not isinstance(c, (bytes, bytearray)) for c in contents)
+    # Single-pass classification with early break once both flags are set.
+    has_bytes = False
+    has_non_bytes = False
+    for c in contents:
+        if isinstance(c, (bytes, bytearray)):
+            has_bytes = True
+        else:
+            has_non_bytes = True
+        if has_bytes and has_non_bytes:
+            break
 
     # Legacy / SDK-shaped passthrough: e.g. video.py passes
     # types.Content with FileData for the Gemini File API.

--- a/src/course_supporter/llm/providers/gemini.py
+++ b/src/course_supporter/llm/providers/gemini.py
@@ -11,6 +11,33 @@ from pydantic import BaseModel
 from course_supporter.llm.providers.base import LLMProvider
 from course_supporter.llm.schemas import LLMRequest, LLMResponse
 
+# Image MIME signatures (magic bytes). Only the formats Gemini accepts
+# and that we actually produce are listed: VD frame_sampler emits JPEG
+# (ffmpeg frame_%06d.jpg), describe_slides emits PNG (PyMuPDF
+# pixmap.tobytes("png")). WebP/HEIC/HEIF are left in because Gemini
+# supports them and users may one day paste such content.
+_IMAGE_MIME_SIGNATURES: tuple[tuple[bytes, str], ...] = (
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+)
+
+
+def _detect_image_mime(data: bytes) -> str:
+    """Detect image MIME type from magic bytes.
+
+    Falls back to ``application/octet-stream`` for unknown formats so the
+    SDK surfaces a clear error rather than silently mislabeling bytes.
+    """
+    for signature, mime in _IMAGE_MIME_SIGNATURES:
+        if data.startswith(signature):
+            return mime
+    # RIFF....WEBP needs a two-segment check.
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return "application/octet-stream"
+
 
 def _build_contents(request: LLMRequest) -> str | list[Any]:
     """Build ``contents`` payload for Gemini SDK from an LLMRequest.
@@ -26,29 +53,40 @@ def _build_contents(request: LLMRequest) -> str | list[Any]:
     SDK-accepted shape:
 
     - text-only (no contents): pass the prompt string directly
-    - already-shaped contents (Content / Part / str items): pass through
-    - raw bytes + prompt: wrap bytes in ``Part.from_bytes`` (image/jpeg)
-      and append the prompt as a text part, all inside one ``Content``
+    - already-shaped contents (all items non-bytes): pass through
+    - raw bytes list + optional prompt: wrap each bytes item in
+      ``Part.from_bytes`` (MIME auto-detected from magic bytes) and
+      append the prompt as a text Part, all inside one ``Content``
+
+    Mixing bytes with SDK-native items in the same list is rejected —
+    callers should commit to one shape.
     """
     contents = request.contents
     if not contents:
         return request.prompt
 
-    # If caller already built SDK-native items (strings, Content, Part,
-    # File, Image, dict), pass through unchanged to preserve existing
-    # callers (e.g. video.py uses types.Content directly for video URIs).
-    if all(not isinstance(c, (bytes, bytearray)) for c in contents):
+    has_bytes = any(isinstance(c, (bytes, bytearray)) for c in contents)
+    has_non_bytes = any(not isinstance(c, (bytes, bytearray)) for c in contents)
+
+    # Legacy / SDK-shaped passthrough: e.g. video.py passes
+    # types.Content with FileData for the Gemini File API.
+    if not has_bytes:
         return contents
+
+    if has_non_bytes:
+        msg = (
+            "Gemini _build_contents: cannot mix raw bytes with SDK-native "
+            "items in the same contents list. Pass either all bytes "
+            "(image data) or all SDK-shaped items."
+        )
+        raise TypeError(msg)
 
     parts: list[Any] = []
     for item in contents:
-        if isinstance(item, (bytes, bytearray)):
-            parts.append(
-                types.Part.from_bytes(data=bytes(item), mime_type="image/jpeg")
-            )
-        else:
-            # Unknown item type inside a mixed list — trust SDK to handle it.
-            parts.append(item)
+        data = bytes(item)
+        parts.append(
+            types.Part.from_bytes(data=data, mime_type=_detect_image_mime(data))
+        )
     if request.prompt:
         parts.append(types.Part.from_text(text=request.prompt))
     return [types.Content(parts=parts)]

--- a/tests/unit/test_llm/test_providers.py
+++ b/tests/unit/test_llm/test_providers.py
@@ -129,6 +129,73 @@ class TestProviderFactory:
         assert "gemini" in providers
         assert isinstance(providers["gemini"], GeminiProvider)
 
+
+class TestGeminiBuildContents:
+    """_build_contents maps our generic format to Gemini SDK shapes."""
+
+    def test_text_only_returns_prompt_string(self) -> None:
+        from course_supporter.llm.providers.gemini import _build_contents
+
+        req = LLMRequest(prompt="hello")
+        assert _build_contents(req) == "hello"
+
+    def test_empty_contents_returns_prompt(self) -> None:
+        from course_supporter.llm.providers.gemini import _build_contents
+
+        req = LLMRequest(prompt="hi", contents=[])
+        assert _build_contents(req) == "hi"
+
+    def test_raw_bytes_wrapped_into_parts_with_prompt(self) -> None:
+        """VD path: bytes list + prompt text → one Content with Parts."""
+        from google.genai import types
+
+        from course_supporter.llm.providers.gemini import _build_contents
+
+        img = b"\xff\xd8\xff\xe0fake-jpeg-bytes"
+        req = LLMRequest(prompt="Describe this", contents=[img])
+        result = _build_contents(req)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        content = result[0]
+        assert isinstance(content, types.Content)
+        # Parts: 1 image + 1 text
+        assert len(content.parts) == 2
+
+    def test_multiple_images_plus_prompt(self) -> None:
+        from google.genai import types
+
+        from course_supporter.llm.providers.gemini import _build_contents
+
+        req = LLMRequest(
+            prompt="compare",
+            contents=[b"img1", b"img2", b"img3"],
+        )
+        result = _build_contents(req)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert len(result[0].parts) == 4  # 3 images + 1 text
+        # First three parts carry image data
+        for i in range(3):
+            assert isinstance(result[0].parts[i], types.Part)
+
+    def test_already_sdk_shaped_contents_passthrough(self) -> None:
+        """Legacy caller passes Content/Part/str — must not rewrap into Parts."""
+        from google.genai import types
+
+        from course_supporter.llm.providers.gemini import _build_contents
+
+        existing = [types.Content(parts=[types.Part.from_text(text="hi")])]
+        req = LLMRequest(prompt="ignored", contents=existing)
+        result = _build_contents(req)
+        # Pydantic may rebuild the list, but items must be the same Content
+        # objects (no wrapping into a new Content with mixed Parts).
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], types.Content)
+        assert len(result[0].parts) == 1  # still the single "hi" text part
+
     def test_deepseek_uses_openai_compat(self) -> None:
         from course_supporter.config import Settings
         from course_supporter.llm.factory import create_providers

--- a/tests/unit/test_llm/test_providers.py
+++ b/tests/unit/test_llm/test_providers.py
@@ -151,6 +151,7 @@ class TestGeminiBuildContents:
 
         from course_supporter.llm.providers.gemini import _build_contents
 
+        # Valid JPEG magic bytes so MIME detection succeeds.
         img = b"\xff\xd8\xff\xe0fake-jpeg-bytes"
         req = LLMRequest(prompt="Describe this", contents=[img])
         result = _build_contents(req)
@@ -167,16 +168,13 @@ class TestGeminiBuildContents:
 
         from course_supporter.llm.providers.gemini import _build_contents
 
-        req = LLMRequest(
-            prompt="compare",
-            contents=[b"img1", b"img2", b"img3"],
-        )
+        jpeg = b"\xff\xd8\xff\xe0" + b"x" * 10
+        req = LLMRequest(prompt="compare", contents=[jpeg, jpeg, jpeg])
         result = _build_contents(req)
 
         assert isinstance(result, list)
         assert len(result) == 1
         assert len(result[0].parts) == 4  # 3 images + 1 text
-        # First three parts carry image data
         for i in range(3):
             assert isinstance(result[0].parts[i], types.Part)
 
@@ -189,12 +187,58 @@ class TestGeminiBuildContents:
         existing = [types.Content(parts=[types.Part.from_text(text="hi")])]
         req = LLMRequest(prompt="ignored", contents=existing)
         result = _build_contents(req)
-        # Pydantic may rebuild the list, but items must be the same Content
-        # objects (no wrapping into a new Content with mixed Parts).
         assert isinstance(result, list)
         assert len(result) == 1
         assert isinstance(result[0], types.Content)
         assert len(result[0].parts) == 1  # still the single "hi" text part
+
+    def test_mixed_bytes_and_sdk_items_rejected(self) -> None:
+        """Mixing bytes with SDK-native items is a bug — raise TypeError."""
+        from google.genai import types
+
+        from course_supporter.llm.providers.gemini import _build_contents
+
+        req = LLMRequest(
+            prompt="x",
+            contents=[
+                b"\xff\xd8\xff\xe0",
+                types.Content(parts=[types.Part.from_text(text="hi")]),
+            ],
+        )
+        with pytest.raises(TypeError, match="cannot mix raw bytes"):
+            _build_contents(req)
+
+
+class TestGeminiDetectImageMime:
+    """Magic-byte MIME detection for image payloads."""
+
+    def test_jpeg(self) -> None:
+        from course_supporter.llm.providers.gemini import _detect_image_mime
+
+        assert _detect_image_mime(b"\xff\xd8\xff\xe0JFIF...") == "image/jpeg"
+
+    def test_png(self) -> None:
+        from course_supporter.llm.providers.gemini import _detect_image_mime
+
+        assert _detect_image_mime(b"\x89PNG\r\n\x1a\nIHDR...") == "image/png"
+
+    def test_gif(self) -> None:
+        from course_supporter.llm.providers.gemini import _detect_image_mime
+
+        assert _detect_image_mime(b"GIF89a...") == "image/gif"
+        assert _detect_image_mime(b"GIF87a...") == "image/gif"
+
+    def test_webp(self) -> None:
+        from course_supporter.llm.providers.gemini import _detect_image_mime
+
+        # RIFF<4 bytes size>WEBP<...>
+        data = b"RIFF\x00\x00\x00\x00WEBPVP8 ..."
+        assert _detect_image_mime(data) == "image/webp"
+
+    def test_unknown_falls_back_to_octet_stream(self) -> None:
+        from course_supporter.llm.providers.gemini import _detect_image_mime
+
+        assert _detect_image_mime(b"random nonsense") == "application/octet-stream"
 
     def test_deepseek_uses_openai_compat(self) -> None:
         from course_supporter.config import Settings


### PR DESCRIPTION
Два критичні баги, виявлені під час E2E перепроцесингу відео "1.1.3 Імена".

  1. DeepSeek max_output_tokens повертаємо на 8192

  Попередній фікс (16384) був помилкою — API DeepSeek повертає HTTP 400 на будь-яке значення >8192:
  "Invalid max_tokens value, the valid range of max_tokens is [1, 8192]"
  Це зробило ситуацію гіршою: кожен material_outline падав одразу на 400 → 2 retry → fallback на Claude ($0.146 за кожне відео). Повертаємо 8192 з коментарем в YAML.

  2. GeminiProvider тепер приймає raw bytes vision

  Після VD refactor'у (сумісність з Mistral/OpenAI) VisualAnalyzer передає зображення як list[bytes] в request.contents, а prompt окремо. OpenAI-compat провайдери коректно конвертують в base64 image_url. Gemini ж повертав 25 Pydantic validation errors — SDK очікує Content/Part/Image/File/str, не голі bytes.

  Додано helper _build_contents():
  - text-only → passes prompt string
  - bytes + prompt → wraps у Content з Part.from_bytes(mime_type="image/jpeg") + text Part
  - legacy shape (для video.py з File API) → passthrough

  Тест 1.1.3 показав 100% fallback на Mistral для всіх 241 VD calls (219 frames + 22 scene memories), ~30 хв wallclock марно на Gemini retries, Gemini quota не використовувалась.

  Test plan

  - 1831 tests pass (+5 нових)
  - Deploy + retry наступного відео (019d7b9b-... — 1.2.1 str)
  - Gemini тепер успішно обробляє VD → fallback на Mistral лише при справжньому 503/429
  - DeepSeek material_outline має шанс на коротких відео; для довгих очікуємо Claude fallback (як було)
