### PR TITLE
refactor(ingestion): rename SourceProcessor to MaterialProcessor + 3-…

### DIFF
--- a/scripts/eval_architect.py
+++ b/scripts/eval_architect.py
@@ -91,7 +91,7 @@ async def run_real_pipeline() -> CourseStructure:
             source_url=str(filepath),
             title=filepath.stem,
         )
-        doc = await processor.process(material, router=None)
+        doc = await processor.process_raw(material, router=None)
         documents.append(doc)
 
     context = merge.merge(documents)

--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -71,7 +71,7 @@ class _MaterialProxy:
 async def _resolve_s3_url(
     material: _HasSourceUrl,
     s3: S3Client | None,
-) -> AsyncIterator[Any]:  # Any: processor.process() expects MaterialEntry
+) -> AsyncIterator[Any]:  # Any: processor.process_raw() expects MaterialEntry
     """Download S3 object to temp file, yield a proxy with local path.
 
     The original ORM object is **never mutated**, preventing accidental
@@ -197,7 +197,7 @@ async def arq_ingest_material(
                 raise ValueError(msg) from None
 
             async with _resolve_s3_url(entry, s3) as resolved:
-                doc = await processor.process(resolved, router=router)
+                doc = await processor.process_raw(resolved, router=router)
 
             content = doc.model_dump_json()
             detected_language = doc.metadata.get("detected_language")

--- a/src/course_supporter/ingestion/__init__.py
+++ b/src/course_supporter/ingestion/__init__.py
@@ -1,13 +1,13 @@
 """Ingestion pipeline for processing course materials."""
 
 from course_supporter.ingestion.base import (
+    MaterialProcessor,
     ProcessingError,
-    SourceProcessor,
     UnsupportedFormatError,
 )
 
 __all__ = [
+    "MaterialProcessor",
     "ProcessingError",
-    "SourceProcessor",
     "UnsupportedFormatError",
 ]

--- a/src/course_supporter/ingestion/base.py
+++ b/src/course_supporter/ingestion/base.py
@@ -1,4 +1,12 @@
-"""SourceProcessor abstract base class and custom exceptions."""
+"""MaterialProcessor abstract base class and custom exceptions.
+
+Defines the three-stage ingestion protocol used by all source-type
+processors (video, audio, presentation, text, web). Stage 1
+(``process_raw``) is implemented by every subclass today; Stages 5/6
+(``process_macro``, ``process_detail``) are stubbed in the base with
+``NotImplementedError`` and will be filled in per-source in follow-up
+PRs of the Content Ingestion roadmap.
+"""
 
 from __future__ import annotations
 
@@ -9,7 +17,11 @@ from course_supporter.models.source import SourceDocument
 
 if TYPE_CHECKING:
     from course_supporter.llm.router import ModelRouter
-    from course_supporter.storage.orm import MaterialEntry
+    from course_supporter.storage.orm import (
+        MaterialEntry,
+        MaterialMacroSection,
+        MaterialSegment,
+    )
 
 
 class ProcessingError(Exception):
@@ -20,21 +32,30 @@ class UnsupportedFormatError(ProcessingError):
     """Raised when source material format is not supported by processor."""
 
 
-class SourceProcessor(abc.ABC):
+class MaterialProcessor(abc.ABC):
     """Abstract base class for all source material processors.
 
-    Each processor transforms a MaterialEntry into a SourceDocument
-    containing extracted ContentChunks.
+    Encodes the three-stage Content Ingestion pipeline:
+
+    1. :meth:`process_raw` — parse raw upload into a ``SourceDocument``
+       (Stage 1). Implemented by every subclass today.
+    2. :meth:`process_macro` — generate table-of-contents sections
+       (Stage 5, LLM for video/audio/presentation, ladder for text/web).
+    3. :meth:`process_detail` — produce cleaned or sliced segments
+       per macro section (Stage 6).
+
+    Stages 5 and 6 currently stub to ``NotImplementedError`` in the
+    base class and are filled in per-source by PRs #4c+.
     """
 
     @abc.abstractmethod
-    async def process(
+    async def process_raw(
         self,
         source: MaterialEntry,
         *,
         router: ModelRouter | None = None,
     ) -> SourceDocument:
-        """Process source material and return structured document.
+        """Parse raw source material into a structured ``SourceDocument``.
 
         Args:
             source: The source material to process.
@@ -49,3 +70,35 @@ class SourceProcessor(abc.ABC):
             UnsupportedFormatError: If source format is not supported.
         """
         ...
+
+    async def process_macro(
+        self,
+        source: MaterialEntry,
+        *,
+        router: ModelRouter | None = None,
+    ) -> list[MaterialMacroSection]:
+        """Generate table-of-contents sections for the given material.
+
+        Default implementation raises ``NotImplementedError``. Each
+        processor will override this once the Stage 5 pipeline lands
+        (PR #4c+).
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.process_macro is not yet implemented"
+        )
+
+    async def process_detail(
+        self,
+        macro: MaterialMacroSection,
+        *,
+        router: ModelRouter | None = None,
+    ) -> list[MaterialSegment]:
+        """Produce cleaned/sliced segments for a single macro section.
+
+        Default implementation raises ``NotImplementedError``. Each
+        processor will override this once the Stage 6 pipeline lands
+        (PR #4c+).
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.process_detail is not yet implemented"
+        )

