### PR TITLE
fix: MergeStep accepts empty documents for intermediate node generation

### DIFF
--- a/src/course_supporter/ingestion/merge.py
+++ b/src/course_supporter/ingestion/merge.py
@@ -46,21 +46,35 @@ class MergeStep:
     ) -> CourseContext:
         """Merge source documents and optional mappings into CourseContext.
 
+        Accepts an empty ``documents`` list: intermediate parent nodes that
+        delegate their context to child snapshots have no own materials to
+        merge, and the caller supplies the context via ``material_tree`` +
+        out-of-band ``children_snapshots``. Upstream callers that require
+        materials (leaf generation) guard with
+        ``_collect_ready_documents(..., allow_empty=False)`` before reaching
+        this step.
+
         Args:
-            documents: List of processed SourceDocuments.
+            documents: List of processed SourceDocuments. May be empty.
             mappings: Optional slide<->video mappings for cross-referencing.
             material_tree: Optional tree hierarchy with material associations.
 
         Returns:
             CourseContext with sorted documents, mappings, and tree metadata.
-
-        Raises:
-            ValueError: If documents list is empty.
         """
-        if not documents:
-            raise ValueError("Cannot merge empty documents list")
-
         resolved_mappings = mappings or []
+
+        if not documents:
+            logger.info(
+                "merge_empty_documents",
+                mapping_count=len(resolved_mappings),
+                tree_node_count=len(material_tree) if material_tree else 0,
+            )
+            return CourseContext(
+                documents=[],
+                slide_video_mappings=resolved_mappings,
+                material_tree=material_tree or [],
+            )
 
         # Sort documents by source_type priority
         sorted_docs = sorted(

--- a/tests/unit/test_ingestion/test_merge.py
+++ b/tests/unit/test_ingestion/test_merge.py
@@ -1,7 +1,5 @@
 """Tests for MergeStep."""
 
-import pytest
-
 from course_supporter.ingestion.merge import MergeStep
 from course_supporter.models.course import (
     CourseContext,
@@ -61,12 +59,47 @@ class TestMergeStep:
 
         assert len(result.documents) == 2
 
-    def test_empty_documents_raises(self) -> None:
-        """Empty documents list -> ValueError."""
+    def test_empty_documents_returns_empty_context(self) -> None:
+        """Empty documents list returns an empty CourseContext.
+
+        Intermediate parent nodes that rely on child snapshots have no own
+        materials to merge; upstream guards (``_collect_ready_documents``)
+        enforce non-empty for leaf generation where materials are required.
+        """
         step = MergeStep()
 
-        with pytest.raises(ValueError, match="Cannot merge empty documents list"):
-            step.merge([])
+        result = step.merge([])
+
+        assert result.documents == []
+        assert result.slide_video_mappings == []
+        assert result.material_tree == []
+
+    def test_empty_documents_preserves_material_tree(self) -> None:
+        """An empty merge still carries the ``material_tree`` forward.
+
+        The parent-generate path passes a tree summary so the Architect
+        can still orient itself via the hierarchy even without own
+        materials.
+        """
+        import uuid as _uuid
+
+        step = MergeStep()
+        tree = [
+            MaterialNodeSummary(
+                node_id=_uuid.uuid4(),
+                title="Intro",
+                parent_id=None,
+                depth=0,
+                order=0,
+                material_refs=[],
+            )
+        ]
+
+        result = step.merge([], mappings=None, material_tree=tree)
+
+        assert result.documents == []
+        assert len(result.material_tree) == 1
+        assert result.material_tree[0].title == "Intro"
 
     def test_document_ordering(self) -> None:
         """Documents sorted by priority: video -> presentation -> text -> web."""


### PR DESCRIPTION
`MergeStep.merge` raised `ValueError("Cannot merge empty documents list")` whenever called with no `SourceDocument`s. This blocked the intermediate-node generation path, where a parent whose children already have snapshots legitimately delegates its context to those snapshots and has no own materials to merge.

Observed on prod 2026-04-14 during E2E:
- Intro materialnode (no own materials, 3 children incl. 2 with snapshots) → `arq_execute_step` chose the "parent + children snapshots" branch → `_collect_ready_documents([target_node], allow_empty=True)` correctly returned `[]` → `ArchitectAgent.execute` unconditionally called `MergeStep().merge([])` → ValueError → `execute_step_failed` → cascading failure to the reconcile step.

Fix: when `documents` is empty, return an empty-but-valid `CourseContext` carrying the `material_tree` and any `mappings` forward. The Architect already has dedicated paths (`children_snapshots`, `outline_context`, `material_tree`) to populate the LLM prompt without raw documents.

Upstream callers that *require* materials (leaf generation in `/generate`) continue to guard via `_collect_ready_documents(..., allow_empty=False)` which raises `NoReadyMaterialsError` before the merge is reached, so this loosening cannot mask a real "no inputs" bug.

- Replace the raise with a logged empty-context return.
- Update existing `test_empty_documents_raises` → covers the new empty-OK contract.
- Add `test_empty_documents_preserves_material_tree` to pin the forwarding of `material_tree` through the empty-merge path.

Verified locally: full suite 1853 passed, ruff + mypy clean.