### PR TITLE
feat: task_type on MaterialEntry — preserve authored assignments

### DIFF
--- a/migrations/versions/b3c4d5e6f7a8_add_task_type_to_material_entries.py
+++ b/migrations/versions/b3c4d5e6f7a8_add_task_type_to_material_entries.py
@@ -1,0 +1,56 @@
+"""add_task_type_to_material_entries
+
+Revision ID: b3c4d5e6f7a8
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-14 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "b3c4d5e6f7a8"
+down_revision: Union[str, Sequence[str], None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add task_type enum and nullable column to material_entries.
+
+    task_type marks a material as containing a concrete assignment. When set,
+    the MethodistAgent must preserve the material as a recommended assignment
+    instead of generating one from scratch. The enum mirrors AssignmentType
+    in models/methodist.py.
+    """
+    op.execute(
+        "CREATE TYPE task_type_enum AS ENUM ('test', 'short_task', 'task', 'project')"
+    )
+    op.add_column(
+        "material_entries",
+        sa.Column(
+            "task_type",
+            sa.Enum(
+                "test",
+                "short_task",
+                "task",
+                "project",
+                name="task_type_enum",
+                create_type=False,
+            ),
+            nullable=True,
+            comment=(
+                "Assignment type if this material represents a concrete task "
+                "(test, short_task, task, project). NULL means regular material."
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove task_type column and enum."""
+    op.drop_column("material_entries", "task_type")
+    op.execute("DROP TYPE IF EXISTS task_type_enum")

--- a/prompts/methodist/v1_system.yaml
+++ b/prompts/methodist/v1_system.yaml
@@ -32,6 +32,25 @@ system_prompt: |
   educational materials are the *implementation*. Check if the implementation
   matches the intent. If only educational materials exist, infer the intent.
 
+  ## Task Materials (explicit `task_type`)
+
+  Some materials carry an explicit **`task_type`** tag in the Material Roles
+  section: one of ``test``, ``short_task``, ``task``, or ``project``. These
+  are concrete assignments authored by the course owner.
+
+  **You MUST preserve them as `recommended_assignments` verbatim:**
+  - Do NOT rewrite, paraphrase, or replace the author's task
+  - Do NOT generate a substitute assignment of the same type
+  - The ``assignment_type`` field in the output MUST match the material's
+    ``task_type`` exactly
+  - Populate ``title`` and ``description`` from the material content; fill
+    ``steps`` / ``sample_questions`` only if the source text contains them
+  - You MAY still add additional assignments (of any type) if the node is
+    under-assessed — but never replace an authored task
+
+  Treat the tagged material as authoritative for that taxonomy tier at this
+  node.
+
   ## Sliding Window Context
 
   You receive context about the node's position in the course tree:

--- a/src/course_supporter/agents/methodist.py
+++ b/src/course_supporter/agents/methodist.py
@@ -305,17 +305,23 @@ def format_methodist_parent(
 
 
 def format_material_roles(
-    entries: list[tuple[str, str, str]],
+    entries: list[tuple[str, str, str, str | None]],
 ) -> str:
     """Format material role info for the Methodist prompt.
 
     Args:
-        entries: List of (title, source_type, material_role) tuples.
+        entries: List of (title, source_type, material_role, task_type) tuples.
+            ``task_type`` is the AssignmentType value (``test`` / ``short_task``
+            / ``task`` / ``project``) when the material is an explicit
+            assignment, or ``None`` for regular materials.
     """
     if not entries:
         return ""
     lines = ["## Material Roles", ""]
-    for title, stype, role in entries:
-        lines.append(f"- **{title}** ({stype}): {role}")
+    for title, stype, role, task_type in entries:
+        line = f"- **{title}** ({stype}): {role}"
+        if task_type:
+            line += f" — **task_type: `{task_type}`** (authored assignment)"
+        lines.append(line)
     lines.append("")
     return "\n".join(lines)

--- a/src/course_supporter/api/routes/materials.py
+++ b/src/course_supporter/api/routes/materials.py
@@ -46,6 +46,7 @@ from course_supporter.auth.context import TenantContext
 from course_supporter.auth.registry import AuthScope
 from course_supporter.auth.scopes import require_scope
 from course_supporter.enqueue import enqueue_ingestion
+from course_supporter.models.methodist import AssignmentType
 from course_supporter.models.source import MaterialRole, SourceType
 from course_supporter.storage.material_entry_repository import MaterialEntryRepository
 from course_supporter.storage.material_node_repository import MaterialNodeRepository
@@ -116,6 +117,16 @@ async def create_material(
             "or methodological (declares course intent).",
         ),
     ] = MaterialRole.EDUCATIONAL,
+    task_type: Annotated[
+        AssignmentType | None,
+        Form(
+            description=(
+                "Mark the material as a concrete task of the given taxonomy "
+                "tier (test, short_task, task, project). Omit for regular "
+                "materials."
+            ),
+        ),
+    ] = None,
     source_url: Annotated[
         str | None,
         Form(description="URL to the source material. Required if no file."),
@@ -207,6 +218,7 @@ async def create_material(
         source_url=actual_url,
         filename=actual_filename,
         material_role=material_role,
+        task_type=task_type,
         language=language,
     )
 
@@ -226,6 +238,7 @@ async def create_material(
         entry_id=str(entry.id),
         node_id=str(node_id),
         job_id=str(job.id),
+        task_type=task_type,
     )
     response = MaterialEntryCreateResponse.model_validate(entry)
     response.job_id = job.id
@@ -331,6 +344,7 @@ async def confirm_upload(
         source_url=s3_url,
         filename=actual_filename,
         material_role=body.material_role,
+        task_type=body.task_type,
         language=body.language,
     )
 
@@ -399,9 +413,11 @@ async def update_material(
     tenant: PrepDep,
     session: SessionDep,
 ) -> MaterialEntryResponse:
-    """Update material metadata (currently only material_role).
+    """Update material metadata (material_role and/or task_type).
 
-    Toggles between ``educational`` and ``methodological`` roles.
+    Only fields explicitly sent in the request body are updated.
+    Pass ``task_type: null`` to clear the task flag; omit the field
+    to keep the current value.
     """
     entry_repo = MaterialEntryRepository(session)
     node_repo = MaterialNodeRepository(session)
@@ -409,15 +425,29 @@ async def update_material(
         entry_repo, node_repo, entry_id, tenant.tenant_id
     )
 
-    entry = await entry_repo.update_material_role(
-        entry, material_role=body.material_role
-    )
+    fields_set = body.model_fields_set
+    if not fields_set:
+        raise HTTPException(
+            status_code=422,
+            detail="At least one field must be provided.",
+        )
+
+    if "material_role" in fields_set and body.material_role is not None:
+        entry = await entry_repo.update_material_role(
+            entry, material_role=body.material_role
+        )
+
+    if "task_type" in fields_set:
+        entry = await entry_repo.update_task_type(entry, task_type=body.task_type)
+
     await session.commit()
 
     logger.info(
-        "material_role_updated",
+        "material_updated",
         entry_id=str(entry_id),
         material_role=body.material_role,
+        task_type=body.task_type,
+        fields=list(fields_set),
     )
     return MaterialEntryResponse.model_validate(entry)
 

--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -10,6 +10,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from course_supporter.models.course import TIMECODE_RE, SlideVideoMapEntry
+from course_supporter.models.methodist import AssignmentType
 from course_supporter.models.source import MaterialRole, SourceType
 from course_supporter.storage.orm import GenerationMode, MappingValidationState
 
@@ -399,6 +400,13 @@ class MaterialEntrySummaryResponse(BaseModel):
     material_role: str = Field(
         description="Role: ``educational`` or ``methodological``."
     )
+    task_type: AssignmentType | None = Field(
+        default=None,
+        description=(
+            "Assignment type if this material is a concrete task. "
+            "``null`` for regular (non-task) materials."
+        ),
+    )
     source_url: str = Field(description="URL or S3 path to the raw material.")
     filename: str | None = Field(description="Original filename, if available.")
     order: int = Field(description="0-based position among sibling materials.")
@@ -470,6 +478,16 @@ class MaterialEntryCreateRequest(BaseModel):
         ),
         examples=["educational", "methodological"],
     )
+    task_type: AssignmentType | None = Field(
+        default=None,
+        description=(
+            "Mark the material as a concrete assignment of the given taxonomy "
+            "tier (``test``, ``short_task``, ``task``, ``project``). When set, "
+            "the Methodist agent preserves this material as a "
+            "recommended_assignment verbatim. ``null`` for regular materials."
+        ),
+        examples=[None, "test", "task"],
+    )
     source_url: str = Field(
         ...,
         max_length=2000,
@@ -494,10 +512,23 @@ class MaterialEntryCreateRequest(BaseModel):
 
 
 class MaterialEntryUpdateRequest(BaseModel):
-    """Request body for PATCH /materials/{entry_id}."""
+    """Request body for PATCH /materials/{entry_id}.
 
-    material_role: MaterialRole = Field(
-        description="New role: ``educational`` or ``methodological``."
+    All fields are optional — only fields present in the request body
+    are updated. Field presence is detected via ``model_fields_set``.
+    Passing ``task_type: null`` explicitly clears the task flag.
+    """
+
+    material_role: MaterialRole | None = Field(
+        default=None,
+        description="New role: ``educational`` or ``methodological``.",
+    )
+    task_type: AssignmentType | None = Field(
+        default=None,
+        description=(
+            "Assignment taxonomy tier. Pass ``null`` to clear. "
+            "Omit the field to keep the current value."
+        ),
     )
 
 
@@ -515,6 +546,12 @@ class MaterialEntryResponse(BaseModel):
     )
     material_role: str = Field(
         description="Role: ``educational`` or ``methodological``."
+    )
+    task_type: AssignmentType | None = Field(
+        default=None,
+        description=(
+            "Assignment type if this material is a concrete task, else ``null``."
+        ),
     )
     source_url: str = Field(description="URL or S3 path to the raw material.")
     filename: str | None = Field(description="Original filename, if available.")
@@ -559,6 +596,12 @@ class MaterialEntryCreateResponse(BaseModel):
     )
     material_role: str = Field(
         description="Role: ``educational`` or ``methodological``."
+    )
+    task_type: AssignmentType | None = Field(
+        default=None,
+        description=(
+            "Assignment type if this material is a concrete task, else ``null``."
+        ),
     )
     source_url: str = Field(description="URL or S3 path to the raw material.")
     filename: str | None = Field(description="Original filename, if available.")