--- a/src/course_supporter/ingestion/factory.py
+++ b/src/course_supporter/ingestion/factory.py
@@ -27,7 +27,7 @@ from course_supporter.models.source import SourceType
 
 if TYPE_CHECKING:
     from course_supporter.config import Settings
-    from course_supporter.ingestion.base import SourceProcessor
+    from course_supporter.ingestion.base import MaterialProcessor
     from course_supporter.llm.router import ModelRouter
     from course_supporter.stt.router import STTRouter
     from course_supporter.vd.pipeline import VDPipeline
@@ -147,7 +147,7 @@ def create_processors(
     *,
     vd_pipeline: VDPipeline | None = None,
     stt_router: STTRouter | None = None,
-) -> dict[SourceType, SourceProcessor]:
+) -> dict[SourceType, MaterialProcessor]:
     """Create processor instances wired with heavy steps.
 
     Args:
@@ -160,7 +160,7 @@ def create_processors(
     Returns:
         Mapping from SourceType to fully-wired processor instances.
     """
-    video_processor: SourceProcessor
+    video_processor: MaterialProcessor
     if stt_router is not None:
         video_processor = VideoProcessor(
             stt_router=stt_router,

--- a/src/course_supporter/ingestion/presentation.py
+++ b/src/course_supporter/ingestion/presentation.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import structlog
 
 from course_supporter.ingestion.base import (
-    SourceProcessor,
+    MaterialProcessor,
     UnsupportedFormatError,
 )
 from course_supporter.ingestion.heavy_steps import (
@@ -34,7 +34,7 @@ logger = structlog.get_logger()
 SUPPORTED_EXTENSIONS = {".pdf", ".pptx"}
 
 
-class PresentationProcessor(SourceProcessor):
+class PresentationProcessor(MaterialProcessor):
     """Process PDF and PPTX presentations.
 
     Extracts text from each slide/page as SLIDE_TEXT chunks.
@@ -58,7 +58,7 @@ class PresentationProcessor(SourceProcessor):
 
         return local_parse_pdf
 
-    async def process(
+    async def process_raw(
         self,
         source: MaterialEntry,
         *,

--- a/src/course_supporter/ingestion/text.py
+++ b/src/course_supporter/ingestion/text.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import structlog
 
 from course_supporter.ingestion.base import (
-    SourceProcessor,
+    MaterialProcessor,
     UnsupportedFormatError,
 )
 from course_supporter.models.source import (
@@ -28,14 +28,14 @@ logger = structlog.get_logger()
 SUPPORTED_EXTENSIONS = {".md", ".markdown", ".docx", ".html", ".htm", ".txt"}
 
 
-class TextProcessor(SourceProcessor):
+class TextProcessor(MaterialProcessor):
     """Process text documents (MD, DOCX, HTML, TXT).
 
     Extracts headings and paragraphs without LLM.
     The router parameter is accepted but not used.
     """
 
-    async def process(
+    async def process_raw(
         self,
         source: MaterialEntry,
         *,

--- a/src/course_supporter/ingestion/video.py
+++ b/src/course_supporter/ingestion/video.py
@@ -19,8 +19,8 @@ from typing import TYPE_CHECKING, Any
 import structlog
 
 from course_supporter.ingestion.base import (
+    MaterialProcessor,
     ProcessingError,
-    SourceProcessor,
     UnsupportedFormatError,
 )
 from course_supporter.ingestion.heavy_steps import (
@@ -111,7 +111,7 @@ async def _extract_audio_ffmpeg(video_path: str) -> str:
     return audio_path
 
 
-class GeminiVideoProcessor(SourceProcessor):
+class GeminiVideoProcessor(MaterialProcessor):
     """Process video using Gemini Vision API.
 
     Uploads video to Gemini File API, sends to vision model
@@ -119,7 +119,7 @@ class GeminiVideoProcessor(SourceProcessor):
     ContentChunks.
     """
 
-    async def process(
+    async def process_raw(
         self,
         source: MaterialEntry,
         *,
@@ -245,7 +245,7 @@ class GeminiVideoProcessor(SourceProcessor):
         return chunks
 
 
-class WhisperVideoProcessor(SourceProcessor):
+class WhisperVideoProcessor(MaterialProcessor):
     """Process video using local FFmpeg + OpenAI Whisper.
 
     Extracts audio track via FFmpeg subprocess, then transcribes
@@ -270,7 +270,7 @@ class WhisperVideoProcessor(SourceProcessor):
 
         return local_transcribe
 
-    async def process(
+    async def process_raw(
         self,
         source: MaterialEntry,
         *,
@@ -422,7 +422,7 @@ class WhisperVideoProcessor(SourceProcessor):
         return chunks
 
 
-class VideoProcessor(SourceProcessor):
+class VideoProcessor(MaterialProcessor):
     """Composite video processor: parallel STT + VD.
 
     Runs audio transcription (STT Router) and visual description (VD) as
@@ -454,7 +454,7 @@ class VideoProcessor(SourceProcessor):
         self._stt_router = stt_router
         self._vd = vd_pipeline
 
-    async def process(
+    async def process_raw(
         self,
         source: MaterialEntry,
         *,

--- a/src/course_supporter/ingestion/web.py
+++ b/src/course_supporter/ingestion/web.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 import structlog
 
 from course_supporter.ingestion.base import (
-    SourceProcessor,
+    MaterialProcessor,
     UnsupportedFormatError,
 )
 from course_supporter.ingestion.heavy_steps import (
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 logger = structlog.get_logger()
 
 
-class WebProcessor(SourceProcessor):
+class WebProcessor(MaterialProcessor):
     """Process web pages by delegating to an injected scraping function.
 
     Uses ``ScrapeWebFunc`` for content extraction (default: ``local_scrape_web``).
@@ -51,7 +51,7 @@ class WebProcessor(SourceProcessor):
 
         return local_scrape_web
 
-    async def process(
+    async def process_raw(
         self,
         source: MaterialEntry,
         *,

--- a/src/course_supporter/models/source.py
+++ b/src/course_supporter/models/source.py
@@ -59,7 +59,7 @@ class ContentChunk(BaseModel):
 
 
 class SourceDocument(BaseModel):
-    """Unified output of any SourceProcessor.
+    """Unified output of any MaterialProcessor.
 
     Contains all extracted content from a single source material
     (one video, one PDF, etc.) as a list of ContentChunks.

--- a/tests/integration/test_arq_task_e2e.py
+++ b/tests/integration/test_arq_task_e2e.py
@@ -58,7 +58,7 @@ def _mock_processors(
         else {}
     )
     processor = MagicMock()
-    processor.process = AsyncMock(return_value=mock_doc)
+    processor.process_raw = AsyncMock(return_value=mock_doc)
     return {SourceType.WEB: processor}
 
 
@@ -68,7 +68,7 @@ def _failing_processors(
 ) -> dict[SourceType, MagicMock]:
     """Create a processors dict with a processor that raises."""
     processor = MagicMock()
-    processor.process = AsyncMock(side_effect=RuntimeError(error))
+    processor.process_raw = AsyncMock(side_effect=RuntimeError(error))
     return {SourceType.WEB: processor}
 
 

--- a/tests/unit/test_api/test_ingestion_task.py
+++ b/tests/unit/test_api/test_ingestion_task.py
@@ -62,7 +62,7 @@ def _mock_processors(
             source_url="https://example.com",
         )
     mock_proc = MagicMock()
-    mock_proc.process = AsyncMock(return_value=doc)
+    mock_proc.process_raw = AsyncMock(return_value=doc)
     return {source_type: mock_proc}
 
 
@@ -73,7 +73,7 @@ def _failing_processors(
 ) -> dict[SourceType, MagicMock]:
     """Create a processors dict with a processor that raises."""
     mock_proc = MagicMock()
-    mock_proc.process = AsyncMock(side_effect=RuntimeError(error))
+    mock_proc.process_raw = AsyncMock(side_effect=RuntimeError(error))
     return {source_type: mock_proc}
 
 
@@ -306,7 +306,7 @@ class TestArqIngestMaterial:
             )
 
         mock_proc = MagicMock()
-        mock_proc.process = capture_process
+        mock_proc.process_raw = capture_process
         procs = {SourceType.TEXT: mock_proc}
 
         with (

--- a/tests/unit/test_ingestion/test_presentation.py
+++ b/tests/unit/test_ingestion/test_presentation.py
@@ -38,7 +38,7 @@ class TestPDFProcessing:
             ]
         )
         proc = PresentationProcessor(parse_pdf_func=mock_parse)
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         assert isinstance(doc, SourceDocument)
         assert doc.source_type == SourceType.PRESENTATION
@@ -63,7 +63,7 @@ class TestPDFProcessing:
             parse_pdf_func=mock_parse,
             describe_slides_func=mock_describe,
         )
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         desc_chunks = [
             c for c in doc.chunks if c.chunk_type == ChunkType.SLIDE_DESCRIPTION
@@ -75,7 +75,7 @@ class TestPDFProcessing:
         """No pages -> empty chunks."""
         mock_parse = _mock_parse_pdf([])
         proc = PresentationProcessor(parse_pdf_func=mock_parse)
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         assert doc.chunks == []
         assert doc.metadata["page_count"] == 0
@@ -93,7 +93,7 @@ class TestPDFProcessing:
             parse_pdf_func=mock_parse,
             describe_slides_func=mock_describe,
         )
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         text_chunks = [c for c in doc.chunks if c.chunk_type == ChunkType.SLIDE_TEXT]
         assert len(text_chunks) == 1
@@ -110,7 +110,7 @@ class TestPDFProcessing:
             ]
         )
         proc = PresentationProcessor(parse_pdf_func=mock_parse)
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         text_chunks = [c for c in doc.chunks if c.chunk_type == ChunkType.SLIDE_TEXT]
         assert len(text_chunks) == 1
@@ -123,7 +123,7 @@ class TestPDFProcessing:
         """Pages with only whitespace are not returned by parse_pdf."""
         mock_parse = _mock_parse_pdf([])  # parse_pdf strips empty pages
         proc = PresentationProcessor(parse_pdf_func=mock_parse)
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         assert doc.chunks == []
         assert doc.metadata["page_count"] == 0
@@ -147,7 +147,7 @@ class TestPDFProcessing:
             parse_pdf_func=mock_parse,
             describe_slides_func=mock_describe,
         )
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         assert len(doc.chunks) == 4
         assert doc.chunks[0].chunk_type == ChunkType.SLIDE_TEXT
