### PR TITLE
feat(auth): replace per-key rate_limit_prep/check with plan_id

### DIFF
--- a/config/auth.yaml
+++ b/config/auth.yaml
@@ -1,10 +1,33 @@
 # ============================================================
-# Auth: API scopes and their metadata
+# Auth: API scopes, plans, and rate limits.
+#
+# Scopes are authorization markers — which operations an API key
+# is allowed to perform. A scope is just a name + a human description.
+#
+# Plans bundle per-scope rate limits. Every APIKey row points to a
+# plan via api_keys.plan_id. At request time the matched scope's
+# limit is looked up from the plan.
+#
+# Adding a new scope:
+#   1. Append it under `scopes:` here.
+#   2. Add AuthScope enum member in src/course_supporter/auth/registry.py.
+#   3. Add the scope's limit to every plan below (startup validation
+#      will fail if any plan is missing it).
+#
+# Adding a new plan:
+#   1. Append it under `plans:` here with all current scopes.
+#   2. Assign tenants via api_keys.plan_id (no code change needed).
 # ============================================================
+
 scopes:
   prep:
     description: "Course preparation operations (CRUD, upload, generation)"
-    rate_limit_field: rate_limit_prep
   check:
     description: "Course checking operations (read-only queries, mentoring)"
-    rate_limit_field: rate_limit_check
+
+default_plan: basic
+
+plans:
+  basic:
+    prep: 60
+    check: 300

--- a/migrations/versions/c4d5e6f7a8b9_api_keys_plan_id.py
+++ b/migrations/versions/c4d5e6f7a8b9_api_keys_plan_id.py
@@ -1,0 +1,71 @@
+"""api_keys: replace rate_limit_prep/check with plan_id
+
+Revision ID: c4d5e6f7a8b9
+Revises: b3c4d5e6f7a8
+Create Date: 2026-04-15 10:00:00.000000
+
+Moves per-key rate limits out of the database into config/auth.yaml.
+Each APIKey now points to a named plan (default: 'basic') and the
+scope-enforcement layer resolves the effective limit from the plan
+registry at request time.
+
+Data migration: server_default='basic' backfills plan_id for every
+existing row. Prod audit at deploy time showed a single key with
+(60, 300), which matches the 'basic' plan exactly — no manual UPDATE
+required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c4d5e6f7a8b9"
+down_revision: str | Sequence[str] | None = "b3c4d5e6f7a8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add plan_id, drop rate_limit_prep/check."""
+    op.add_column(
+        "api_keys",
+        sa.Column(
+            "plan_id",
+            sa.String(length=50),
+            nullable=False,
+            server_default="basic",
+            comment=(
+                "Name of plan from config/auth.yaml — "
+                "resolves to per-scope rate limits at runtime."
+            ),
+        ),
+    )
+    op.drop_column("api_keys", "rate_limit_prep")
+    op.drop_column("api_keys", "rate_limit_check")
+
+
+def downgrade() -> None:
+    """Restore rate_limit_prep/check columns with prior defaults."""
+    op.add_column(
+        "api_keys",
+        sa.Column(
+            "rate_limit_prep",
+            sa.Integer(),
+            nullable=False,
+            server_default="60",
+            comment="Max requests per 60s window for prep scope",
+        ),
+    )
+    op.add_column(
+        "api_keys",
+        sa.Column(
+            "rate_limit_check",
+            sa.Integer(),
+            nullable=False,
+            server_default="300",
+            comment="Max requests per 60s window for check scope",
+        ),
+    )
+    op.drop_column("api_keys", "plan_id")

--- a/scripts/manage_tenant.py
+++ b/scripts/manage_tenant.py
@@ -23,6 +23,7 @@ from sqlalchemy import create_engine, func, select
 from sqlalchemy.orm import Session
 
 from course_supporter.auth.keys import generate_api_key
+from course_supporter.auth.registry import get_auth_registry
 from course_supporter.config import settings
 from course_supporter.storage.orm import APIKey, Tenant
 
@@ -55,6 +56,15 @@ def create_tenant(args: argparse.Namespace) -> None:
 
 def create_key(args: argparse.Namespace) -> None:
     """Generate an API key for a tenant."""