@@ -963,6 +1006,13 @@ class ConfirmUploadRequest(BaseModel):
         description=(
             "Role: ``educational`` (delivers content) "
             "or ``methodological`` (declares course intent)."
+        ),
+    )
+    task_type: AssignmentType | None = Field(
+        default=None,
+        description=(
+            "Mark the material as a concrete task of the given taxonomy tier. "
+            "``null`` for regular materials."
         ),
     )
     filename: str | None = Field(

--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -1201,7 +1201,7 @@ async def arq_execute_methodist_step(
             node_repo = MaterialNodeRepository(session)
             mat_node = await node_repo.get_by_id(mn_id)
             outline_ctx = ""
-            material_roles_info: list[tuple[str, str, str]] = []
+            material_roles_info: list[tuple[str, str, str, str | None]] = []
             if mat_node is not None:
                 entry_repo = MaterialEntryRepository(session)
                 entries = await entry_repo.get_for_node(mn_id)
@@ -1212,6 +1212,7 @@ async def arq_execute_methodist_step(
                             entry.filename or entry.source_url,
                             entry.source_type,
                             entry.material_role,
+                            entry.task_type,
                         )
                     )
                     if entry.outline_content:

--- a/src/course_supporter/storage/material_entry_repository.py
+++ b/src/course_supporter/storage/material_entry_repository.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from course_supporter.models.methodist import AssignmentType
 from course_supporter.models.source import MaterialRole
 from course_supporter.storage.orm import MaterialEntry, MaterialNode
 
@@ -31,6 +32,7 @@ class MaterialEntryRepository:
         source_url: str,
         filename: str | None = None,
         material_role: str = "educational",
+        task_type: AssignmentType | str | None = None,
         language: str | None = None,
     ) -> MaterialEntry:
         """Create a new material entry with auto-incremented order.
@@ -41,6 +43,9 @@ class MaterialEntryRepository:
             source_url: URL or storage path for the raw material.
             filename: Original filename (for uploads).
             material_role: Role: educational or methodological.
+            task_type: Optional AssignmentType when this material represents
+                a concrete task (test, short_task, task, project). NULL for
+                regular materials.
             language: Optional ISO 639-1 language override. When None,
                 the course default is used and STT falls back to
                 auto-detection (which caches its result back here).
@@ -49,12 +54,18 @@ class MaterialEntryRepository:
             The newly created MaterialEntry.
         """
         next_order = await self._next_sibling_order(node_id)