@@ -164,7 +164,7 @@ class TestPDFProcessing:
         mock_parse = _mock_parse_pdf([])
 
         proc = PresentationProcessor(parse_pdf_func=mock_parse)
-        await proc.process(_make_source(url="file:///slides.pdf"))
+        await proc.process_raw(_make_source(url="file:///slides.pdf"))
 
         mock_parse.assert_awaited_once()
         args = mock_parse.call_args
@@ -199,7 +199,7 @@ class TestPPTXProcessing:
 
         with patch("pptx.Presentation", return_value=mock_prs):
             proc = PresentationProcessor()
-            doc = await proc.process(
+            doc = await proc.process_raw(
                 _make_source(url="file:///s.pptx", filename="s.pptx")
             )
 
@@ -213,7 +213,7 @@ class TestPPTXProcessing:
 
         with patch("pptx.Presentation", return_value=mock_prs):
             proc = PresentationProcessor()
-            doc = await proc.process(
+            doc = await proc.process_raw(
                 _make_source(url="file:///s.pptx", filename="s.pptx"),
                 router=None,
             )
@@ -227,7 +227,7 @@ class TestPPTXProcessing:
 
         with patch("pptx.Presentation", return_value=mock_prs):
             proc = PresentationProcessor()
-            doc = await proc.process(
+            doc = await proc.process_raw(
                 _make_source(url="file:///s.pptx", filename="s.pptx")
             )
 
@@ -242,13 +242,13 @@ class TestPresentationProcessorValidation:
         with pytest.raises(
             UnsupportedFormatError, match="Unsupported presentation format"
         ):
-            await proc.process(_make_source(url="file:///s.doc", filename="s.doc"))
+            await proc.process_raw(_make_source(url="file:///s.doc", filename="s.doc"))
 
     async def test_invalid_source_type(self) -> None:
         """Non-presentation source_type -> UnsupportedFormatError."""
         proc = PresentationProcessor()
         with pytest.raises(UnsupportedFormatError, match="expects 'presentation'"):
-            await proc.process(_make_source(source_type="video"))
+            await proc.process_raw(_make_source(source_type="video"))
 
     async def test_slide_numbering(self) -> None:
         """Chunk index and metadata use 1-based slide numbers."""
@@ -260,7 +260,7 @@ class TestPresentationProcessorValidation:
             ]
         )
         proc = PresentationProcessor(parse_pdf_func=mock_parse)
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         for i, chunk in enumerate(doc.chunks):
             assert chunk.metadata["slide_number"] == i + 1
@@ -270,7 +270,7 @@ class TestPresentationProcessorValidation:
         """page_count and format in metadata."""
         mock_parse = _mock_parse_pdf([])
         proc = PresentationProcessor(parse_pdf_func=mock_parse)
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         assert doc.metadata["format"] == "pdf"
         assert doc.metadata["page_count"] == 0
@@ -282,7 +282,7 @@ class TestPresentationProcessorValidation:
 
         with patch("pptx.Presentation", return_value=mock_prs):
             proc = PresentationProcessor()
-            doc = await proc.process(
+            doc = await proc.process_raw(
                 _make_source(url="file:///s.pptx", filename="s.pptx")
             )
 

--- a/tests/unit/test_ingestion/test_schemas.py
+++ b/tests/unit/test_ingestion/test_schemas.py
@@ -5,8 +5,8 @@ from datetime import datetime
 import pytest
 
 from course_supporter.ingestion.base import (
+    MaterialProcessor,
     ProcessingError,
-    SourceProcessor,
     UnsupportedFormatError,
 )
 from course_supporter.models.course import CourseContext, SlideTimecodeRef
@@ -109,11 +109,11 @@ class TestCourseContext:
         assert ctx.slide_video_mappings[0].video_timecode_start == "00:05:30"
 
 
-class TestSourceProcessor:
+class TestMaterialProcessor:
     def test_source_processor_is_abstract(self) -> None:
-        """SourceProcessor cannot be instantiated directly."""
+        """MaterialProcessor cannot be instantiated directly."""
         with pytest.raises(TypeError):
-            SourceProcessor()  # type: ignore[abstract]
+            MaterialProcessor()  # type: ignore[abstract]
 
     def test_processing_error_hierarchy(self) -> None:
         """UnsupportedFormatError is a subclass of ProcessingError."""

--- a/tests/unit/test_ingestion/test_text.py
+++ b/tests/unit/test_ingestion/test_text.py
@@ -29,7 +29,7 @@ class TestMarkdownProcessing:
 
         with patch("pathlib.Path.read_text", return_value=md_content):
             proc = TextProcessor()
-            doc = await proc.process(_make_source())
+            doc = await proc.process_raw(_make_source())
 
         assert isinstance(doc, SourceDocument)
         headings = [c for c in doc.chunks if c.chunk_type == ChunkType.HEADING]
@@ -45,7 +45,7 @@ class TestMarkdownProcessing:
 
         with patch("pathlib.Path.read_text", return_value=md_content):
             proc = TextProcessor()
-            doc = await proc.process(_make_source())
+            doc = await proc.process_raw(_make_source())
 
         paragraphs = [c for c in doc.chunks if c.chunk_type == ChunkType.PARAGRAPH]
         assert len(paragraphs) == 2
@@ -67,7 +67,7 @@ class TestDocxProcessing:
 
         with patch("docx.Document", return_value=mock_doc):
             proc = TextProcessor()
-            doc = await proc.process(
+            doc = await proc.process_raw(
                 _make_source(url="file:///d.docx", filename="d.docx")
             )
 
@@ -90,7 +90,7 @@ class TestDocxProcessing:
 
         with patch("docx.Document", return_value=mock_doc):
             proc = TextProcessor()
-            doc = await proc.process(
+            doc = await proc.process_raw(
                 _make_source(url="file:///d.docx", filename="d.docx")
             )
 
@@ -105,7 +105,7 @@ class TestHTMLProcessing:
 
         with patch("pathlib.Path.read_text", return_value=html):
             proc = TextProcessor()
-            doc = await proc.process(
+            doc = await proc.process_raw(
                 _make_source(url="file:///p.html", filename="p.html")
             )
 
@@ -122,7 +122,7 @@ class TestPlainTextProcessing:
         """.txt → single PARAGRAPH chunk."""
         with patch("pathlib.Path.read_text", return_value="Just plain text"):
             proc = TextProcessor()
-            doc = await proc.process(
+            doc = await proc.process_raw(
                 _make_source(url="file:///f.txt", filename="f.txt")
             )
 
@@ -133,7 +133,7 @@ class TestPlainTextProcessing:
         """Empty content → empty chunks."""
         with patch("pathlib.Path.read_text", return_value=""):
             proc = TextProcessor()
-            doc = await proc.process(
+            doc = await proc.process_raw(
                 _make_source(url="file:///f.txt", filename="f.txt")
             )
 
@@ -145,13 +145,13 @@ class TestTextProcessorValidation:
         """.rtf → UnsupportedFormatError."""
         proc = TextProcessor()
         with pytest.raises(UnsupportedFormatError, match="Unsupported text format"):
-            await proc.process(_make_source(url="file:///f.rtf", filename="f.rtf"))
+            await proc.process_raw(_make_source(url="file:///f.rtf", filename="f.rtf"))
 
     async def test_invalid_source_type(self) -> None:
         """Non-text source_type → UnsupportedFormatError."""
         proc = TextProcessor()
         with pytest.raises(UnsupportedFormatError, match="expects 'text'"):
-            await proc.process(_make_source(source_type="video"))
+            await proc.process_raw(_make_source(source_type="video"))
 
     async def test_chunk_ordering(self) -> None:
         """Chunks indexed sequentially."""
@@ -159,7 +159,7 @@ class TestTextProcessorValidation:
 
         with patch("pathlib.Path.read_text", return_value=md_content):
             proc = TextProcessor()
-            doc = await proc.process(_make_source())
+            doc = await proc.process_raw(_make_source())
 
         indices = [c.index for c in doc.chunks]
         assert indices == list(range(len(indices)))
@@ -168,7 +168,7 @@ class TestTextProcessorValidation:
         """Output source_type is SourceType.TEXT."""
         with patch("pathlib.Path.read_text", return_value="text"):
             proc = TextProcessor()
-            doc = await proc.process(
+            doc = await proc.process_raw(
                 _make_source(url="file:///f.txt", filename="f.txt")
             )
 

--- a/tests/unit/test_ingestion/test_video.py
+++ b/tests/unit/test_ingestion/test_video.py
@@ -41,7 +41,7 @@ class TestGeminiVideoProcessor:
         )
 
         proc = GeminiVideoProcessor()
-        doc = await proc.process(_make_source(), router=router)
+        doc = await proc.process_raw(_make_source(), router=router)
 
         assert isinstance(doc, SourceDocument)
         assert doc.source_type == SourceType.VIDEO
@@ -56,7 +56,7 @@ class TestGeminiVideoProcessor:
         )
 
         proc = GeminiVideoProcessor()
-        doc = await proc.process(_make_source(), router=router)
+        doc = await proc.process_raw(_make_source(), router=router)
 
         chunk = doc.chunks[0]
         assert chunk.chunk_type == ChunkType.TRANSCRIPT
@@ -67,14 +67,14 @@ class TestGeminiVideoProcessor:
         """None router raises ProcessingError."""
         proc = GeminiVideoProcessor()
         with pytest.raises(ProcessingError, match="requires a ModelRouter"):
-            await proc.process(_make_source(), router=None)
+            await proc.process_raw(_make_source(), router=None)
 
     async def test_invalid_source_type(self) -> None:
         """Non-video source raises UnsupportedFormatError."""
         proc = GeminiVideoProcessor()
         router = AsyncMock()
         with pytest.raises(UnsupportedFormatError, match="expects 'video'"):
-            await proc.process(_make_source(source_type="text"), router=router)
+            await proc.process_raw(_make_source(source_type="text"), router=router)
 
     async def test_llm_failure_propagates(self) -> None:
         """Router exception propagates as-is."""
@@ -83,7 +83,7 @@ class TestGeminiVideoProcessor:
 
         proc = GeminiVideoProcessor()
         with pytest.raises(RuntimeError, match="API down"):
-            await proc.process(_make_source(), router=router)
+            await proc.process_raw(_make_source(), router=router)
 
     async def test_output_fields(self) -> None:
         """Verify output shape: source_type, source_url, metadata."""
@@ -94,7 +94,9 @@ class TestGeminiVideoProcessor:
         )
 
         proc = GeminiVideoProcessor()
-        doc = await proc.process(_make_source(url="s3://bucket/v.mp4"), router=router)
+        doc = await proc.process_raw(
+            _make_source(url="s3://bucket/v.mp4"), router=router
+        )
 
         assert doc.source_url == "s3://bucket/v.mp4"
         assert doc.metadata["strategy"] == "gemini"
@@ -108,7 +110,7 @@ class TestGeminiVideoProcessor:
         )
 
         proc = GeminiVideoProcessor()
-        doc = await proc.process(_make_source(), router=router)
+        doc = await proc.process_raw(_make_source(), router=router)
 
         assert len(doc.chunks) == 2
         assert doc.chunks[0].start_sec == 0.0
@@ -123,7 +125,7 @@ class TestGeminiVideoProcessor:
         )
 
         proc = GeminiVideoProcessor()
-        doc = await proc.process(_make_source(), router=router)
+        doc = await proc.process_raw(_make_source(), router=router)
 
         assert len(doc.chunks) == 2
         assert doc.chunks[0].text == "First"
@@ -140,7 +142,7 @@ class TestGeminiVideoProcessor:
         )
 
         proc = GeminiVideoProcessor()
-        doc = await proc.process(_make_source(), router=router)
+        doc = await proc.process_raw(_make_source(), router=router)
 
         indices = [c.index for c in doc.chunks]
         assert indices == [0, 1, 2]
@@ -155,7 +157,7 @@ class TestGeminiVideoProcessor:
 
         proc = GeminiVideoProcessor()
         with pytest.raises(ProcessingError, match="did not process the video"):
-            await proc.process(_make_source(), router=router)
+            await proc.process_raw(_make_source(), router=router)
 
     async def test_none_tokens_raises_processing_error(self) -> None:
         """tokens_in=None -> ProcessingError."""
@@ -167,7 +169,7 @@ class TestGeminiVideoProcessor:
 
         proc = GeminiVideoProcessor()
         with pytest.raises(ProcessingError, match="did not process the video"):
-            await proc.process(_make_source(), router=router)
+            await proc.process_raw(_make_source(), router=router)
 
 
 def _mock_stt_router(
@@ -205,7 +207,7 @@ class TestVideoProcessor:
             patch("pathlib.Path.unlink"),
             patch("pathlib.Path.is_file", return_value=True),
         ):
-            doc = await proc.process(_make_source())
+            doc = await proc.process_raw(_make_source())
 
         assert len(doc.chunks) == 1
         assert doc.chunks[0].chunk_type == ChunkType.TRANSCRIPT
@@ -215,13 +217,13 @@ class TestVideoProcessor:
         """UnsupportedFormatError for non-video source."""
         proc = VideoProcessor(stt_router=AsyncMock())
         with pytest.raises(UnsupportedFormatError, match="expects 'video'"):
-            await proc.process(_make_source(source_type="text"))
+            await proc.process_raw(_make_source(source_type="text"))
 
     async def test_url_source_rejected(self) -> None:
         """Remote URL raises ProcessingError (local files only)."""
         proc = VideoProcessor(stt_router=AsyncMock())
         with pytest.raises(ProcessingError, match="requires a local file path"):
-            await proc.process(_make_source(url="https://example.com/v.mp4"))
+            await proc.process_raw(_make_source(url="https://example.com/v.mp4"))
 
 
 class TestTimecodeToSeconds:

--- a/tests/unit/test_ingestion/test_video_whisper.py
+++ b/tests/unit/test_ingestion/test_video_whisper.py
@@ -54,7 +54,7 @@ class TestWhisperVideoProcessor:
             patch.object(proc, "_extract_audio", return_value="/tmp/audio.wav"),
             patch("pathlib.Path.unlink"),
         ):
-            doc = await proc.process(_make_source())
+            doc = await proc.process_raw(_make_source())
 
         assert isinstance(doc, SourceDocument)
         assert doc.source_type == SourceType.VIDEO
@@ -74,7 +74,7 @@ class TestWhisperVideoProcessor:
             patch.object(proc, "_extract_audio", return_value="/tmp/a.wav"),
             patch("pathlib.Path.unlink"),
         ):
