### PR TITLE
refactor(api): drop pedagogical fields from Node response schemas

### DIFF
--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -153,15 +153,6 @@ class NodeResponse(BaseModel):
     )
     title: str = Field(description="Node title.")
     description: str | None = Field(description="Optional node description.")
-    learning_goal: str | None = Field(
-        default=None, description="Learning goal for this node."
-    )
-    expected_knowledge: list[str] | None = Field(
-        default=None, description="Expected knowledge items."
-    )
-    expected_skills: list[str] | None = Field(
-        default=None, description="Expected skills items."
-    )
     default_language: str | None = Field(
         default=None,
         description=("Default ISO 639-1 language for materials under this subtree."),
@@ -198,15 +189,6 @@ class NodeTreeResponse(BaseModel):
     )
     title: str = Field(description="Node title.")
     description: str | None = Field(description="Optional node description.")
-    learning_goal: str | None = Field(
-        default=None, description="Learning goal for this node."
-    )
-    expected_knowledge: list[str] | None = Field(
-        default=None, description="Expected knowledge items."
-    )
-    expected_skills: list[str] | None = Field(
-        default=None, description="Expected skills items."
-    )
     order: int = Field(description="0-based position among siblings.")
     node_fingerprint: str | None = Field(
         description="Merkle hash of this node's content. ``null`` if not computed."
@@ -285,15 +267,6 @@ class NodeWithMaterialsResponse(BaseModel):
     id: uuid.UUID = Field(description="Unique node identifier (UUIDv7).")
     title: str = Field(description="Node title.")
     description: str | None = Field(description="Optional node description.")
-    learning_goal: str | None = Field(
-        default=None, description="Learning goal for this node."
-    )
-    expected_knowledge: list[str] | None = Field(
-        default=None, description="Expected knowledge items."
-    )
-    expected_skills: list[str] | None = Field(
-        default=None, description="Expected skills items."
-    )
     order: int = Field(description="0-based position among siblings.")
     node_fingerprint: str | None = Field(
         description="Merkle hash of this node's content. ``null`` if not computed."


### PR DESCRIPTION
Removes `learning_goal`, `expected_knowledge`, `expected_skills` from `NodeResponse`, `NodeTreeResponse`, and `NodeWithMaterialsResponse`.

These fields live on `MaterialNode` historically but are no longer the source of truth — production code reads pedagogical metadata from `StructureNodeEditable` (populated by Architect). Frontend TypeScript interfaces for Node/NodeTree/NodeWithMaterials never declared these fields either, so payload cleanup is an internal tidy with no client contract break.

Unblocks the follow-up PR to drop the three columns from the `material_nodes` table entirely.