+    registry = get_auth_registry()
+    if args.plan not in registry.plans:
+        print(
+            f"Unknown plan: {args.plan}. "
+            f"Available: {', '.join(sorted(registry.plans))}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     with get_sync_session() as session:
         tenant = session.execute(
             select(Tenant).where(Tenant.name == args.tenant)
@@ -72,8 +82,7 @@ def create_key(args: argparse.Namespace) -> None:
             key_prefix=key_prefix,
             label=args.label,
             scopes=scopes,
-            rate_limit_prep=args.rate_prep,
-            rate_limit_check=args.rate_check,
+            plan_id=args.plan,
         )
         session.add(api_key)
         session.commit()
@@ -82,6 +91,7 @@ def create_key(args: argparse.Namespace) -> None:
         print(f"   Key:     {full_key}")
         print(f"   Prefix:  {key_prefix}")
         print(f"   Scopes:  {', '.join(scopes)}")
+        print(f"   Plan:    {args.plan}")
         print(f"   Label:   {args.label}")
         print()
         print("Save this key now -- it cannot be retrieved later!")
@@ -141,7 +151,10 @@ def list_keys(args: argparse.Namespace) -> None:
         for i, key in enumerate(keys, 1):
             status = "active" if key.is_active else "revoked"
             scopes = ",".join(key.scopes) if key.scopes else "none"
-            print(f"  {i}. {key.key_prefix} [{key.label}] scopes={scopes} {status}")
+            print(
+                f"  {i}. {key.key_prefix} [{key.label}] "
+                f"scopes={scopes} plan={key.plan_id} {status}"
+            )
 
 
 def revoke_key(args: argparse.Namespace) -> None:
@@ -196,8 +209,11 @@ def main() -> None:
     p.add_argument("--tenant", required=True, help="Tenant name")
     p.add_argument("--scopes", required=True, help="Comma-separated: prep,check")
     p.add_argument("--label", default="default", help="Key label")
-    p.add_argument("--rate-prep", type=int, default=60, help="Prep rate limit/min")
-    p.add_argument("--rate-check", type=int, default=300, help="Check rate limit/min")
+    p.add_argument(
+        "--plan",
+        default="basic",
+        help="Rate-limit plan name from config/auth.yaml (default: basic)",
+    )
 
     # list-tenants
     sub.add_parser("list-tenants", help="List all tenants")

--- a/src/course_supporter/api/deps.py
+++ b/src/course_supporter/api/deps.py
@@ -74,8 +74,7 @@ async def get_current_tenant(
         tenant_id=api_key_record.tenant_id,
         tenant_name=api_key_record.tenant.name,
         scopes=api_key_record.scopes,
-        rate_limit_prep=api_key_record.rate_limit_prep,
-        rate_limit_check=api_key_record.rate_limit_check,
+        plan_id=api_key_record.plan_id,
         key_prefix=api_key_record.key_prefix,
     )
 

--- a/src/course_supporter/auth/context.py
+++ b/src/course_supporter/auth/context.py
@@ -10,12 +10,13 @@ from dataclasses import dataclass
 class TenantContext:
     """Authenticated tenant context, injected into every request.
 
-    Extracted from API key during authentication.
+    Extracted from API key during authentication. Rate limits are not
+    stored here — they are resolved from the auth registry using
+    ``plan_id`` at the moment a scope is enforced.
     """
 
     tenant_id: uuid.UUID
     tenant_name: str
     scopes: list[str]
-    rate_limit_prep: int
-    rate_limit_check: int
+    plan_id: str
     key_prefix: str

--- a/src/course_supporter/auth/registry.py
+++ b/src/course_supporter/auth/registry.py
@@ -1,12 +1,27 @@
-"""Auth scope registry — loaded from config/auth.yaml."""
+"""Auth scope registry — loaded from config/auth.yaml.
+
+The registry defines two policy objects:
+
+* ``scopes`` — authorization markers. A scope is a name + description;
+  an APIKey is permitted to perform operations whose endpoint requires
+  one of the key's scopes.
+* ``plans`` — named bundles of per-scope rate limits. Each APIKey points
+  to a plan via ``api_keys.plan_id``. At request time the matched
+  scope's limit is resolved from the key's plan.
+
+Rate limits are intentionally NOT stored in the database: they are
+policy, not per-key data, and belong in version-controlled config.
+Per-key overrides can be layered on later if the need arises.
+"""
 
 from __future__ import annotations
 
 from enum import StrEnum
+from functools import lru_cache
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 
 class AuthScope(StrEnum):
@@ -24,13 +39,59 @@ class ScopeConfig(BaseModel):
     """Metadata for a single scope."""
 
     description: str
-    rate_limit_field: str
 
 
 class AuthRegistryConfig(BaseModel):
     """Top-level auth config (config/auth.yaml)."""
 
     scopes: dict[str, ScopeConfig]
+    default_plan: str
+    plans: dict[str, dict[str, int]]
+
+    @model_validator(mode="after")
+    def _validate_plans(self) -> AuthRegistryConfig:
+        """Enforce invariants: default plan exists, plans cover all scopes.
+
+        Fails fast at startup if YAML is inconsistent, so drift is
+        impossible to deploy.
+        """
+        if self.default_plan not in self.plans:
+            raise ValueError(
+                f"default_plan '{self.default_plan}' not found in plans: "
+                f"{sorted(self.plans)}"
+            )
+
+        scope_names = set(self.scopes)
+        for plan_name, limits in self.plans.items():
+            plan_scopes = set(limits)
+            missing = scope_names - plan_scopes
+            extra = plan_scopes - scope_names
+            if missing:
+                raise ValueError(
+                    f"Plan '{plan_name}' is missing rate limits for scopes: "
+                    f"{sorted(missing)}"
+                )
+            if extra:
+                raise ValueError(
+                    f"Plan '{plan_name}' defines limits for unknown scopes: "
+                    f"{sorted(extra)}"
+                )
+            for scope_name, limit in limits.items():
+                if limit <= 0:
+                    raise ValueError(
+                        f"Plan '{plan_name}' has non-positive limit for "
+                        f"scope '{scope_name}': {limit}"
+                    )
+        return self
+
+    def limit_for(self, plan_id: str, scope: str) -> int:
+        """Resolve rate limit for a (plan_id, scope) pair.
+
+        Unknown plan_id falls back to default_plan — keeps runtime
+        resilient to stale DB rows after a plan rename.
+        """
+        plan = self.plans.get(plan_id) or self.plans[self.default_plan]
+        return plan[scope]
 
 
 def load_auth_registry(config_path: Path) -> AuthRegistryConfig:
@@ -48,3 +109,16 @@ def load_auth_registry(config_path: Path) -> AuthRegistryConfig:
     except yaml.YAMLError as e:
         raise ValueError(f"Failed to parse auth config '{config_path}': {e}") from e
     return AuthRegistryConfig.model_validate(raw)
+
+
+_DEFAULT_AUTH_CONFIG_PATH = Path("config/auth.yaml")
+
+
+@lru_cache(maxsize=1)
+def get_auth_registry() -> AuthRegistryConfig:
+    """Return the process-wide singleton registry.
+
+    Parses YAML once per process. Call ``get_auth_registry.cache_clear()``
+    in tests that need to reload with a different config.
+    """
+    return load_auth_registry(_DEFAULT_AUTH_CONFIG_PATH)

--- a/src/course_supporter/auth/scopes.py
+++ b/src/course_supporter/auth/scopes.py
@@ -8,7 +8,7 @@ from fastapi import Depends, HTTPException
 from course_supporter.api.deps import get_current_tenant
 from course_supporter.auth.context import TenantContext
 from course_supporter.auth.rate_limiter import InMemoryRateLimiter
-from course_supporter.auth.registry import AuthScope
+from course_supporter.auth.registry import AuthScope, get_auth_registry
 
 _tenant_dep = Depends(get_current_tenant)
 
@@ -43,14 +43,9 @@ def require_scope(
                 detail=f"Requires scope: {' or '.join(required_scopes)}",
             )
 
-        # 2. Rate limit check — explicit per scope
-        if matched_scope == AuthScope.PREP:
-            limit = tenant.rate_limit_prep
-        elif matched_scope == AuthScope.CHECK:
-            limit = tenant.rate_limit_check
-        else:
-            msg = f"No rate limit configured for scope: {matched_scope}"
-            raise ValueError(msg)
+        # 2. Rate limit: resolve from plan registry
+        registry = get_auth_registry()
+        limit = registry.limit_for(tenant.plan_id, matched_scope)
         key = f"{tenant.tenant_id}:{matched_scope}"
         allowed, retry_after = rate_limiter.check(key, limit)
 

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -92,15 +92,12 @@ class APIKey(Base):
         comment="JSON array of granted scopes. "
         "Defined in config/auth.yaml, validated by AuthScope enum",
     )