-            doc = await proc.process(_make_source())
+            doc = await proc.process_raw(_make_source())
 
         chunk = doc.chunks[0]
         assert chunk.chunk_type == ChunkType.TRANSCRIPT
@@ -93,7 +93,7 @@ class TestWhisperVideoProcessor:
             ),
             pytest.raises(ProcessingError, match="FFmpeg not found"),
         ):
-            await proc.process(_make_source())
+            await proc.process_raw(_make_source())
 
     async def test_ffmpeg_fails(self) -> None:
         """FFmpeg subprocess error -> ProcessingError."""
@@ -107,7 +107,7 @@ class TestWhisperVideoProcessor:
             ),
             pytest.raises(ProcessingError, match="FFmpeg failed"),
         ):
-            await proc.process(_make_source())
+            await proc.process_raw(_make_source())
 
     async def test_empty_audio(self) -> None:
         """Empty transcription result -> empty chunks."""
@@ -118,7 +118,7 @@ class TestWhisperVideoProcessor:
             patch.object(proc, "_extract_audio", return_value="/tmp/a.wav"),
             patch("pathlib.Path.unlink"),
         ):
-            doc = await proc.process(_make_source())
+            doc = await proc.process_raw(_make_source())
 
         assert doc.chunks == []
 
@@ -126,7 +126,7 @@ class TestWhisperVideoProcessor:
         """Non-video source -> UnsupportedFormatError."""
         proc = WhisperVideoProcessor(transcribe_func=_mock_transcribe_func())
         with pytest.raises(UnsupportedFormatError, match="expects 'video'"):
