### PR TITLE
feat(ingestion): add material_macro_sections + material_segments tables

### DIFF
--- a/migrations/versions/a8b9c0d1e2f3_add_material_macro_segment_tables.py
+++ b/migrations/versions/a8b9c0d1e2f3_add_material_macro_segment_tables.py
@@ -57,20 +57,13 @@ def upgrade() -> None:
             "start_pos",
             sa.Integer(),
             nullable=False,
-            comment=(
-                "Start position in the source-specific unit "
-                "(ms for video/audio, 1-indexed slide for presentation, "
-                "char offset for text/web)"
-            ),
+            comment="Start position in source-specific unit (see ORM for details)",
         ),
         sa.Column(
             "end_pos",
             sa.Integer(),
             nullable=False,
-            comment=(
-                "End position. Exclusive for video/audio/text/web, "
-                "inclusive for presentation"
-            ),
+            comment="End position in source-specific unit (see ORM for details)",
         ),
         sa.Column(
             "status",
@@ -89,10 +82,7 @@ def upgrade() -> None:
             "llm_call_id",
             sa.Uuid(),
             nullable=True,
-            comment=(
-                "FK to ExternalServiceCall that produced this section. "
-                "NULL for deterministic (text/web) sections"
-            ),
+            comment="FK to ExternalServiceCall; NULL for deterministic sections",
         ),
         sa.Column(
             "created_at",
@@ -157,30 +147,25 @@ def upgrade() -> None:
             "start_pos",
             sa.Integer(),
             nullable=False,
-            comment=(
-                "Absolute start in the source unit (not relative to the macro section)"
-            ),
+            comment="Absolute start in source unit (see ORM for details)",
         ),
         sa.Column(
             "end_pos",
             sa.Integer(),
             nullable=False,
-            comment="Absolute end in the source unit",
+            comment="Absolute end in source unit (see ORM for details)",
         ),
         sa.Column(
             "content",
             sa.Text(),
             nullable=False,
-            comment="Cleaned (LLM) or sliced (text/web) content of this segment",
+            comment="Cleaned (LLM) or sliced (text/web) content",
         ),
         sa.Column(
             "llm_call_id",
             sa.Uuid(),
             nullable=True,
-            comment=(
-                "FK to ExternalServiceCall that produced this segment. "
-                "NULL for deterministic (text/web) slices"
-            ),
+            comment="FK to ExternalServiceCall; NULL for deterministic slices",
         ),
         sa.Column(
             "created_at",

--- a/migrations/versions/a8b9c0d1e2f3_add_material_macro_segment_tables.py
+++ b/migrations/versions/a8b9c0d1e2f3_add_material_macro_segment_tables.py
@@ -1,0 +1,255 @@
+"""add material_macro_sections + material_segments tables
+
+Revision ID: a8b9c0d1e2f3
+Revises: f7a8b9c0d1e2
+Create Date: 2026-04-16 15:00:00.000000
+
+PR #4a of Content Ingestion roadmap: schema only, no reads/writes from
+pipeline code. Introduces the two-level Table-Of-Contents model that
+will replace the monolithic ``MaterialEntry.outline_content`` JSON
+blob in subsequent PRs.
+
+- ``material_macro_sections`` — TOC-level sections within a MaterialEntry
+  (Stage 5 pipeline output)
+- ``material_segments`` — cleaned/sliced content inside a macro section
+  (Stage 6 pipeline output)
+
+Position semantics live in column comments; unit depends on the parent
+MaterialEntry.source_type.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a8b9c0d1e2f3"
+down_revision: str | Sequence[str] | None = "f7a8b9c0d1e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create macro sections + segments tables and supporting indexes."""
+    op.create_table(
+        "material_macro_sections",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "material_entry_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="FK to parent MaterialEntry",
+        ),
+        sa.Column(
+            "order",
+            sa.Integer(),
+            nullable=False,
+            comment="0-indexed position within the TOC of this material entry",
+        ),
+        sa.Column(
+            "title",
+            sa.String(length=500),
+            nullable=False,
+            comment="Self-contained section title",
+        ),
+        sa.Column(
+            "start_pos",
+            sa.Integer(),
+            nullable=False,
+            comment=(
+                "Start position in the source-specific unit "
+                "(ms for video/audio, 1-indexed slide for presentation, "
+                "char offset for text/web)"
+            ),
+        ),
+        sa.Column(
+            "end_pos",
+            sa.Integer(),
+            nullable=False,
+            comment=(
+                "End position. Exclusive for video/audio/text/web, "
+                "inclusive for presentation"
+            ),
+        ),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "pending",
+                "ready",
+                "failed",
+                name="material_macro_section_status_enum",
+            ),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+            comment="Lifecycle status: pending → ready | failed",
+        ),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column(
+            "llm_call_id",
+            sa.Uuid(),
+            nullable=True,
+            comment=(
+                "FK to ExternalServiceCall that produced this section. "
+                "NULL for deterministic (text/web) sections"
+            ),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["material_entry_id"],
+            ["material_entries.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["llm_call_id"],
+            ["external_service_calls.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint("start_pos >= 0", name="ck_macro_start_pos_nonneg"),
+        sa.CheckConstraint("end_pos > start_pos", name="ck_macro_end_pos_gt_start"),
+        comment=(
+            "Table-of-contents level sections within a MaterialEntry "
+            "(Stage 5 output of the ingestion pipeline)"
+        ),
+    )
+    op.create_index(
+        op.f("ix_material_macro_sections_material_entry_id"),
+        "material_macro_sections",
+        ["material_entry_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_material_macro_sections_entry_order",
+        "material_macro_sections",
+        ["material_entry_id", "order"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_material_macro_sections_unready",
+        "material_macro_sections",
+        ["status"],
+        unique=False,
+        postgresql_where=sa.text("status != 'ready'"),
+    )
+
+    op.create_table(
+        "material_segments",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "macro_section_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="FK to parent MaterialMacroSection",
+        ),
+        sa.Column(
+            "order",
+            sa.Integer(),
+            nullable=False,
+            comment="0-indexed position within the parent macro section",
+        ),
+        sa.Column(
+            "start_pos",
+            sa.Integer(),
+            nullable=False,
+            comment=(
+                "Absolute start in the source unit (not relative to the macro section)"
+            ),
+        ),
+        sa.Column(
+            "end_pos",
+            sa.Integer(),
+            nullable=False,
+            comment="Absolute end in the source unit",
+        ),
+        sa.Column(
+            "content",
+            sa.Text(),
+            nullable=False,
+            comment="Cleaned (LLM) or sliced (text/web) content of this segment",
+        ),
+        sa.Column(
+            "llm_call_id",
+            sa.Uuid(),
+            nullable=True,
+            comment=(
+                "FK to ExternalServiceCall that produced this segment. "
+                "NULL for deterministic (text/web) slices"
+            ),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["macro_section_id"],
+            ["material_macro_sections.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["llm_call_id"],
+            ["external_service_calls.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint("start_pos >= 0", name="ck_segment_start_pos_nonneg"),
+        sa.CheckConstraint("end_pos > start_pos", name="ck_segment_end_pos_gt_start"),
+        comment=(
+            "Cleaned / sliced content segments inside a "
+            "MaterialMacroSection (Stage 6 output)"
+        ),
+    )
+    op.create_index(
+        op.f("ix_material_segments_macro_section_id"),
+        "material_segments",
+        ["macro_section_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_material_segments_macro_order",
+        "material_segments",
+        ["macro_section_id", "order"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_material_segments_macro_start_pos",
+        "material_segments",
+        ["macro_section_id", "start_pos"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop segments and macro sections tables plus the status enum."""
+    op.drop_index(
+        "ix_material_segments_macro_start_pos", table_name="material_segments"
+    )
+    op.drop_index("ix_material_segments_macro_order", table_name="material_segments")
+    op.drop_index(
+        op.f("ix_material_segments_macro_section_id"),
+        table_name="material_segments",
+    )
+    op.drop_table("material_segments")
+
+    op.drop_index(
+        "ix_material_macro_sections_unready",
+        table_name="material_macro_sections",
+    )
+    op.drop_index(
+        "ix_material_macro_sections_entry_order",
+        table_name="material_macro_sections",
+    )
+    op.drop_index(
+        op.f("ix_material_macro_sections_material_entry_id"),
+        table_name="material_macro_sections",
+    )
+    op.drop_table("material_macro_sections")
+
+    op.execute("DROP TYPE IF EXISTS material_macro_section_status_enum")

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -419,7 +419,6 @@ class MaterialMacroSection(Base):
             name="material_macro_section_status_enum",
             create_type=False,
         ),
-        default=MacroSectionStatus.PENDING,
         server_default="pending",
         comment="Lifecycle status: pending → ready | failed",
     )

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import uuid_utils as uuid7_lib
 from sqlalchemy import (
+    CheckConstraint,
     DateTime,
     Enum,
     Float,
@@ -17,6 +18,7 @@ from sqlalchemy import (
     Text,
     Uuid,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
@@ -339,6 +341,180 @@ class MaterialEntry(Base):
     # Relationships
     node: Mapped["MaterialNode"] = relationship(back_populates="materials")
     pending_job: Mapped["Job | None"] = relationship(back_populates="material_entries")
+    macro_sections: Mapped[list["MaterialMacroSection"]] = relationship(
+        back_populates="entry",
+        cascade="all, delete-orphan",
+    )
+
+
+class MacroSectionStatus(StrEnum):
+    """Processing status of a MaterialMacroSection."""
+
+    PENDING = "pending"
+    READY = "ready"
+    FAILED = "failed"
+
+
+class MaterialMacroSection(Base):
+    """Thematic table-of-contents entry within a MaterialEntry.
+
+    One row per logical section (thematic block, slide group, article
+    chapter). Produced by Stage 5 of the ingestion pipeline — LLM call
+    for video/audio/presentation or deterministic ladder for text/web.
+    Immutable after status=ready; regeneration replaces the set.
+    """
+
+    __tablename__ = "material_macro_sections"
+    __table_args__ = (
+        Index(
+            "ix_material_macro_sections_entry_order",
+            "material_entry_id",
+            "order",
+        ),
+        Index(
+            "ix_material_macro_sections_unready",
+            "status",
+            postgresql_where=text("status != 'ready'"),
+        ),
+        CheckConstraint("start_pos >= 0", name="ck_macro_start_pos_nonneg"),
+        CheckConstraint("end_pos > start_pos", name="ck_macro_end_pos_gt_start"),
+        {
+            "comment": (
+                "Table-of-contents level sections within a MaterialEntry "
+                "(Stage 5 output of the ingestion pipeline)"
+            ),
+        },
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
+    material_entry_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("material_entries.id", ondelete="CASCADE"),
+        index=True,
+        comment="FK to parent MaterialEntry",
+    )
+    order: Mapped[int] = mapped_column(
+        Integer,
+        comment="0-indexed position within the TOC of this material entry",
+    )
+    title: Mapped[str] = mapped_column(
+        String(500),
+        comment="Self-contained section title",
+    )
+    start_pos: Mapped[int] = mapped_column(
+        Integer,
+        comment="Start position in the source-specific unit "
+        "(ms for video/audio, 1-indexed slide for presentation, "
+        "char offset for text/web)",
+    )
+    end_pos: Mapped[int] = mapped_column(
+        Integer,
+        comment="End position. Exclusive for video/audio/text/web, "
+        "inclusive for presentation",
+    )
+    status: Mapped[str] = mapped_column(
+        Enum(
+            "pending",
+            "ready",
+            "failed",
+            name="material_macro_section_status_enum",
+            create_type=False,
+        ),
+        default=MacroSectionStatus.PENDING,
+        server_default="pending",
+        comment="Lifecycle status: pending → ready | failed",
+    )
+    error_message: Mapped[str | None] = mapped_column(Text)
+    llm_call_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("external_service_calls.id", ondelete="SET NULL"),
+        comment="FK to ExternalServiceCall that produced this section. "
+        "NULL for deterministic (text/web) sections",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    # Relationships
+    entry: Mapped["MaterialEntry"] = relationship(back_populates="macro_sections")
+    segments: Mapped[list["MaterialSegment"]] = relationship(
+        back_populates="macro_section",
+        cascade="all, delete-orphan",
+    )
+    llm_call: Mapped["ExternalServiceCall | None"] = relationship()
+
+
+class MaterialSegment(Base):
+    """Cleaned/sliced content unit inside a MaterialMacroSection.
+
+    Produced by Stage 6 of the ingestion pipeline. For
+    video/audio/presentation this is LLM-cleaned narrative; for text/web
+    this is a deterministic slice of ``MaterialEntry.processed_content``.
+
+    Invariants (enforced at write time, not by DB):
+    - For every segment of a given macro section:
+      ``segment.start_pos >= macro.start_pos AND
+       segment.end_pos <= macro.end_pos``
+    - Segments within a macro section must not overlap
+    - Sum of segment ranges covers the macro range without gaps
+    """
+
+    __tablename__ = "material_segments"
+    __table_args__ = (
+        Index(
+            "ix_material_segments_macro_order",
+            "macro_section_id",
+            "order",
+        ),
+        Index(
+            "ix_material_segments_macro_start_pos",
+            "macro_section_id",
+            "start_pos",
+        ),
+        CheckConstraint("start_pos >= 0", name="ck_segment_start_pos_nonneg"),
+        CheckConstraint("end_pos > start_pos", name="ck_segment_end_pos_gt_start"),
+        {
+            "comment": (
+                "Cleaned / sliced content segments inside a "
+                "MaterialMacroSection (Stage 6 output)"
+            ),
+        },
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
+    macro_section_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("material_macro_sections.id", ondelete="CASCADE"),
+        index=True,
+        comment="FK to parent MaterialMacroSection",
+    )
+    order: Mapped[int] = mapped_column(
+        Integer,
+        comment="0-indexed position within the parent macro section",
+    )
+    start_pos: Mapped[int] = mapped_column(
+        Integer,
+        comment="Absolute start in the source unit (not relative to the macro section)",
+    )
+    end_pos: Mapped[int] = mapped_column(
+        Integer,
+        comment="Absolute end in the source unit",
+    )
+    content: Mapped[str] = mapped_column(
+        Text,
+        comment="Cleaned (LLM) or sliced (text/web) content of this segment",
+    )
+    llm_call_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("external_service_calls.id", ondelete="SET NULL"),
+        comment="FK to ExternalServiceCall that produced this segment. "
+        "NULL for deterministic (text/web) slices",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    # Relationships
+    macro_section: Mapped["MaterialMacroSection"] = relationship(
+        back_populates="segments"
+    )
+    llm_call: Mapped["ExternalServiceCall | None"] = relationship()
 
 
 # ──────────────────────────────────────────────

--- a/tests/unit/test_orm_models.py
+++ b/tests/unit/test_orm_models.py
@@ -4,7 +4,9 @@ from course_supporter.storage.orm import (
     Base,
     ExternalServiceCall,
     MaterialEntry,
+    MaterialMacroSection,
     MaterialNode,
+    MaterialSegment,
 )
 
 
@@ -19,6 +21,8 @@ class TestORMModels:
             "api_keys",
             "material_nodes",
             "material_entries",
+            "material_macro_sections",
+            "material_segments",
             "structure_snapshots",
             "jobs",
             "external_service_calls",
@@ -46,6 +50,18 @@ class TestORMModels:
         assert "tenants.id" in fks
         assert "jobs.id" in fks
 
+    def test_material_macro_section_fks(self) -> None:
+        """MaterialMacroSection has FKs to entry and LLM call."""
+        fks = {fk.target_fullname for fk in MaterialMacroSection.__table__.foreign_keys}
+        assert "material_entries.id" in fks
+        assert "external_service_calls.id" in fks
+
+    def test_material_segment_fks(self) -> None:
+        """MaterialSegment has FKs to macro section and LLM call."""
+        fks = {fk.target_fullname for fk in MaterialSegment.__table__.foreign_keys}
+        assert "material_macro_sections.id" in fks
+        assert "external_service_calls.id" in fks
+
     def test_ondelete_cascade_on_primary_foreign_keys(self) -> None:
         """Primary FK constraints use CASCADE ondelete."""
         # Check key ownership FKs (not nullable SET NULL FKs like job_id)
@@ -53,10 +69,25 @@ class TestORMModels:
             (MaterialEntry, "materialnode_id"),
             (MaterialNode, "parent_materialnode_id"),
             (MaterialNode, "tenant_id"),
+            (MaterialMacroSection, "material_entry_id"),
+            (MaterialSegment, "macro_section_id"),
         ]
         for model, col_name in cascade_fks:
             col = model.__table__.c[col_name]
             fk = next(iter(col.foreign_keys))
             assert fk.ondelete == "CASCADE", (
                 f"{model.__tablename__}.{col_name} missing CASCADE ondelete"
+            )
+
+    def test_llm_call_fk_set_null(self) -> None:
+        """llm_call_id FKs use SET NULL (preserves cost audit on call delete)."""
+        set_null_fks = [
+            (MaterialMacroSection, "llm_call_id"),
+            (MaterialSegment, "llm_call_id"),
+        ]
+        for model, col_name in set_null_fks:
+            col = model.__table__.c[col_name]
+            fk = next(iter(col.foreign_keys))
+            assert fk.ondelete == "SET NULL", (
+                f"{model.__tablename__}.{col_name} must use SET NULL ondelete"
             )


### PR DESCRIPTION
PR #4a of the Content Ingestion roadmap — schema only, no pipeline code reads or writes these tables yet. Introduces the two-level table-of-contents model that will replace the monolithic `MaterialEntry.outline_content` JSON blob in follow-up PRs.

New tables:
- `material_macro_sections` — TOC-level sections within a MaterialEntry (Stage 5 pipeline output). Fields: order, title, start_pos, end_pos, status (pending/ready/failed), error_message, llm_call_id (SET NULL).
- `material_segments` — cleaned / sliced content inside a macro section (Stage 6 pipeline output). Fields: order, start_pos, end_pos, content, llm_call_id (SET NULL).

Position semantics (unit depends on `MaterialEntry.source_type`) live in column comments: ms for video/audio, 1-indexed slide for presentation, char offset for text/web.

Integrity: CHECK constraints (`start_pos >= 0`, `end_pos > start_pos`); composite indexes on `(parent_id, order)`; partial index on macro section status for unready rows.

Alembic `a8b9c0d1e2f3`; round-trip verified locally (downgrade drops tables + enum, re-upgrade clean).