-    rate_limit_prep: Mapped[int] = mapped_column(
-        Integer,
-        default=60,
-        comment="Max requests per 60s window for prep scope",
-    )
-    rate_limit_check: Mapped[int] = mapped_column(
-        Integer,
-        default=300,
-        comment="Max requests per 60s window for check scope",
+    plan_id: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        server_default="basic",
+        comment="Name of plan from config/auth.yaml — "
+        "resolves to per-scope rate limits at runtime.",
     )
     is_active: Mapped[bool] = mapped_column(default=True)
     expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/tests/unit/test_api/test_generation_routes.py
+++ b/tests/unit/test_api/test_generation_routes.py
@@ -25,8 +25,7 @@ STUB_TENANT = MagicMock(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_api/test_health.py
+++ b/tests/unit/test_api/test_health.py
@@ -19,8 +19,7 @@ STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep", "check"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_api/test_homework_submit.py
+++ b/tests/unit/test_api/test_homework_submit.py
@@ -23,8 +23,7 @@ STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep", "check"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_api/test_job_status.py
+++ b/tests/unit/test_api/test_job_status.py
@@ -17,8 +17,7 @@ STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_api/test_material_entries.py
+++ b/tests/unit/test_api/test_material_entries.py
@@ -21,8 +21,7 @@ STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep", "check"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_api/test_materials.py
+++ b/tests/unit/test_api/test_materials.py
@@ -23,8 +23,7 @@ STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_api/test_nodes.py
+++ b/tests/unit/test_api/test_nodes.py
@@ -19,8 +19,7 @@ STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep", "check"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_api/test_reconciliation_routes.py
+++ b/tests/unit/test_api/test_reconciliation_routes.py
@@ -17,8 +17,7 @@ STUB_TENANT = MagicMock(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_api/test_security.py
+++ b/tests/unit/test_api/test_security.py
@@ -17,8 +17,7 @@ STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep", "check"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_api/test_slide_mapping.py
+++ b/tests/unit/test_api/test_slide_mapping.py
@@ -25,8 +25,7 @@ STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_api/test_storage.py
+++ b/tests/unit/test_api/test_storage.py
@@ -18,8 +18,7 @@ STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -18,8 +18,7 @@ def _make_api_key_record(
     tenant_is_active: bool = True,
     expires_at: datetime | None = None,
     scopes: list[str] | None = None,
-    rate_limit_prep: int = 100,
-    rate_limit_check: int = 1000,
+    plan_id: str = "basic",
 ) -> MagicMock:
     """Create a mock APIKey ORM object joined with Tenant."""
     tenant = MagicMock()
@@ -33,8 +32,7 @@ def _make_api_key_record(
     api_key_record.is_active = is_active
     api_key_record.expires_at = expires_at
     api_key_record.scopes = scopes or ["prep", "check"]
-    api_key_record.rate_limit_prep = rate_limit_prep
-    api_key_record.rate_limit_check = rate_limit_check
+    api_key_record.plan_id = plan_id
     api_key_record.key_prefix = "cs_test"
     return api_key_record
 
@@ -166,8 +164,7 @@ class TestAuthMiddleware:
         """Valid auth populates all TenantContext fields correctly."""
         record = _make_api_key_record(
             scopes=["prep"],
-            rate_limit_prep=50,
-            rate_limit_check=500,
+            plan_id="basic",
         )
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = record

--- a/tests/unit/test_auth_registry.py
+++ b/tests/unit/test_auth_registry.py
@@ -1,14 +1,16 @@
-"""Tests for auth scope registry (S3-005)."""
+"""Tests for auth scope/plan registry."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from course_supporter.auth.registry import (
     AuthRegistryConfig,
     AuthScope,
+    ScopeConfig,
     load_auth_registry,
 )
 
@@ -29,12 +31,16 @@ class TestLoadAuthRegistry:
     """load_auth_registry tests."""
 
     def test_loads_real_config(self) -> None:
-        """Loads config/auth.yaml successfully."""
+        """config/auth.yaml parses and passes validation."""
         config = load_auth_registry(Path("config/auth.yaml"))
+
         assert "prep" in config.scopes
         assert "check" in config.scopes
         assert config.scopes["prep"].description
-        assert config.scopes["check"].rate_limit_field == "rate_limit_check"
+        assert config.default_plan in config.plans
+        basic = config.plans[config.default_plan]
+        assert basic["prep"] > 0
+        assert basic["check"] > 0
 
     def test_file_not_found(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):
@@ -46,27 +52,75 @@ class TestLoadAuthRegistry:
         with pytest.raises(ValueError, match="Failed to parse"):
             load_auth_registry(bad)
 
-    def test_validation_error(self, tmp_path: Path) -> None:
-        from pydantic import ValidationError
 
-        bad = tmp_path / "bad.yaml"
-        bad.write_text("scopes:\n  prep:\n    wrong_field: x\n")
-        with pytest.raises(ValidationError):
-            load_auth_registry(bad)
+class TestAuthRegistryValidation:
+    """Invariants enforced at model construction time."""
 
-
-class TestAuthRegistryConfig:
-    """Pydantic model validation."""
+    def _make(
+        self,
+        *,
+        scopes: dict[str, ScopeConfig] | None = None,
+        default_plan: str = "basic",
+        plans: dict[str, dict[str, int]] | None = None,
+    ) -> AuthRegistryConfig:
+        return AuthRegistryConfig(
+            scopes=scopes
+            or {
+                "prep": ScopeConfig(description="prep"),
+                "check": ScopeConfig(description="check"),
+            },
+            default_plan=default_plan,
+            plans=plans or {"basic": {"prep": 60, "check": 300}},
+        )
 
     def test_valid(self) -> None:
-        config = AuthRegistryConfig.model_validate(
-            {
-                "scopes": {
-                    "prep": {
-                        "description": "Prep ops",
-                        "rate_limit_field": "rate_limit_prep",
-                    },
-                }
-            }
+        config = self._make()
+        assert config.plans["basic"]["prep"] == 60
+
+    def test_default_plan_must_exist(self) -> None:
+        with pytest.raises(ValidationError, match="default_plan 'missing'"):
+            self._make(default_plan="missing")
+
+    def test_plan_must_cover_every_scope(self) -> None:
+        with pytest.raises(ValidationError, match="missing rate limits"):
+            self._make(plans={"basic": {"prep": 60}})  # check missing
+
+    def test_plan_cannot_define_unknown_scope(self) -> None:
+        with pytest.raises(ValidationError, match="unknown scopes"):
+            self._make(
+                plans={"basic": {"prep": 60, "check": 300, "phantom": 10}},
+            )
+
+    def test_limit_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError, match="non-positive limit"):
+            self._make(plans={"basic": {"prep": 0, "check": 300}})
+
+
+class TestLimitFor:
+    """Runtime lookup helper."""
+
+    def test_known_plan_and_scope(self) -> None:
+        config = AuthRegistryConfig(
+            scopes={
+                "prep": ScopeConfig(description="prep"),
+                "check": ScopeConfig(description="check"),
+            },
+            default_plan="basic",
+            plans={
+                "basic": {"prep": 60, "check": 300},
+                "pro": {"prep": 600, "check": 3000},
+            },
         )
-        assert config.scopes["prep"].description == "Prep ops"
+        assert config.limit_for("pro", "prep") == 600
+
+    def test_unknown_plan_falls_back_to_default(self) -> None:
+        """Stale plan_id in DB falls back to default_plan — no runtime error."""
+        config = AuthRegistryConfig(
+            scopes={
+                "prep": ScopeConfig(description="prep"),
+                "check": ScopeConfig(description="check"),
+            },
+            default_plan="basic",
+            plans={"basic": {"prep": 60, "check": 300}},
+        )
+        assert config.limit_for("removed_plan", "prep") == 60

--- a/tests/unit/test_cost_report.py
+++ b/tests/unit/test_cost_report.py
@@ -20,8 +20,7 @@ STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep", "check"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_manage_tenant.py
+++ b/tests/unit/test_manage_tenant.py
@@ -82,8 +82,7 @@ class TestCreateKey:
             tenant="Test Tenant",
             scopes="prep,check",
             label="production",
-            rate_prep=60,
-            rate_check=300,
+            plan="basic",
         )
 
         with patch("scripts.manage_tenant.generate_api_key") as mock_gen:
@@ -115,8 +114,7 @@ class TestCreateKey:
             tenant="NonExistent",
             scopes="prep",
             label="default",
-            rate_prep=60,
-            rate_check=300,
+            plan="basic",
         )
 
         with pytest.raises(SystemExit) as exc_info:

--- a/tests/unit/test_mapping_validation.py
+++ b/tests/unit/test_mapping_validation.py
@@ -25,8 +25,7 @@ STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -107,13 +107,25 @@ class TestRateLimitAPI:
     @pytest.mark.asyncio
     async def test_429_response_in_api(self) -> None:
         """Exceeding rate limit returns 429 with Retry-After header."""
+        from course_supporter.auth.registry import (
+            AuthRegistryConfig,
+            ScopeConfig,
+        )
+
         tenant = TenantContext(
             tenant_id=uuid.uuid4(),
             tenant_name="test-tenant",
             scopes=["prep"],
-            rate_limit_prep=2,
-            rate_limit_check=1000,
+            plan_id="tight",
             key_prefix="cs_test",
+        )
+        test_registry = AuthRegistryConfig(
+            scopes={
+                "prep": ScopeConfig(description="prep"),
+                "check": ScopeConfig(description="check"),
+            },
+            default_plan="tight",
+            plans={"tight": {"prep": 2, "check": 1000}},
         )
 
         mock_session = AsyncMock()
@@ -126,48 +138,54 @@ class TestRateLimitAPI:
 
         rate_limiter._requests.clear()
         try:
-            async with AsyncClient(
-                transport=ASGITransport(app=app),
-                base_url="http://test",
-            ) as client:
-                node = MagicMock()
-                node.id = uuid.uuid4()
-                node.tenant_id = tenant.tenant_id
-                node.parent_materialnode_id = None
-                node.title = "Test"
-                node.description = None
-                node.learning_goal = None
-                node.expected_knowledge = None
-                node.expected_skills = None
-                node.default_language = None
-                node.order = 0
-                node.node_fingerprint = None
-                node.created_at = datetime.now(UTC)
-                node.updated_at = datetime.now(UTC)
+            with patch(
+                "course_supporter.auth.scopes.get_auth_registry",
+                return_value=test_registry,
+            ):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app),
+                    base_url="http://test",
+                ) as client:
+                    node = MagicMock()
+                    node.id = uuid.uuid4()
+                    node.tenant_id = tenant.tenant_id
+                    node.parent_materialnode_id = None
+                    node.title = "Test"
+                    node.description = None
+                    node.learning_goal = None
+                    node.expected_knowledge = None
+                    node.expected_skills = None
+                    node.default_language = None
+                    node.order = 0
+                    node.node_fingerprint = None
+                    node.created_at = datetime.now(UTC)
+                    node.updated_at = datetime.now(UTC)
 
-                with patch.object(MaterialNodeRepository, "create", return_value=node):
-                    # First 2 requests should pass (limit=2)
-                    r1 = await client.post(
-                        "/api/v1/nodes",
-                        json={"title": "Node 1"},
-                    )
-                    assert r1.status_code == 201
+                    with patch.object(
+                        MaterialNodeRepository, "create", return_value=node
+                    ):
+                        # First 2 requests should pass (limit=2)
+                        r1 = await client.post(
+                            "/api/v1/nodes",
+                            json={"title": "Node 1"},
+                        )
+                        assert r1.status_code == 201
 
-                    r2 = await client.post(
-                        "/api/v1/nodes",
-                        json={"title": "Node 2"},
-                    )
-                    assert r2.status_code == 201
+                        r2 = await client.post(
+                            "/api/v1/nodes",
+                            json={"title": "Node 2"},
+                        )
+                        assert r2.status_code == 201
 
-                    # Third request should be rate limited
-                    r3 = await client.post(
-                        "/api/v1/nodes",
-                        json={"title": "Node 3"},
-                    )
-                    assert r3.status_code == 429
-                    assert r3.json()["detail"] == "Rate limit exceeded"
-                    assert "retry-after" in r3.headers
-                    assert int(r3.headers["retry-after"]) >= 1
+                        # Third request should be rate limited
+                        r3 = await client.post(
+                            "/api/v1/nodes",
+                            json={"title": "Node 3"},
+                        )
+                        assert r3.status_code == 429
+                        assert r3.json()["detail"] == "Rate limit exceeded"
+                        assert "retry-after" in r3.headers
+                        assert int(r3.headers["retry-after"]) >= 1
         finally:
             rate_limiter._requests.clear()
             app.dependency_overrides.clear()

--- a/tests/unit/test_s3012_node_based_routing.py
+++ b/tests/unit/test_s3012_node_based_routing.py
@@ -26,8 +26,7 @@ STUB_TENANT = TenantContext(
     tenant_id=uuid.uuid4(),
     tenant_name="test-tenant",
     scopes=["prep", "check"],
-    rate_limit_prep=100,
-    rate_limit_check=1000,
+    plan_id="basic",
     key_prefix="cs_test",
 )
 

--- a/tests/unit/test_scope_enforcement.py
+++ b/tests/unit/test_scope_enforcement.py
@@ -22,8 +22,7 @@ def _make_tenant(scopes: list[str]) -> TenantContext:
         tenant_id=uuid.uuid4(),
         tenant_name="test-tenant",
         scopes=scopes,
-        rate_limit_prep=100,
-        rate_limit_check=1000,
+        plan_id="basic",
         key_prefix="cs_test",
     )
 

--- a/tests/unit/test_tenant_models.py
+++ b/tests/unit/test_tenant_models.py
@@ -44,22 +44,19 @@ class TestAPIKeyModel:
             key_prefix="cs_live_a1b2",
             label="production",
             scopes=["prep", "check"],
-            rate_limit_prep=100,
-            rate_limit_check=500,
+            plan_id="basic",
         )
 
         assert key.key_prefix == "cs_live_a1b2"
         assert key.label == "production"
         assert key.scopes == ["prep", "check"]
-        assert key.rate_limit_prep == 100
-        assert key.rate_limit_check == 500
+        assert key.plan_id == "basic"
 
     def test_api_key_defaults(self) -> None:
         """APIKey column defaults match spec."""
         table = APIKey.__table__
         assert table.c.is_active.default.arg is True
-        assert table.c.rate_limit_prep.default.arg == 60
-        assert table.c.rate_limit_check.default.arg == 300
+        assert table.c.plan_id.server_default.arg == "basic"
 
     def test_api_key_hash_unique_constraint(self) -> None:
         """APIKey model has unique constraint on key_hash column."""


### PR DESCRIPTION
Moves rate limits out of the database into config/auth.yaml as named plans. Each api_keys row carries a plan_id referencing a plan; at request time the matched scope's limit is looked up from the plan registry.

Changes:
- config/auth.yaml: scopes no longer carry rate_limit_field; new `plans:` section with `basic: {prep: 60, check: 300}` and `default_plan: basic`.
- auth/registry.py: AuthRegistryConfig now validates that default_plan exists and every plan covers every declared scope; lru_cache singleton via get_auth_registry().
- auth/scopes.py: hardcoded if/elif removed, resolves via registry.limit_for(plan_id, scope); unknown plan_id falls back to default_plan for resilience against renames.
- storage/orm.py + TenantContext + api/deps.py: drop rate_limit_prep and rate_limit_check, add plan_id (String(50), server_default "basic").
- Alembic c4d5e6f7a8b9: add plan_id NOT NULL DEFAULT 'basic', drop rate_limit_prep/check. Downgrade restores both columns with prior defaults. Roundtrip verified locally.
- scripts/manage_tenant.py: create-key takes --plan instead of --rate-prep/--rate-check, validated against registry at startup.
- Prod audit: the single active key used defaults (60, 300) — maps cleanly to 'basic' via server_default, no manual UPDATE required.

1866 tests pass; ruff + mypy strict clean.