-            await proc.process(_make_source(source_type="text"))
+            await proc.process_raw(_make_source(source_type="text"))
 
     async def test_cleanup_on_error(self) -> None:
         """Temp audio file cleaned up even when transcription fails."""
@@ -139,7 +139,7 @@ class TestWhisperVideoProcessor:
             patch("pathlib.Path.unlink", mock_unlink),
             pytest.raises(RuntimeError, match="Whisper crash"),
         ):
-            await proc.process(_make_source())
+            await proc.process_raw(_make_source())
 
         mock_unlink.assert_called_once()
 
@@ -152,7 +152,7 @@ class TestWhisperVideoProcessor:
             patch.object(proc, "_extract_audio", return_value="/tmp/audio.wav"),
             patch("pathlib.Path.unlink"),
         ):
-            await proc.process(_make_source())
+            await proc.process_raw(_make_source())
 
         mock_func.assert_awaited_once()
         args = mock_func.call_args
@@ -177,7 +177,7 @@ class TestWhisperUrlDownload:
                 ),
             ),
         ):
-            await proc.process(
+            await proc.process_raw(
                 _make_source(url="https://www.youtube.com/watch?v=abc123")
             )
 
@@ -198,7 +198,7 @@ class TestWhisperUrlDownload:
                 ),
             ),
         ):
