### PR TITLE
config: add gemini-3-flash-preview as primary VD vision fallback

### DIFF
--- a/config/external_services.yaml
+++ b/config/external_services.yaml
@@ -8,6 +8,17 @@ providers:
   gemini:
     type: llm
     models:
+      - id: gemini-3-flash-preview
+        # Preview model — added as relief when gemini-2.5-flash is
+        # throttled (503 UNAVAILABLE). Pricing not yet officially
+        # published; using 2.5-flash pricing as a conservative proxy
+        # for the cost report.
+        capabilities: [vision, structured_output, long_context]
+        max_context: 1048576
+        max_output_tokens: 65536
+        unit_type: tokens
+        cost_per_1k_in: 0.00015
+        cost_per_1k_out: 0.0006
       - id: gemini-2.5-flash
         capabilities: [vision, structured_output, long_context]
         max_context: 1048576
@@ -241,17 +252,28 @@ actions:
     strategy: default
     requires: [vision]
     chain:
-      default: [gemini-2.5-flash, mistral-small-latest, gpt-4o-mini]
+      default:
+        - gemini-3-flash-preview
+        - gemini-2.5-flash
+        - mistral-small-latest
+        - gpt-4o-mini
 
   vd_frame_analysis:
     strategy: default
     requires: [vision]
     chain:
-      default: [gemini-2.5-flash, mistral-small-latest, gpt-4o-mini]
+      default:
+        - gemini-3-flash-preview
+        - gemini-2.5-flash
+        - mistral-small-latest
+        - gpt-4o-mini
       quality: [gemini-2.5-pro, gemini-2.5-flash]
       budget: [mistral-small-latest, gpt-4o-mini]
 
   vd_memory:
     strategy: default
     chain:
-      default: [gemini-2.5-flash, mistral-small-latest]
+      default:
+        - gemini-3-flash-preview
+        - gemini-2.5-flash
+        - mistral-small-latest

--- a/config/external_services.yaml
+++ b/config/external_services.yaml
@@ -10,15 +10,18 @@ providers:
     models:
       - id: gemini-3-flash-preview
         # Preview model — added as relief when gemini-2.5-flash is
-        # throttled (503 UNAVAILABLE). Pricing not yet officially
-        # published; using 2.5-flash pricing as a conservative proxy
-        # for the cost report.
+        # throttled (503 UNAVAILABLE).
+        # TODO: Update pricing when official rates for
+        # gemini-3-flash-preview are published. The two cost_per_1k_*
+        # values below are PROVISIONAL — copied from gemini-2.5-flash
+        # as a conservative proxy so the cost report is not wildly
+        # misleading while the preview is in use.
         capabilities: [vision, structured_output, long_context]
         max_context: 1048576
         max_output_tokens: 65536
         unit_type: tokens
-        cost_per_1k_in: 0.00015
-        cost_per_1k_out: 0.0006
+        cost_per_1k_in: 0.00015   # PROVISIONAL: 2.5-flash rate (pending official)
+        cost_per_1k_out: 0.0006   # PROVISIONAL: 2.5-flash rate (pending official)
       - id: gemini-2.5-flash
         capabilities: [vision, structured_output, long_context]
         max_context: 1048576


### PR DESCRIPTION
gemini-2.5-flash has been returning 503 UNAVAILABLE under high demand across projects today, and every VD call that hits 503 burns ~10s on retries before falling through to Mistral. The gemini-3-flash-preview alias has free capacity right now, so slot it in ahead of 2.5-flash for vd_frame_analysis, vd_memory, and describe_slides default chains.

When 3-flash-preview graduates to GA or is deprecated, the chain degrades gracefully — next step is gemini-2.5-flash, then mistral-small-latest, then gpt-4o-mini.

Pricing is not yet officially published for 3-flash-preview; using 2.5-flash's rates as a conservative proxy for the cost report. Registry validation + 1837 tests still pass.