### PR TITLE
chore(material_nodes): make order column nullable

### DIFF
--- a/migrations/versions/d5e6f7a8b9c0_materialnode_order_nullable.py
+++ b/migrations/versions/d5e6f7a8b9c0_materialnode_order_nullable.py
@@ -1,0 +1,56 @@
+"""material_nodes.order: drop NOT NULL, allow null for "no preferred order"
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4d5e6f7a8b9
+Create Date: 2026-04-15 21:00:00.000000
+
+NULL semantics: "no preferred sort position". Sort is
+``ORDER BY order ASC NULLS LAST, created_at ASC`` — NULL siblings appear
+last, sorted by creation time. Existing rows keep their integer values
+(default 0 from prior schema), no data migration required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d5e6f7a8b9c0"
+down_revision: str | Sequence[str] | None = "c4d5e6f7a8b9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Drop NOT NULL from material_nodes.order."""
+    op.alter_column(
+        "material_nodes",
+        "order",
+        existing_type=sa.Integer(),
+        nullable=True,
+        server_default=None,
+        existing_server_default=None,
+        comment=(
+            "Sibling sort key within parent. NULL = no preferred order, "
+            "sorted last by created_at. Sort: ORDER BY order ASC NULLS LAST, "
+            "created_at ASC."
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Restore NOT NULL on material_nodes.order.
+
+    Backfills any NULL rows to 0 before applying the constraint to avoid
+    rollback failure on rows that were inserted as NULL while column was
+    nullable.
+    """
+    op.execute('UPDATE material_nodes SET "order" = 0 WHERE "order" IS NULL')
+    op.alter_column(
+        "material_nodes",
+        "order",
+        existing_type=sa.Integer(),
+        nullable=False,
+        comment=None,
+    )

--- a/src/course_supporter/storage/material_node_repository.py
+++ b/src/course_supporter/storage/material_node_repository.py
@@ -163,7 +163,10 @@ class MaterialNodeRepository:
                 MaterialNode.tenant_id == tenant_id,
                 MaterialNode.parent_materialnode_id.is_(None),
             )
-            .order_by(MaterialNode.order)
+            .order_by(
+                MaterialNode.order.asc().nulls_last(),
+                MaterialNode.created_at.asc(),
+            )
         )
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
@@ -173,7 +176,10 @@ class MaterialNodeRepository:
         stmt = (
             select(MaterialNode)
             .where(MaterialNode.parent_materialnode_id == node_id)
-            .order_by(MaterialNode.order)
+            .order_by(
+                MaterialNode.order.asc().nulls_last(),
+                MaterialNode.created_at.asc(),
+            )
         )
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
@@ -212,7 +218,10 @@ class MaterialNodeRepository:
         stmt = (
             select(MaterialNode)
             .where(MaterialNode.id.in_(select(cte.c.id)))
-            .order_by(MaterialNode.order)
+            .order_by(
+                MaterialNode.order.asc().nulls_last(),
+                MaterialNode.created_at.asc(),
+            )
         )
         if include_materials:
             stmt = stmt.options(
@@ -330,7 +339,10 @@ class MaterialNodeRepository:
                 MaterialNode.parent_materialnode_id == node.parent_materialnode_id,
                 MaterialNode.tenant_id == node.tenant_id,
             )
-            .order_by(MaterialNode.order)
+            .order_by(
+                MaterialNode.order.asc().nulls_last(),
+                MaterialNode.created_at.asc(),
+            )
         )
         result = await self._session.execute(stmt)
         siblings = list(result.scalars().all())
@@ -421,13 +433,20 @@ class MaterialNodeRepository:
         self,
         parent_materialnode_id: uuid.UUID | None,
     ) -> int:
-        """Get next order value for siblings under the given parent."""
+        """Get next order value for siblings under the given parent.
+
+        Siblings with NULL order are excluded from MAX(); newly inserted
+        nodes always get an integer to keep them sortable above NULLs.
+        """
         # SQLAlchemy translates `column == None` to `IS NULL`
         stmt = select(func.coalesce(func.max(MaterialNode.order) + 1, 0)).where(
             MaterialNode.parent_materialnode_id == parent_materialnode_id,
         )
         result = await self._session.execute(stmt)
-        return result.scalar_one()
+        # coalesce ensures non-NULL int return; assert satisfies mypy strict
+        value = result.scalar_one()
+        assert value is not None
+        return int(value)
 
     async def _is_descendant(
         self,

--- a/src/course_supporter/storage/material_node_repository.py
+++ b/src/course_supporter/storage/material_node_repository.py
@@ -90,6 +90,13 @@ class MaterialNodeRepository:
     ) -> MaterialNode:
         """Create a new node with auto-incremented order among siblings.
 
+        Always assigns an integer ``order`` even though the column is
+        nullable. Rationale: a brand-new node is implicitly "the next one"
+        and should sort consistently above any siblings that author later
+        explicitly sets to NULL via PATCH (NULLs sort last). Authors who
+        want "no preferred position" for a fresh node should PATCH
+        ``order=null`` immediately after create.
+
         Args:
             tenant_id: FK to the owning tenant.
             title: Node title.
@@ -99,7 +106,7 @@ class MaterialNodeRepository:
                 materials under this node (inherited by children).
 
         Returns:
-            The newly created MaterialNode.
+            The newly created MaterialNode with integer ``order``.
         """
         next_order = await self._next_sibling_order(parent_materialnode_id)
         node = MaterialNode(
@@ -435,8 +442,13 @@ class MaterialNodeRepository:
     ) -> int:
         """Get next order value for siblings under the given parent.
 
-        Siblings with NULL order are excluded from MAX(); newly inserted
-        nodes always get an integer to keep them sortable above NULLs.
+        Returns ``MAX(order) + 1`` across siblings, or ``0`` if the parent
+        has no children (or all existing children have NULL order — MAX
+        ignores NULLs in SQL).
+
+        Always returns an integer: callers (``create()``) use this to
+        assign a sortable position to new nodes. NULL ``order`` is only
+        introduced via explicit PATCH on an existing node.
         """
         # SQLAlchemy translates `column == None` to `IS NULL`
         stmt = select(func.coalesce(func.max(MaterialNode.order) + 1, 0)).where(

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -152,7 +152,13 @@ class MaterialNode(Base):
         "Usually set on the root (course) node; inherited by children and "
         "their materials unless overridden on the material itself.",
     )
-    order: Mapped[int] = mapped_column(Integer, default=0)
+    order: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+        comment="Sibling sort key within parent. NULL = no preferred order, "
+        "sorted last by created_at. Sort: ORDER BY order ASC NULLS LAST, "
+        "created_at ASC.",
+    )
     node_fingerprint: Mapped[str | None] = mapped_column(
         String(64),
         comment="Merkle SHA-256 of content subtree. NULL = stale. "

--- a/tests/integration/test_material_node_repository_db.py
+++ b/tests/integration/test_material_node_repository_db.py
@@ -1,0 +1,199 @@
+"""Integration tests for MaterialNodeRepository against real PostgreSQL.
+
+Focus: sort behaviors that depend on actual SQL semantics
+(``NULLS LAST``, ``ORDER BY`` chaining), which mock-based unit tests
+cannot verify reliably.
+
+Requires ``docker compose up -d`` (PostgreSQL).
+Run with::
+
+    uv run pytest tests/integration/test_material_node_repository_db.py \\
+        --run-db -v
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.storage.material_node_repository import MaterialNodeRepository
+from course_supporter.storage.orm import MaterialNode, Tenant
+
+pytestmark = pytest.mark.requires_db
+
+
+class TestSortOrder:
+    """Verify ORDER BY order ASC NULLS LAST, created_at ASC across queries."""
+
+    @staticmethod
+    async def _seed_siblings(
+        session: AsyncSession, parent_id: uuid.UUID | None, tenant_id: uuid.UUID
+    ) -> dict[str, MaterialNode]:
+        """Create 4 siblings with mixed (order, created_at) configurations.
+
+        Layout (expected sort result):
+            1. integer order=0, created earliest
+            2. integer order=2, created later
+            3. NULL order, created earliest of NULL-group
+            4. NULL order, created latest
+        """
+        base = datetime.now(UTC) - timedelta(hours=1)
+        siblings = {
+            "ordered_first": MaterialNode(
+                tenant_id=tenant_id,
+                parent_materialnode_id=parent_id,
+                title="ordered_first",
+                order=0,
+                created_at=base,
+            ),
+            "ordered_second": MaterialNode(
+                tenant_id=tenant_id,
+                parent_materialnode_id=parent_id,
+                title="ordered_second",
+                order=2,
+                created_at=base + timedelta(minutes=20),
+            ),
+            "null_old": MaterialNode(
+                tenant_id=tenant_id,
+                parent_materialnode_id=parent_id,
+                title="null_old",
+                order=None,
+                created_at=base + timedelta(minutes=5),
+            ),
+            "null_new": MaterialNode(
+                tenant_id=tenant_id,
+                parent_materialnode_id=parent_id,
+                title="null_new",
+                order=None,
+                created_at=base + timedelta(minutes=40),
+            ),
+        }
+        for node in siblings.values():
+            session.add(node)
+        await session.flush()
+        return siblings
+
+    async def test_get_children_orders_nulls_last_then_created_at(
+        self,
+        db_session: AsyncSession,
+        seed_tenant: Tenant,
+        seed_root_node: MaterialNode,
+    ) -> None:
+        """get_children: integers first by order, then NULLs by created_at."""
+        await self._seed_siblings(
+            db_session,
+            parent_id=seed_root_node.id,
+            tenant_id=seed_tenant.id,
+        )
+
+        repo = MaterialNodeRepository(db_session)
+        result = await repo.get_children(seed_root_node.id)
+
+        titles = [n.title for n in result]
+        assert titles == [
+            "ordered_first",  # order=0
+            "ordered_second",  # order=2
+            "null_old",  # NULL, earlier created_at
+            "null_new",  # NULL, later created_at
+        ]
+
+    async def test_get_roots_applies_same_sort(
+        self,
+        db_session: AsyncSession,
+        seed_tenant: Tenant,
+    ) -> None:
+        """get_roots: NULLs last + created_at tie-break works at root level too."""
+        await self._seed_siblings(
+            db_session,
+            parent_id=None,
+            tenant_id=seed_tenant.id,
+        )
+
+        repo = MaterialNodeRepository(db_session)
+        result = await repo.get_roots(seed_tenant.id)
+
+        titles = [n.title for n in result]
+        assert titles == [
+            "ordered_first",
+            "ordered_second",
+            "null_old",
+            "null_new",
+        ]
+
+    async def test_get_subtree_applies_same_sort(
+        self,
+        db_session: AsyncSession,
+        seed_tenant: Tenant,
+        seed_root_node: MaterialNode,
+    ) -> None:
+        """get_subtree: ordering applied across descendants under root."""
+        await self._seed_siblings(
+            db_session,
+            parent_id=seed_root_node.id,
+            tenant_id=seed_tenant.id,
+        )
+
+        repo = MaterialNodeRepository(db_session)
+        subtree = await repo.get_subtree(seed_root_node.id)
+
+        # Root first, then ordered children
+        assert subtree[0].id == seed_root_node.id
+        children_titles = [n.title for n in seed_root_node.children]
+        assert children_titles == [
+            "ordered_first",
+            "ordered_second",
+            "null_old",
+            "null_new",
+        ]
+
+
+class TestNextSiblingOrderWithNulls:
+    """Verify _next_sibling_order behavior when siblings include NULLs."""
+
+    async def test_max_excludes_nulls(
+        self,
+        db_session: AsyncSession,
+        seed_tenant: Tenant,
+        seed_root_node: MaterialNode,
+    ) -> None:
+        """_next_sibling_order returns MAX(order)+1, ignoring NULL siblings."""
+        # Two ordered siblings (max=5) + one NULL
+        for title, order in (("a", 3), ("b", 5), ("c", None)):
+            db_session.add(
+                MaterialNode(
+                    tenant_id=seed_tenant.id,
+                    parent_materialnode_id=seed_root_node.id,
+                    title=title,
+                    order=order,
+                )
+            )
+        await db_session.flush()
+
+        repo = MaterialNodeRepository(db_session)
+        next_order = await repo._next_sibling_order(seed_root_node.id)
+        assert next_order == 6  # MAX(3, 5) + 1, NULL excluded
+
+    async def test_returns_zero_when_all_siblings_null(
+        self,
+        db_session: AsyncSession,
+        seed_tenant: Tenant,
+        seed_root_node: MaterialNode,
+    ) -> None:
+        """When all siblings are NULL, _next_sibling_order falls back to 0."""
+        for title in ("a", "b"):
+            db_session.add(
+                MaterialNode(
+                    tenant_id=seed_tenant.id,
+                    parent_materialnode_id=seed_root_node.id,
+                    title=title,
+                    order=None,
+                )
+            )
+        await db_session.flush()
+
+        repo = MaterialNodeRepository(db_session)
+        next_order = await repo._next_sibling_order(seed_root_node.id)
+        assert next_order == 0  # coalesce(NULL+1, 0) → 0

--- a/tests/unit/test_material_node.py
+++ b/tests/unit/test_material_node.py
@@ -35,10 +35,12 @@ class TestMaterialNodeModel:
         assert node.parent_materialnode_id == parent_materialnode_id
         assert node.description == "Details about subtopic A"
 
-    def test_order_default(self) -> None:
-        """Order column defaults to 0."""
+    def test_order_nullable(self) -> None:
+        """Order column is nullable; NULL = no preferred sort position."""
         col = MaterialNode.__table__.c.order
-        assert col.default.arg == 0
+        assert col.nullable is True
+        assert col.default is None
+        assert col.server_default is None
 
     def test_pk_uses_uuid7(self) -> None:
         """PK default is UUIDv7 factory."""


### PR DESCRIPTION
## Summary

  Makes `material_nodes.order` nullable. NULL = "no preferred sort position". Sort uses `ORDER BY order ASC NULLS LAST, created_at ASC` across all
  MaterialNode queries.

  This is **PR #1 of 5** in the Content Ingestion redesign roadmap (see `current-doc/db-schema-2026-04-14.md` Part II).

  ## Changes

  - ORM: `MaterialNode.order` → `Mapped[int | None]`, `nullable=True`, no default
  - Repository: 4 ORDER BY clauses updated with `nulls_last()` + `created_at` secondary sort
  - `_next_sibling_order` keeps returning auto-incremented integer for new rows
  - Alembic `d5e6f7a8b9c0`: ALTER COLUMN DROP NOT NULL; downgrade backfills NULLs to 0 before re-applying constraint
  - Test `test_order_default` → `test_order_nullable`
  - Doc: Part I updated to reflect nullable semantics

  ## Test plan

  - [x] Unit tests: 1866 passed, 23 skipped
  - [x] `ruff check` + `ruff format` clean
  - [x] `mypy --strict` clean
  - [x] Migration upgrade + downgrade + upgrade roundtrip on local Postgres
  - [ ] Post-deploy: smoke check that node listing still works