-            await proc.process(_make_source(url="/tmp/local_video.mp4"))
+            await proc.process_raw(_make_source(url="/tmp/local_video.mp4"))
 
         mock_dl.assert_not_awaited()
 
@@ -268,7 +268,7 @@ class TestVideoProcessorParallel:
             patch("pathlib.Path.unlink"),
             patch("pathlib.Path.is_file", return_value=True),
         ):
-            doc = await proc.process(_make_source())
+            doc = await proc.process_raw(_make_source())
 
         assert len(doc.chunks) == 2
         assert doc.chunks[0].chunk_type == ChunkType.TRANSCRIPT
@@ -301,7 +301,7 @@ class TestVideoProcessorParallel:
             patch("pathlib.Path.unlink"),
             patch("pathlib.Path.is_file", return_value=True),
         ):
-            doc = await proc.process(_make_source())
+            doc = await proc.process_raw(_make_source())
 
         assert len(doc.chunks) == 1
         assert doc.chunks[0].chunk_type == ChunkType.TRANSCRIPT
@@ -327,7 +327,7 @@ class TestVideoProcessorParallel:
             patch("pathlib.Path.unlink"),
             patch("pathlib.Path.is_file", return_value=True),
         ):
-            doc = await proc.process(_make_source())
+            doc = await proc.process_raw(_make_source())
 
         assert doc.metadata["strategy"] == "stt"
         assert doc.metadata["vd_scenes"] == 0