+        task_type_value: str | None
+        if isinstance(task_type, AssignmentType):
+            task_type_value = task_type.value
+        else:
+            task_type_value = task_type
         entry = MaterialEntry(
             materialnode_id=node_id,
             source_type=source_type,
             source_url=source_url,
             filename=filename,
             material_role=material_role,
+            task_type=task_type_value,
             language=language,
             order=next_order,
         )
@@ -294,6 +305,22 @@ class MaterialEntryRepository:
             material_role: New role (MaterialRole.EDUCATIONAL or METHODOLOGICAL).
         """
         entry.material_role = material_role.value
+        await self._session.flush()
+        return entry
+
+    async def update_task_type(
+        self,
+        entry: MaterialEntry,
+        *,
+        task_type: AssignmentType | None,
+    ) -> MaterialEntry:
+        """Update the task_type field on an already-loaded entry.
+
+        Args:
+            entry: Entry ORM model to update.
+            task_type: New AssignmentType, or None to clear the task flag.
+        """
+        entry.task_type = task_type.value if task_type is not None else None
         await self._session.flush()
         return entry
 

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -257,6 +257,20 @@ class MaterialEntry(Base):
         server_default="educational",
         comment="Role: educational (content) or methodological (intent)",
     )
+    task_type: Mapped[str | None] = mapped_column(
+        Enum(
+            "test",
+            "short_task",
+            "task",
+            "project",
+            name="task_type_enum",
+            create_type=False,
+        ),
+        nullable=True,
+        default=None,
+        comment="Assignment type when material is a concrete task "
+        "(test/short_task/task/project). NULL for regular materials.",
+    )
     order: Mapped[int] = mapped_column(Integer, default=0)
 
     # ── Raw layer ──

--- a/tests/unit/test_api/test_material_entries.py
+++ b/tests/unit/test_api/test_material_entries.py
@@ -47,6 +47,7 @@ def _mock_entry(
     node_id: uuid.UUID | None = None,
     source_type: str = "text",
     material_role: str = "educational",
+    task_type: str | None = None,
     source_url: str = "https://example.com/doc.md",
     filename: str | None = None,
     order: int = 0,
@@ -60,6 +61,7 @@ def _mock_entry(
     entry.materialnode_id = node_id or uuid.uuid4()
     entry.source_type = source_type
     entry.material_role = material_role
+    entry.task_type = task_type
     entry.source_url = source_url
     entry.filename = filename
     entry.language = None
@@ -628,6 +630,102 @@ class TestUpdateMaterial:
         resp = await client.patch(
             f"/api/v1/materials/{uuid.uuid4()}",
             json={"material_role": "invalid"},
+        )
+        assert resp.status_code == 422
+
+    async def test_set_task_type(self, client: AsyncClient, node_id: uuid.UUID) -> None:
+        """PATCH sets task_type without changing role."""
+        entry = _mock_entry(node_id=node_id, material_role="educational")
+        updated = _mock_entry(
+            node_id=node_id,
+            material_role="educational",
+            task_type="short_task",
+        )
+        update_task_mock = AsyncMock(return_value=updated)
+        with (
+            patch.object(MaterialEntryRepository, "get_by_id", return_value=entry),
+            patch.object(
+                MaterialNodeRepository,
+                "get_by_id",
+                return_value=_mock_node(node_id=node_id),
+            ),
+            patch.object(
+                MaterialEntryRepository,
+                "update_task_type",
+                update_task_mock,
+            ),
+        ):
+            resp = await client.patch(
+                f"/api/v1/materials/{entry.id}",
+                json={"task_type": "short_task"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["task_type"] == "short_task"
+        # material_role update should NOT have been called since it wasn't in body
+        update_task_mock.assert_awaited_once()
+
+    async def test_clear_task_type(
+        self, client: AsyncClient, node_id: uuid.UUID
+    ) -> None:
+        """PATCH with task_type: null clears the task flag."""
+        entry = _mock_entry(
+            node_id=node_id,
+            material_role="educational",
+            task_type="task",
+        )
+        updated = _mock_entry(
+            node_id=node_id,
+            material_role="educational",
+            task_type=None,
+        )
+        update_task_mock = AsyncMock(return_value=updated)
+        with (
+            patch.object(MaterialEntryRepository, "get_by_id", return_value=entry),
+            patch.object(
+                MaterialNodeRepository,
+                "get_by_id",
+                return_value=_mock_node(node_id=node_id),
+            ),
+            patch.object(
+                MaterialEntryRepository,
+                "update_task_type",
+                update_task_mock,
+            ),
+        ):
+            resp = await client.patch(
+                f"/api/v1/materials/{entry.id}",
+                json={"task_type": None},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["task_type"] is None
+        update_task_mock.assert_awaited_once()
+
+    async def test_empty_body_returns_422(
+        self, client: AsyncClient, node_id: uuid.UUID
+    ) -> None:
+        """PATCH with no fields returns 422."""
+        entry = _mock_entry(node_id=node_id)
+        with (
+            patch.object(MaterialEntryRepository, "get_by_id", return_value=entry),
+            patch.object(
+                MaterialNodeRepository,
+                "get_by_id",
+                return_value=_mock_node(node_id=node_id),
+            ),
+        ):
+            resp = await client.patch(
+                f"/api/v1/materials/{entry.id}",
+                json={},
+            )
+        assert resp.status_code == 422
+
+    async def test_invalid_task_type_returns_422(
+        self, client: AsyncClient, node_id: uuid.UUID
+    ) -> None:
+        """PATCH rejects task_type outside the taxonomy."""
+        resp = await client.patch(
+            f"/api/v1/materials/{uuid.uuid4()}",
+            json={"task_type": "essay"},
         )
         assert resp.status_code == 422
 

--- a/tests/unit/test_api/test_materials.py
+++ b/tests/unit/test_api/test_materials.py
@@ -50,6 +50,7 @@ def _mock_entry(
     source_url: str = "https://example.com/doc.md",
     filename: str | None = None,
     state: str = "raw",
+    task_type: str | None = None,
 ) -> MagicMock:
     """Create a mock MaterialEntry."""
     entry = MagicMock()
@@ -57,6 +58,7 @@ def _mock_entry(
     entry.materialnode_id = node_id or uuid.uuid4()
     entry.source_type = source_type
     entry.material_role = "educational"
+    entry.task_type = task_type
     entry.source_url = source_url
     entry.filename = filename
     entry.language = None
@@ -236,6 +238,54 @@ class TestMaterialUploadValidation:
             )
         assert response.status_code == 201
         assert response.json()["state"] == "raw"
+
+    async def test_create_material_accepts_task_type(
+        self, client: AsyncClient, node_id: uuid.UUID
+    ) -> None:
+        """POST /materials forwards task_type to the repository."""
+        entry = _mock_entry(
+            node_id=node_id,
+            source_type="text",
+            task_type="short_task",
+        )
+        job = _mock_job()
+        create_mock = AsyncMock(return_value=entry)
+        with (
+            patch.object(
+                MaterialNodeRepository,
+                "get_by_id",
+                return_value=_mock_node(node_id=node_id),
+            ),
+            patch.object(MaterialEntryRepository, "create", create_mock),
+            patch(ENQUEUE_FUNC, new_callable=AsyncMock, return_value=job),
+        ):
+            response = await client.post(
+                f"/api/v1/nodes/{node_id}/materials",
+                data={
+                    "source_type": "text",
+                    "source_url": "https://example.com/hw.md",
+                    "task_type": "short_task",
+                },
+            )
+        assert response.status_code == 201
+        assert response.json()["task_type"] == "short_task"
+        # Repository receives the enum value
+        call_kwargs = create_mock.call_args.kwargs
+        assert call_kwargs["task_type"] == "short_task"
+
+    async def test_create_material_rejects_invalid_task_type(
+        self, client: AsyncClient, node_id: uuid.UUID
+    ) -> None:
+        """POST /materials rejects task_type outside the taxonomy."""
+        response = await client.post(
+            f"/api/v1/nodes/{node_id}/materials",
+            data={
+                "source_type": "text",
+                "source_url": "https://example.com/x.md",
+                "task_type": "essay",
+            },
+        )
+        assert response.status_code == 422
 
 
 # -- POST /nodes/{nid}/materials/upload-url --

--- a/tests/unit/test_material_entry_repository.py
+++ b/tests/unit/test_material_entry_repository.py
@@ -107,6 +107,86 @@ class TestCreate:
         assert added.order == 2
         assert result is added
 
+    async def test_create_without_task_type(self) -> None:
+        """task_type defaults to None on regular materials."""
+        session = AsyncMock()
+        session.add = MagicMock()
+        repo = MaterialEntryRepository(session)
+
+        with patch.object(repo, "_next_sibling_order", return_value=0):
+            await repo.create(
+                node_id=uuid.uuid4(),
+                source_type="text",
+                source_url="s3://bucket/article.md",
+            )
+
+        added = session.add.call_args[0][0]
+        assert added.task_type is None
+
+    async def test_create_with_task_type_enum(self) -> None:
+        """AssignmentType is persisted as its string value."""
+        from course_supporter.models.methodist import AssignmentType
+
+        session = AsyncMock()
+        session.add = MagicMock()
+        repo = MaterialEntryRepository(session)
+
+        with patch.object(repo, "_next_sibling_order", return_value=0):
+            await repo.create(
+                node_id=uuid.uuid4(),
+                source_type="text",
+                source_url="s3://bucket/hw1.md",
+                task_type=AssignmentType.SHORT_TASK,
+            )
+
+        added = session.add.call_args[0][0]
+        assert added.task_type == "short_task"
+
+    async def test_create_with_task_type_string(self) -> None:
+        """Raw string values are accepted for task_type."""
+        session = AsyncMock()
+        session.add = MagicMock()
+        repo = MaterialEntryRepository(session)
+
+        with patch.object(repo, "_next_sibling_order", return_value=0):
+            await repo.create(
+                node_id=uuid.uuid4(),
+                source_type="text",
+                source_url="s3://bucket/hw1.md",
+                task_type="task",
+            )
+
+        added = session.add.call_args[0][0]
+        assert added.task_type == "task"
+
+
+class TestUpdateTaskType:
+    """MaterialEntryRepository.update_task_type tests."""
+
+    async def test_set_task_type(self) -> None:
+        from course_supporter.models.methodist import AssignmentType
+
+        session = AsyncMock()
+        repo = MaterialEntryRepository(session)
+        entry = _mock_entry()
+        entry.task_type = None
+
+        result = await repo.update_task_type(entry, task_type=AssignmentType.PROJECT)
+
+        assert result.task_type == "project"
+        session.flush.assert_awaited()
+
+    async def test_clear_task_type(self) -> None:
+        session = AsyncMock()
+        repo = MaterialEntryRepository(session)
+        entry = _mock_entry()
+        entry.task_type = "task"
+
+        result = await repo.update_task_type(entry, task_type=None)
+
+        assert result.task_type is None
+        session.flush.assert_awaited()
+
 
 class TestGetById:
     """MaterialEntryRepository.get_by_id tests."""

--- a/tests/unit/test_methodist_agent.py
+++ b/tests/unit/test_methodist_agent.py
@@ -139,13 +139,28 @@ class TestFormatHelpers:
 
     def test_format_material_roles(self) -> None:
         entries = [
-            ("Lecture 1", "video", "educational"),
-            ("Syllabus", "text", "methodological"),
+            ("Lecture 1", "video", "educational", None),
+            ("Syllabus", "text", "methodological", None),
         ]
         result = format_material_roles(entries)
         assert "educational" in result
         assert "methodological" in result
         assert "Lecture 1" in result
+
+    def test_format_material_roles_with_task_type(self) -> None:
+        entries = [
+            ("Lecture 1", "video", "educational", None),
+            ("HW: variables", "text", "educational", "short_task"),
+            ("Capstone", "text", "educational", "project"),
+        ]
+        result = format_material_roles(entries)
+        assert "HW: variables" in result
+        assert "`short_task`" in result
+        assert "`project`" in result
+        assert "authored assignment" in result
+        # non-task lines must not include the task marker
+        lecture_line = next(ln for ln in result.splitlines() if "Lecture 1" in ln)
+        assert "task_type" not in lecture_line
 
 
 class TestMethodistAgentErrorHandling:


### PR DESCRIPTION
Adds a nullable `task_type` column (enum test/short_task/task/project) to MaterialEntry so course owners can upload ready-made assignments and have the Methodist agent preserve them verbatim as recommended_assignments instead of generating substitute tasks.

- migration b3c4d5e6f7a8: task_type_enum + material_entries.task_type
- ORM, Create/Update/Response schemas, ConfirmUploadRequest
- POST /nodes/{nid}/materials accepts task_type form field
- PATCH /materials/{eid} uses model_fields_set for partial updates (explicit null clears task_type)
- MaterialEntryRepository.update_task_type + task_type on create
- Methodist system prompt instructed to preserve authored tasks
- format_material_roles shows task_type in context block
- 12 new unit tests; full suite 1849 passed