--- a/tests/unit/test_ingestion/test_web.py
+++ b/tests/unit/test_ingestion/test_web.py
@@ -35,7 +35,7 @@ class TestWebProcessor:
     async def test_fetch_success(self) -> None:
         """Injected scrape_func -> SourceDocument with WEB_CONTENT chunks."""
         proc = WebProcessor(scrape_func=_mock_scrape_func())
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         assert isinstance(doc, SourceDocument)
         assert doc.source_type == SourceType.WEB
@@ -49,20 +49,20 @@ class TestWebProcessor:
         )
         proc = WebProcessor(scrape_func=mock_func)
         with pytest.raises(ProcessingError, match="Failed to fetch URL"):
-            await proc.process(_make_source())
+            await proc.process_raw(_make_source())
 
     async def test_extract_empty(self) -> None:
         """Empty text from scrape_func -> empty chunks (not an error)."""
         mock = _mock_scrape_func(text="", raw_html="<html></html>")
         proc = WebProcessor(scrape_func=mock)
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         assert doc.chunks == []
 
     async def test_domain_in_metadata(self) -> None:
         """URL domain extracted to metadata."""
         proc = WebProcessor(scrape_func=_mock_scrape_func(text="text"))
-        doc = await proc.process(
+        doc = await proc.process_raw(
             _make_source(url="https://docs.python.org/3/tutorial.html")
         )
 
@@ -72,13 +72,13 @@ class TestWebProcessor:
         """Non-web source_type -> UnsupportedFormatError."""
         proc = WebProcessor(scrape_func=_mock_scrape_func())
         with pytest.raises(UnsupportedFormatError, match="expects 'web'"):
-            await proc.process(_make_source(source_type="text"))
+            await proc.process_raw(_make_source(source_type="text"))
 
     async def test_content_snapshot(self) -> None:
         """Raw HTML saved in metadata for later re-processing."""
         raw_html = "<html><body>Raw content</body></html>"
         proc = WebProcessor(scrape_func=_mock_scrape_func(raw_html=raw_html))
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         assert doc.metadata["content_snapshot"] == raw_html
 
@@ -87,7 +87,7 @@ class TestWebProcessor:
         proc = WebProcessor(
             scrape_func=_mock_scrape_func(text="Para 1\n\nPara 2\n\nPara 3")
         )
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         assert len(doc.chunks) == 3
         indices = [c.index for c in doc.chunks]
@@ -96,7 +96,7 @@ class TestWebProcessor:
     async def test_fetched_at_in_metadata(self) -> None:
         """fetched_at timestamp present in metadata."""
         proc = WebProcessor(scrape_func=_mock_scrape_func())
-        doc = await proc.process(_make_source())
+        doc = await proc.process_raw(_make_source())
 
         assert "fetched_at" in doc.metadata
 
@@ -104,7 +104,7 @@ class TestWebProcessor:
         """scrape_func receives URL and ScrapeWebParams."""
         mock_func = _mock_scrape_func()
         proc = WebProcessor(scrape_func=mock_func)
-        await proc.process(_make_source(url="https://example.com/page"))
+        await proc.process_raw(_make_source(url="https://example.com/page"))
 
         mock_func.assert_awaited_once()
         args = mock_func.call_args

--- a/tests/unit/test_ingestion_callback.py
+++ b/tests/unit/test_ingestion_callback.py
@@ -428,7 +428,7 @@ class TestCallbackIntegrationWithArqTask:
         mock_doc.metadata = {}
 
         mock_processor = MagicMock()
-        mock_processor.process = AsyncMock(return_value=mock_doc)
+        mock_processor.process_raw = AsyncMock(return_value=mock_doc)
 
         session = AsyncMock()
         session.commit = AsyncMock()
@@ -509,7 +509,7 @@ class TestCallbackIntegrationWithArqTask:
         _factory_fn = "course_supporter.api.tasks.create_processors"
 
         mock_processor = MagicMock()
-        mock_processor.process = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_processor.process_raw = AsyncMock(side_effect=RuntimeError("boom"))
 
         mock_entry = MagicMock()
         mock_entry.source_url = "https://example.com"


### PR DESCRIPTION
…stage protocol

PR #4b of the Content Ingestion roadmap. Aligns the base class name with the design doc and introduces the 3-stage protocol that future PRs (#4c+) will fill in per source type.

- `SourceProcessor` (ABC) → `MaterialProcessor`
- `process()` → `process_raw()` (Stage 1, unchanged logic)
- Added stub `process_macro()` (Stage 5) and `process_detail()` (Stage 6) on the base class — both raise NotImplementedError so misses in derived classes fail loudly. Will be overridden in 4c+.

Mechanical rename across 4 processor implementations + 3 VideoProcessor subclasses, factory type hints, ingestion `__init__` export, docstring in `SourceDocument`, `arq_ingest_material` + `eval_architect.py` call sites, and 7 test files (unit + integration).

No behaviour change — processors still produce the same SourceDocument the old pipeline consumed. Writes to the new macro/segment tables land in subsequent PRs.