### PR TITLE
Task 0.1 — Soft-delete Infrastructure (vision §3 KD3, KD12).

### DIFF
--- a/migrations/versions/b9c0d1e2f3a4_0_1_soft_delete_infrastructure.py
+++ b/migrations/versions/b9c0d1e2f3a4_0_1_soft_delete_infrastructure.py
@@ -1,0 +1,119 @@
+"""0.1 soft-delete infrastructure: deleted_at column + protection trigger
+
+Revision ID: b9c0d1e2f3a4
+Revises: a8b9c0d1e2f3
+Create Date: 2026-04-27 12:24:42.000000
+
+Task 0.1 of the Phase 0 sprint (vision §3 KD3, KD12). Introduces the
+universal soft-delete primitive across every soft-deletable table:
+
+- ``deleted_at TIMESTAMPTZ NULL`` column on each listed table
+  (NULL = active, NOT NULL = soft-deleted).
+- Partial index ``ix_<table>_active`` on ``deleted_at IS NULL`` —
+  cheap "active-only" filtering without bloating the index with
+  deleted rows.
+- A single ``block_update_on_soft_deleted()`` plpgsql function and a
+  ``BEFORE UPDATE`` trigger applied to every soft-deletable table.
+  The trigger blocks any UPDATE on a row whose ``deleted_at IS NOT
+  NULL`` unless the only column actually changing is ``deleted_at``
+  itself (this preserves un-delete and idempotent re-delete via raw
+  SQL — see the soft-delete repository for the application-level
+  early-return path).
+
+Concrete cascade maps and per-entity content scrubbing are NOT
+configured here; they are wired with each entity's own phase task
+(1.x, 3.x, 4.x).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b9c0d1e2f3a4"
+down_revision: str | Sequence[str] | None = "a8b9c0d1e2f3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+SOFT_DELETABLE_TABLES: tuple[str, ...] = (
+    "tenants",
+    "api_keys",
+    "material_nodes",
+    "material_entries",
+    "material_macro_sections",
+    "material_segments",
+    "jobs",
+    "students",
+    "homework_submissions",
+)
+
+TRIGGER_FUNCTION_NAME = "block_update_on_soft_deleted"
+
+TRIGGER_FUNCTION_SQL = f"""
+CREATE OR REPLACE FUNCTION {TRIGGER_FUNCTION_NAME}()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF OLD.deleted_at IS NOT NULL THEN
+        IF (to_jsonb(NEW) - 'deleted_at')
+            IS DISTINCT FROM (to_jsonb(OLD) - 'deleted_at') THEN
+            RAISE EXCEPTION
+                'Cannot UPDATE soft-deleted row in %.%: '
+                'only deleted_at may change while deleted_at IS NOT NULL',
+                TG_TABLE_SCHEMA, TG_TABLE_NAME;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+def _trigger_name(table: str) -> str:
+    return f"trg_{table}_block_update_when_deleted"
+
+
+def upgrade() -> None:
+    """Add deleted_at + partial index + protection trigger on each table."""
+    for table in SOFT_DELETABLE_TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "deleted_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+                comment=(
+                    "Soft-delete timestamp (vision KD3). "
+                    "NULL = active; NOT NULL = soft-deleted."
+                ),
+            ),
+        )
+        op.create_index(
+            f"ix_{table}_active",
+            table,
+            ["deleted_at"],
+            unique=False,
+            postgresql_where=sa.text("deleted_at IS NULL"),
+        )
+
+    op.execute(TRIGGER_FUNCTION_SQL)
+
+    for table in SOFT_DELETABLE_TABLES:
+        op.execute(
+            f"CREATE TRIGGER {_trigger_name(table)} "
+            f"BEFORE UPDATE ON {table} "
+            f"FOR EACH ROW EXECUTE FUNCTION {TRIGGER_FUNCTION_NAME}();"
+        )
+
+
+def downgrade() -> None:
+    """Drop triggers, function, partial indexes, and the deleted_at column."""
+    for table in SOFT_DELETABLE_TABLES:
+        op.execute(f"DROP TRIGGER IF EXISTS {_trigger_name(table)} ON {table};")
+
+    op.execute(f"DROP FUNCTION IF EXISTS {TRIGGER_FUNCTION_NAME}();")
+
+    for table in SOFT_DELETABLE_TABLES:
+        op.drop_index(f"ix_{table}_active", table_name=table)
+        op.drop_column(table, "deleted_at")

--- a/migrations/versions/b9c0d1e2f3a4_0_1_soft_delete_infrastructure.py
+++ b/migrations/versions/b9c0d1e2f3a4_0_1_soft_delete_infrastructure.py
@@ -25,6 +25,7 @@ configured here; they are wired with each entity's own phase task
 (1.x, 3.x, 4.x).
 """
 
+import re
 from collections.abc import Sequence
 
 import sqlalchemy as sa
@@ -50,6 +51,26 @@ SOFT_DELETABLE_TABLES: tuple[str, ...] = (
 )
 
 TRIGGER_FUNCTION_NAME = "block_update_on_soft_deleted"
+
+# PostgreSQL DDL cannot use parameter binding for identifiers
+# (``CREATE TRIGGER $1 ON $2`` is not valid SQL — bind params attach
+# values, not object names), so trigger and table names below are
+# interpolated into raw SQL via f-strings. All names come from the
+# hardcoded ``SOFT_DELETABLE_TABLES`` whitelist or ``TRIGGER_FUNCTION_NAME``;
+# user input never reaches these strings. The assertions below make
+# that property executable: if a future contributor adds a non-plain
+# identifier to the whitelist, the migration fails on import rather
+# than emitting unsafe DDL.
+_SAFE_IDENT = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+assert all(_SAFE_IDENT.match(t) for t in SOFT_DELETABLE_TABLES), (
+    "SOFT_DELETABLE_TABLES must contain plain SQL identifiers; got: "
+    f"{[t for t in SOFT_DELETABLE_TABLES if not _SAFE_IDENT.match(t)]}"
+)
+assert _SAFE_IDENT.match(TRIGGER_FUNCTION_NAME), (
+    f"TRIGGER_FUNCTION_NAME must be a plain SQL identifier; got: "
+    f"{TRIGGER_FUNCTION_NAME!r}"
+)
 
 TRIGGER_FUNCTION_SQL = f"""
 CREATE OR REPLACE FUNCTION {TRIGGER_FUNCTION_NAME}()

--- a/src/course_supporter/storage/cascade.py
+++ b/src/course_supporter/storage/cascade.py
@@ -1,17 +1,41 @@
 """Cascade soft-delete service (vision §3 KD3, KD12).
 
 Engine for recursive soft-delete across declared FK relationships.
-This module ships only the engine; concrete ``cascade_map`` definitions
-land per-entity in subsequent phase tasks. The mapping is consumed
-either as an explicit dict or built dynamically from each model's
-``__cascades_soft_delete_to__`` class attribute.
+Concrete ``cascade_map`` definitions land per-entity in subsequent
+phase tasks; this module ships only the engine, consumed either via
+an explicit dict or via :func:`build_cascade_map` walking each model's
+``__cascades_soft_delete_to__`` declaration.
+
+Performance properties (relevant once concrete cascades are wired in
+phases 1, 3, 4):
+
+* **Breadth-first traversal.** The engine walks the cascade tree level
+  by level rather than depth-first. At each level it groups newly-
+  discovered entities by type and emits **one** batched ``SELECT ...
+  WHERE fk_col IN (parent_ids)`` per ``(parent_type, child_type)``
+  pair. This collapses what would otherwise be O(N) per-parent
+  queries into O(L * T) where L = depth of the cascade and
+  T = number of distinct (parent_type → child_type) pairs at each
+  level. For a typical course tree (Tenant → MaterialNode tree →
+  MaterialEntry → MaterialMacroSection → MaterialSegment) this is a
+  small constant number of round-trips regardless of fan-out.
+* **Cached FK resolution.** Mapper inspection runs once per
+  ``(parent_cls, child_cls)`` pair across the process via
+  :func:`functools.cache`; cascade traversals re-use the resolved
+  columns without re-walking SQLAlchemy metadata.
+
+Both optimisations preserve the original observable behaviour
+(idempotent root, single pre-write hook with the full id list,
+cycle-safe via a ``visited`` set, all-or-nothing write semantics).
 """
 
 from __future__ import annotations
 
 import uuid
+from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
+from functools import cache
 from typing import Any, Protocol, cast
 
 from sqlalchemy import inspect, select
@@ -61,20 +85,66 @@ def build_cascade_map(root: type) -> dict[type, list[type]]:
     return cascade_map
 
 
+@cache
+def _resolve_cascade_columns(parent_cls: type, child_cls: type) -> tuple[Any, Any]:
+    """Resolve the cascade query columns on ``child_cls``.
+
+    Returns ``(fk_col, deleted_at_col)`` where ``fk_col`` is the column
+    on ``child_cls`` that references ``parent_cls``'s mapped table and
+    ``deleted_at_col`` is the soft-delete column on the same child
+    table. Pure mapper inspection — does not touch the DB.
+
+    Cached via ``functools.cache``: SQLAlchemy mapper metadata is
+    fixed at import time, so each ``(parent_cls, child_cls)`` pair is
+    inspected at most once per process. The cache key is the pair of
+    classes themselves (both hashable).
+
+    Raises:
+        ValueError: when ``child_cls`` has no foreign key to
+            ``parent_cls`` (cascade misconfigured) or when it has more
+            than one (ambiguous cascade — must be made explicit by the
+            caller, e.g. by splitting the descendant or by omitting it
+            from the cascade map).
+    """
+    parent_mapper = cast(Mapper[Any], inspect(parent_cls))
+    child_mapper = cast(Mapper[Any], inspect(child_cls))
+    parent_table = parent_mapper.local_table
+
+    fk_cols = [
+        col
+        for col in child_mapper.local_table.columns
+        for fk in col.foreign_keys
+        if fk.column.table is parent_table
+    ]
+    if not fk_cols:
+        raise ValueError(
+            f"No foreign key from {child_cls.__name__} to {parent_cls.__name__}"
+        )
+    if len(fk_cols) > 1:
+        raise ValueError(
+            f"Ambiguous foreign keys from {child_cls.__name__} "
+            f"to {parent_cls.__name__}: {[c.name for c in fk_cols]}"
+        )
+
+    fk_col = fk_cols[0]
+    deleted_at_col = child_mapper.local_table.c.deleted_at
+    return fk_col, deleted_at_col
+
+
 class CascadeDeleteService:
     """Recursive soft-delete engine (vision §3 KD3, KD12).
 
-    Walks the ``cascade_map`` from the root entity, collecting every
-    reachable active descendant via foreign-key inspection, then writes
-    ``deleted_at`` on all of them in the same DB session. The caller
-    controls the transaction boundary — ``commit`` is not invoked here,
-    so a failure mid-traversal rolls back the whole cascade with the
-    surrounding transaction.
+    Walks the ``cascade_map`` breadth-first from the root entity,
+    collecting every reachable active descendant via batched queries,
+    then writes ``deleted_at`` on all of them in the same DB session.
+    The caller controls the transaction boundary — ``commit`` is not
+    invoked here, so a failure mid-traversal rolls back the whole
+    cascade with the surrounding transaction.
 
-    The skeleton ships with no concrete cascade maps wired up; those
-    arrive per-entity in subsequent phase tasks. ``build_cascade_map``
-    constructs the map at runtime from each model's
-    ``__cascades_soft_delete_to__`` declaration.
+    See module docstring for the BFS + caching rationale. Concrete
+    cascade maps land per-entity in subsequent phase tasks;
+    :func:`build_cascade_map` constructs the map at runtime from each
+    model's ``__cascades_soft_delete_to__`` declaration.
     """
 
     def __init__(self, session: AsyncSession) -> None:
@@ -104,10 +174,7 @@ class CascadeDeleteService:
             return
 
         ts = now if now is not None else datetime.now(UTC)
-        visited: set[tuple[type, uuid.UUID]] = set()
-        to_delete: list[SoftDeletableEntity] = []
-
-        await self._collect(entity, cascade_map, visited, to_delete)
+        to_delete = await self._collect_all(entity, cascade_map)
 
         if on_cancel_jobs is not None:
             await on_cancel_jobs([e.id for e in to_delete])
@@ -117,65 +184,82 @@ class CascadeDeleteService:
 
         await self._session.flush()
 
-    async def _collect(
+    async def _collect_all(
         self,
-        entity: SoftDeletableEntity,
+        root: SoftDeletableEntity,
         cascade_map: dict[type, list[type]],
-        visited: set[tuple[type, uuid.UUID]],
-        to_delete: list[SoftDeletableEntity],
-    ) -> None:
-        cls = type(entity)
-        key = (cls, entity.id)
-        if key in visited:
-            return
-        visited.add(key)
-        if entity.deleted_at is not None:
-            return
+    ) -> list[SoftDeletableEntity]:
+        """BFS across cascade levels with batched fetch per pair.
 
-        to_delete.append(entity)
+        At each level, newly-discovered entities are grouped by their
+        concrete type. For every ``(parent_type, child_type)`` pair
+        present in ``cascade_map``, a single ``SELECT ... WHERE fk IN
+        (parent_ids) AND deleted_at IS NULL`` query collects the next
+        level's children — independent of how many parents are at this
+        level. The ``visited`` set deduplicates entities that are
+        reachable through multiple paths (DAG cascades) and terminates
+        cycles.
+        """
+        visited: set[tuple[type, uuid.UUID]] = set()
+        to_delete: list[SoftDeletableEntity] = []
+        frontier: list[SoftDeletableEntity] = [root]
 
-        for child_cls in cascade_map.get(cls, []):
-            for child in await self._fetch_active_children(entity, child_cls):
-                await self._collect(child, cascade_map, visited, to_delete)
+        while frontier:
+            current: list[SoftDeletableEntity] = []
+            for entity in frontier:
+                cls = type(entity)
+                key = (cls, entity.id)
+                if key in visited:
+                    continue
+                visited.add(key)
+                if entity.deleted_at is not None:
+                    continue
+                to_delete.append(entity)
+                current.append(entity)
 
-    async def _fetch_active_children(
+            by_parent_type: dict[type, list[SoftDeletableEntity]] = defaultdict(list)
+            for entity in current:
+                by_parent_type[type(entity)].append(entity)
+
+            next_frontier: list[SoftDeletableEntity] = []
+            for parent_cls, parents in by_parent_type.items():
+                child_classes = cascade_map.get(parent_cls, [])
+                if not child_classes:
+                    continue
+                parent_ids = [p.id for p in parents]
+                for child_cls in child_classes:
+                    children = await self._fetch_active_children_batch(
+                        parent_cls, parent_ids, child_cls
+                    )
+                    next_frontier.extend(children)
+
+            frontier = next_frontier
+
+        return to_delete
+
+    async def _fetch_active_children_batch(
         self,
-        parent: SoftDeletableEntity,
+        parent_cls: type,
+        parent_ids: list[uuid.UUID],
         child_cls: type,
     ) -> list[SoftDeletableEntity]:
-        """Return active rows of ``child_cls`` linked to ``parent`` by FK.
+        """Batched fetch of active ``child_cls`` rows whose FK ∈ ``parent_ids``.
 
-        Resolves the relationship by inspecting ``child_cls``'s mapped
-        columns and picking the one that references the parent's
-        mapped table. Raises ``ValueError`` on zero or multiple matches
-        — ambiguous cascade relationships must be made explicit by the
-        caller (e.g., split the descendant into a separate type, or
-        omit it from the cascade map).
+        Issues a single ``SELECT ... WHERE fk_col IN (parent_ids) AND
+        deleted_at IS NULL`` query. Returns ``[]`` immediately on an
+        empty ``parent_ids`` (avoids constructing an invalid empty-IN
+        SQL). FK resolution is delegated to the cached
+        :func:`_resolve_cascade_columns`, so the per-call cost is just
+        query construction + execution.
         """
-        parent_mapper = cast(Mapper[Any], inspect(type(parent)))
-        child_mapper = cast(Mapper[Any], inspect(child_cls))
-        parent_table = parent_mapper.local_table
+        if not parent_ids:
+            return []
 
-        fk_cols = [
-            col
-            for col in child_mapper.local_table.columns
-            for fk in col.foreign_keys
-            if fk.column.table is parent_table
-        ]
-        if not fk_cols:
-            raise ValueError(
-                f"No foreign key from {child_cls.__name__} to {type(parent).__name__}"
-            )
-        if len(fk_cols) > 1:
-            raise ValueError(
-                f"Ambiguous foreign keys from {child_cls.__name__} "
-                f"to {type(parent).__name__}: {[c.name for c in fk_cols]}"
-            )
-
-        fk_col = fk_cols[0]
-        deleted_at_col = child_mapper.local_table.c.deleted_at
+        fk_col, deleted_at_col = _resolve_cascade_columns(parent_cls, child_cls)
         stmt: Any = (
-            select(child_cls).where(fk_col == parent.id).where(deleted_at_col.is_(None))
+            select(child_cls)
+            .where(fk_col.in_(parent_ids))
+            .where(deleted_at_col.is_(None))
         )
         result = await self._session.execute(stmt)
         return list(result.scalars().all())

--- a/src/course_supporter/storage/cascade.py
+++ b/src/course_supporter/storage/cascade.py
@@ -1,0 +1,181 @@
+"""Cascade soft-delete service (vision §3 KD3, KD12).
+
+Engine for recursive soft-delete across declared FK relationships.
+This module ships only the engine; concrete ``cascade_map`` definitions
+land per-entity in subsequent phase tasks. The mapping is consumed
+either as an explicit dict or built dynamically from each model's
+``__cascades_soft_delete_to__`` class attribute.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Any, Protocol, cast
+
+from sqlalchemy import inspect, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapper
+
+
+class SoftDeletableEntity(Protocol):
+    """Structural type for any model that participates in cascade delete.
+
+    Concrete soft-deletable models (mixed with ``SoftDeleteMixin``) all
+    expose these two attributes — ``id`` is declared on each model and
+    ``deleted_at`` is contributed by the mixin.
+    """
+
+    id: uuid.UUID
+    deleted_at: datetime | None
+
+
+OnCancelJobs = Callable[[list[uuid.UUID]], Awaitable[None]]
+"""Hook invoked once per cascade with all entity ids about to be deleted.
+
+Concrete Job-cancellation logic lives outside this engine — wired by
+the caller in task 0.3 and in per-entity tasks in later phases.
+"""
+
+
+def build_cascade_map(root: type) -> dict[type, list[type]]:
+    """Build a cascade_map from ``__cascades_soft_delete_to__`` declarations.
+
+    Walks the transitive closure starting from ``root``: every visited
+    type contributes its ``__cascades_soft_delete_to__`` list as the
+    map entry, and each direct descendant is then recursed into.
+
+    Returns ``{type: [direct descendant types]}`` suitable for
+    :meth:`CascadeDeleteService.soft_delete_with_cascade`.
+    """
+    cascade_map: dict[type, list[type]] = {}
+    pending: list[type] = [root]
+    while pending:
+        cls = pending.pop()
+        if cls in cascade_map:
+            continue
+        descendants: list[type] = list(getattr(cls, "__cascades_soft_delete_to__", []))
+        cascade_map[cls] = descendants
+        pending.extend(descendants)
+    return cascade_map
+
+
+class CascadeDeleteService:
+    """Recursive soft-delete engine (vision §3 KD3, KD12).
+
+    Walks the ``cascade_map`` from the root entity, collecting every
+    reachable active descendant via foreign-key inspection, then writes
+    ``deleted_at`` on all of them in the same DB session. The caller
+    controls the transaction boundary — ``commit`` is not invoked here,
+    so a failure mid-traversal rolls back the whole cascade with the
+    surrounding transaction.
+
+    The skeleton ships with no concrete cascade maps wired up; those
+    arrive per-entity in subsequent phase tasks. ``build_cascade_map``
+    constructs the map at runtime from each model's
+    ``__cascades_soft_delete_to__`` declaration.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def soft_delete_with_cascade(
+        self,
+        entity: SoftDeletableEntity,
+        cascade_map: dict[type, list[type]],
+        *,
+        on_cancel_jobs: OnCancelJobs | None = None,
+        now: datetime | None = None,
+    ) -> None:
+        """Soft-delete ``entity`` and every active descendant.
+
+        Idempotent: returns immediately if ``entity`` is already
+        soft-deleted (no UPDATE, no hook call). Cycle-safe via a
+        ``visited`` set keyed by ``(type, id)`` so cascade_map cycles
+        cannot trigger infinite recursion.
+
+        ``on_cancel_jobs`` is invoked once before any UPDATE with the
+        full list of collected ids. ``now`` overrides the timestamp
+        applied to all rows (defaults to ``datetime.now(UTC)``);
+        useful for deterministic tests.
+        """
+        if entity.deleted_at is not None:
+            return
+
+        ts = now if now is not None else datetime.now(UTC)
+        visited: set[tuple[type, uuid.UUID]] = set()
+        to_delete: list[SoftDeletableEntity] = []
+
+        await self._collect(entity, cascade_map, visited, to_delete)
+
+        if on_cancel_jobs is not None:
+            await on_cancel_jobs([e.id for e in to_delete])
+
+        for row in to_delete:
+            row.deleted_at = ts
+
+        await self._session.flush()
+
+    async def _collect(
+        self,
+        entity: SoftDeletableEntity,
+        cascade_map: dict[type, list[type]],
+        visited: set[tuple[type, uuid.UUID]],
+        to_delete: list[SoftDeletableEntity],
+    ) -> None:
+        cls = type(entity)
+        key = (cls, entity.id)
+        if key in visited:
+            return
+        visited.add(key)
+        if entity.deleted_at is not None:
+            return
+
+        to_delete.append(entity)
+
+        for child_cls in cascade_map.get(cls, []):
+            for child in await self._fetch_active_children(entity, child_cls):
+                await self._collect(child, cascade_map, visited, to_delete)
+
+    async def _fetch_active_children(
+        self,
+        parent: SoftDeletableEntity,
+        child_cls: type,
+    ) -> list[SoftDeletableEntity]:
+        """Return active rows of ``child_cls`` linked to ``parent`` by FK.
+
+        Resolves the relationship by inspecting ``child_cls``'s mapped
+        columns and picking the one that references the parent's
+        mapped table. Raises ``ValueError`` on zero or multiple matches
+        — ambiguous cascade relationships must be made explicit by the
+        caller (e.g., split the descendant into a separate type, or
+        omit it from the cascade map).
+        """
+        parent_mapper = cast(Mapper[Any], inspect(type(parent)))
+        child_mapper = cast(Mapper[Any], inspect(child_cls))
+        parent_table = parent_mapper.local_table
+
+        fk_cols = [
+            col
+            for col in child_mapper.local_table.columns
+            for fk in col.foreign_keys
+            if fk.column.table is parent_table
+        ]
+        if not fk_cols:
+            raise ValueError(
+                f"No foreign key from {child_cls.__name__} to {type(parent).__name__}"
+            )
+        if len(fk_cols) > 1:
+            raise ValueError(
+                f"Ambiguous foreign keys from {child_cls.__name__} "
+                f"to {type(parent).__name__}: {[c.name for c in fk_cols]}"
+            )
+
+        fk_col = fk_cols[0]
+        deleted_at_col: Any = child_cls.deleted_at  # type: ignore[attr-defined]
+        stmt: Any = (
+            select(child_cls).where(fk_col == parent.id).where(deleted_at_col.is_(None))
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())

--- a/src/course_supporter/storage/cascade.py
+++ b/src/course_supporter/storage/cascade.py
@@ -173,7 +173,7 @@ class CascadeDeleteService:
             )
 
         fk_col = fk_cols[0]
-        deleted_at_col: Any = child_cls.deleted_at  # type: ignore[attr-defined]
+        deleted_at_col = child_mapper.local_table.c.deleted_at
         stmt: Any = (
             select(child_cls).where(fk_col == parent.id).where(deleted_at_col.is_(None))
         )

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, ClassVar
 
 import uuid_utils as uuid7_lib
 from sqlalchemy import (
@@ -31,6 +31,48 @@ def _uuid7() -> uuid.UUID:
 
 class Base(DeclarativeBase):
     """Base class for all ORM models."""
+
+
+class SoftDeleteMixin:
+    """Universal soft-delete pattern (vision §3 KD3, KD12).
+
+    Adds a nullable ``deleted_at`` timestamp to a mapped model. ``NULL``
+    means the row is active; a non-null timestamp means soft-deleted.
+
+    Cascade descendants are declared via ``__cascades_soft_delete_to__``
+    — a list of model classes that ``CascadeDeleteService`` should also
+    soft-delete when this entity is deleted. The skeleton is delivered
+    in task 0.1 with empty lists; concrete cascades are wired
+    per-entity in later phase tasks (1.x, 3.x, 4.x).
+
+    Author-content scrubbing on delete is the responsibility of each
+    entity's own deletion handler — vision KD3 lists per-entity scrub
+    rules. This mixin only provides the ``deleted_at`` column and the
+    cascade declaration hook.
+
+    The accompanying Alembic migration adds:
+      - ``deleted_at TIMESTAMPTZ NULL`` column on every soft-deletable table.
+      - ``ix_<table>_active`` partial index on ``deleted_at IS NULL`` for
+        cheap "active-only" queries.
+      - ``BEFORE UPDATE`` trigger that blocks updates of regular columns
+        on already soft-deleted rows (only ``deleted_at``/``updated_at``
+        diffs are permitted, allowing re-deletion idempotency and
+        un-delete).
+    """
+
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+        comment="Soft-delete timestamp (vision KD3). "
+        "NULL = active; NOT NULL = soft-deleted.",
+    )
+
+    __cascades_soft_delete_to__: ClassVar[list[type]] = []
+    """Descendant model classes that cascade-delete from this entity.
+
+    Populated per-entity in subsequent phase tasks.
+    """
 
 
 # ──────────────────────────────────────────────

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -54,10 +54,12 @@ class SoftDeleteMixin:
       - ``deleted_at TIMESTAMPTZ NULL`` column on every soft-deletable table.
       - ``ix_<table>_active`` partial index on ``deleted_at IS NULL`` for
         cheap "active-only" queries.
-      - ``BEFORE UPDATE`` trigger that blocks updates of regular columns
-        on already soft-deleted rows (only ``deleted_at``/``updated_at``
-        diffs are permitted, allowing re-deletion idempotency and
-        un-delete).
+      - ``BEFORE UPDATE`` trigger that blocks any UPDATE on already
+        soft-deleted rows except ones that change *only* ``deleted_at``
+        itself (allowing un-delete and idempotent re-delete via raw
+        SQL). Repository-level idempotency is enforced earlier in
+        ``SoftDeleteRepository.soft_delete``, so the trigger is a
+        safety net for direct DB writes.
     """
 
     deleted_at: Mapped[datetime | None] = mapped_column(
@@ -80,9 +82,16 @@ class SoftDeleteMixin:
 # ──────────────────────────────────────────────
 
 
-class Tenant(Base):
+class Tenant(SoftDeleteMixin, Base):
     __tablename__ = "tenants"
-    __table_args__ = {"comment": "Multi-tenant organizations"}
+    __table_args__ = (
+        Index(
+            "ix_tenants_active",
+            "deleted_at",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        {"comment": "Multi-tenant organizations"},
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
     name: Mapped[str] = mapped_column(String(200), unique=True)
@@ -105,11 +114,16 @@ class Tenant(Base):
     )
 
 
-class APIKey(Base):
+class APIKey(SoftDeleteMixin, Base):
     __tablename__ = "api_keys"
-    __table_args__ = {
-        "comment": "Authentication keys with scope-based access control",
-    }
+    __table_args__ = (
+        Index(
+            "ix_api_keys_active",
+            "deleted_at",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        {"comment": "Authentication keys with scope-based access control"},
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
     tenant_id: Mapped[uuid.UUID] = mapped_column(
@@ -158,7 +172,7 @@ class APIKey(Base):
 # ──────────────────────────────────────────────
 
 
-class MaterialNode(Base):
+class MaterialNode(SoftDeleteMixin, Base):
     """Node in the material tree (recursive adjacency list).
 
     Root nodes (parent_materialnode_id IS NULL) serve as "courses" — top-level
@@ -167,12 +181,19 @@ class MaterialNode(Base):
     """
 
     __tablename__ = "material_nodes"
-    __table_args__ = {
-        "comment": (
-            "Hierarchical tree of raw and unprocessed course materials. "
-            "Root node (parent IS NULL) = course"
+    __table_args__ = (
+        Index(
+            "ix_material_nodes_active",
+            "deleted_at",
+            postgresql_where=text("deleted_at IS NULL"),
         ),
-    }
+        {
+            "comment": (
+                "Hierarchical tree of raw and unprocessed course materials. "
+                "Root node (parent IS NULL) = course"
+            ),
+        },
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
     tenant_id: Mapped[uuid.UUID] = mapped_column(
@@ -247,7 +268,7 @@ class MaterialState(StrEnum):
     ERROR = "error"
 
 
-class MaterialEntry(Base):
+class MaterialEntry(SoftDeleteMixin, Base):
     """A single material attached to a node in the material tree.
 
     Separates raw (uploaded) and processed (ingested) layers with a
@@ -256,10 +277,17 @@ class MaterialEntry(Base):
     """
 
     __tablename__ = "material_entries"
-    __table_args__ = {
-        "comment": "Raw and processed learning materials "
-        "(video, presentation, text, web)",
-    }
+    __table_args__ = (
+        Index(
+            "ix_material_entries_active",
+            "deleted_at",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        {
+            "comment": "Raw and processed learning materials "
+            "(video, presentation, text, web)",
+        },
+    )
 
     def __repr__(self) -> str:
         return (
@@ -397,7 +425,7 @@ class MacroSectionStatus(StrEnum):
     FAILED = "failed"
 
 
-class MaterialMacroSection(Base):
+class MaterialMacroSection(SoftDeleteMixin, Base):
     """Thematic table-of-contents entry within a MaterialEntry.
 
     One row per logical section (thematic block, slide group, article
@@ -417,6 +445,11 @@ class MaterialMacroSection(Base):
             "ix_material_macro_sections_unready",
             "status",
             postgresql_where=text("status != 'ready'"),
+        ),
+        Index(
+            "ix_material_macro_sections_active",
+            "deleted_at",
+            postgresql_where=text("deleted_at IS NULL"),
         ),
         CheckConstraint("start_pos >= 0", name="ck_macro_start_pos_nonneg"),
         CheckConstraint("end_pos > start_pos", name="ck_macro_end_pos_gt_start"),
@@ -483,7 +516,7 @@ class MaterialMacroSection(Base):
     llm_call: Mapped["ExternalServiceCall | None"] = relationship()
 
 
-class MaterialSegment(Base):
+class MaterialSegment(SoftDeleteMixin, Base):
     """Cleaned/sliced content unit inside a MaterialMacroSection.
 
     Produced by Stage 6 of the ingestion pipeline. For
@@ -509,6 +542,11 @@ class MaterialSegment(Base):
             "ix_material_segments_macro_start_pos",
             "macro_section_id",
             "start_pos",
+        ),
+        Index(
+            "ix_material_segments_active",
+            "deleted_at",
+            postgresql_where=text("deleted_at IS NULL"),
         ),
         CheckConstraint("start_pos >= 0", name="ck_segment_start_pos_nonneg"),
         CheckConstraint("end_pos > start_pos", name="ck_segment_end_pos_gt_start"),
@@ -971,11 +1009,16 @@ class ReconciliationPreview(Base):
 # ──────────────────────────────────────────────
 
 
-class Job(Base):
+class Job(SoftDeleteMixin, Base):
     __tablename__ = "jobs"
-    __table_args__ = {
-        "comment": "Background task queue entries (ingestion, generation)",
-    }
+    __table_args__ = (
+        Index(
+            "ix_jobs_active",
+            "deleted_at",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        {"comment": "Background task queue entries (ingestion, generation)"},
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
     tenant_id: Mapped[uuid.UUID | None] = mapped_column(
@@ -1080,10 +1123,15 @@ class HomeworkStatus(StrEnum):
     FAILED = "failed"
 
 
-class Student(Base):
+class Student(SoftDeleteMixin, Base):
     __tablename__ = "students"
     __table_args__ = (
         Index("uq_student_tenant_external", "tenant_id", "external_id", unique=True),
+        Index(
+            "ix_students_active",
+            "deleted_at",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
         {"comment": "External students submitting homework"},
     )
 
@@ -1125,11 +1173,16 @@ class Student(Base):
         )
 
 
-class HomeworkSubmission(Base):
+class HomeworkSubmission(SoftDeleteMixin, Base):
     __tablename__ = "homework_submissions"
-    __table_args__ = {
-        "comment": "Homework submissions from external systems for Mentor review",
-    }
+    __table_args__ = (
+        Index(
+            "ix_homework_submissions_active",
+            "deleted_at",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        {"comment": "Homework submissions from external systems for Mentor review"},
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
     tenant_id: Mapped[uuid.UUID] = mapped_column(

--- a/src/course_supporter/storage/repositories.py
+++ b/src/course_supporter/storage/repositories.py
@@ -3,13 +3,81 @@
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 from course_supporter.models.reports import CostReport, CostSummary, GroupedCost
-from course_supporter.storage.orm import ExternalServiceCall
+from course_supporter.storage.orm import ExternalServiceCall, SoftDeleteMixin
+
+
+class SoftDeleteRepository[ModelT: SoftDeleteMixin]:
+    """Base repository for entities with the soft-delete pattern.
+
+    Provides three filtered listing flavors and an idempotent
+    ``soft_delete`` setter (vision §3 KD3, KD12). Subclasses bind a
+    concrete model by setting the ``model`` class attribute:
+
+        class TenantRepository(SoftDeleteRepository[Tenant]):
+            model = Tenant
+
+    Methods do not commit; the caller controls the transaction
+    boundary, matching the project's existing repository style.
+    """
+
+    model: type[ModelT]
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def find_active(self) -> list[ModelT]:
+        """List rows where ``deleted_at IS NULL``."""
+        stmt = select(self.model).where(self.model.deleted_at.is_(None))
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def find_including_deleted(self) -> list[ModelT]:
+        """List all rows regardless of soft-delete state.
+
+        Use for audit, cost attribution, and other read paths that
+        must see historical entities.
+        """
+        stmt = select(self.model)
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def find_only_deleted(self) -> list[ModelT]:
+        """List rows where ``deleted_at IS NOT NULL``.
+
+        Use for orphan cleanup tasks (e.g., S3 hard-delete sweeper).
+        """
+        stmt = select(self.model).where(self.model.deleted_at.is_not(None))
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def soft_delete(
+        self,
+        entity_id: uuid.UUID,
+        *,
+        now: datetime | None = None,
+    ) -> ModelT | None:
+        """Set ``deleted_at`` on the row identified by ``entity_id``.
+
+        Returns the entity (or ``None`` if not found). Idempotent —
+        re-calling on an already-deleted row is a no-op and does not
+        trigger an UPDATE (which would be blocked by the DB-level
+        soft-delete protection trigger).
+        """
+        entity = await self._session.get(self.model, entity_id)
+        if entity is None:
+            return None
+        if entity.deleted_at is not None:
+            return entity
+        entity.deleted_at = now if now is not None else datetime.now(UTC)
+        await self._session.flush()
+        return entity
 
 
 class ExternalServiceCallRepository:

--- a/tests/integration/test_soft_delete_db_protection.py
+++ b/tests/integration/test_soft_delete_db_protection.py
@@ -1,0 +1,124 @@
+"""Integration: DB-level soft-delete protection trigger + repository.
+
+Marked ``requires_db`` — exercises the BEFORE UPDATE trigger and the
+partial-index/find-flavour behaviour against a live PostgreSQL.
+
+Run with: ``uv run pytest -m requires_db --run-db``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.storage.orm import Tenant
+from course_supporter.storage.repositories import SoftDeleteRepository
+
+pytestmark = pytest.mark.requires_db
+
+
+class TenantRepository(SoftDeleteRepository[Tenant]):
+    model = Tenant
+
+
+async def _make_active_tenant(session: AsyncSession) -> Tenant:
+    tenant = Tenant(name=f"trigger-test-{uuid.uuid4().hex[:8]}")
+    session.add(tenant)
+    await session.flush()
+    return tenant
+
+
+# ── Trigger behaviour ─────────────────────────────────────────────
+
+
+class TestSoftDeleteTrigger:
+    async def test_update_regular_field_on_deleted_row_raises(
+        self, db_session: AsyncSession
+    ) -> None:
+        tenant = await _make_active_tenant(db_session)
+        repo = TenantRepository(db_session)
+        await repo.soft_delete(tenant.id)
+
+        with pytest.raises(DBAPIError) as excinfo:
+            await db_session.execute(
+                text("UPDATE tenants SET name = :n WHERE id = :id"),
+                {"n": "renamed", "id": tenant.id},
+            )
+        assert "soft-deleted" in str(excinfo.value).lower()
+
+    async def test_update_only_deleted_at_succeeds(
+        self, db_session: AsyncSession
+    ) -> None:
+        tenant = await _make_active_tenant(db_session)
+        repo = TenantRepository(db_session)
+        await repo.soft_delete(tenant.id)
+
+        # Un-delete via raw SQL — only deleted_at changes.
+        await db_session.execute(
+            text("UPDATE tenants SET deleted_at = NULL WHERE id = :id"),
+            {"id": tenant.id},
+        )
+        await db_session.refresh(tenant)
+        assert tenant.deleted_at is None
+
+
+# ── Repository find_* against real DB ─────────────────────────────
+
+
+class TestRepositoryAgainstDB:
+    async def test_find_active_excludes_deleted(self, db_session: AsyncSession) -> None:
+        repo = TenantRepository(db_session)
+        active = await _make_active_tenant(db_session)
+        deleted = await _make_active_tenant(db_session)
+        await repo.soft_delete(deleted.id)
+
+        rows = await repo.find_active()
+        ids = {r.id for r in rows}
+        assert active.id in ids
+        assert deleted.id not in ids
+
+    async def test_find_only_deleted_returns_only_deleted(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = TenantRepository(db_session)
+        active = await _make_active_tenant(db_session)
+        deleted = await _make_active_tenant(db_session)
+        await repo.soft_delete(deleted.id)
+
+        rows = await repo.find_only_deleted()
+        ids = {r.id for r in rows}
+        assert deleted.id in ids
+        assert active.id not in ids
+
+    async def test_find_including_deleted_returns_both(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = TenantRepository(db_session)
+        active = await _make_active_tenant(db_session)
+        deleted = await _make_active_tenant(db_session)
+        await repo.soft_delete(deleted.id)
+
+        rows = await repo.find_including_deleted()
+        ids = {r.id for r in rows}
+        assert {active.id, deleted.id}.issubset(ids)
+
+    async def test_soft_delete_idempotent_on_real_db(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Second call must NOT issue an UPDATE — the trigger would block it."""
+        repo = TenantRepository(db_session)
+        tenant = await _make_active_tenant(db_session)
+
+        first = await repo.soft_delete(tenant.id)
+        assert first is not None
+        first_ts = first.deleted_at
+        assert first_ts is not None
+
+        # If repository early-return is broken, this would raise via trigger.
+        second = await repo.soft_delete(tenant.id)
+        assert second is not None
+        assert second.deleted_at == first_ts

--- a/tests/unit/test_cascade_delete_service.py
+++ b/tests/unit/test_cascade_delete_service.py
@@ -1,0 +1,216 @@
+"""Unit tests for CascadeDeleteService (vision §3 KD3, KD12)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any, ClassVar
+from unittest.mock import AsyncMock
+
+import pytest
+
+from course_supporter.storage.cascade import (
+    CascadeDeleteService,
+    SoftDeletableEntity,
+    build_cascade_map,
+)
+
+# ── Fakes: minimal soft-deletable entities (no SQLAlchemy involved) ─
+
+
+class FakeEntity:
+    """In-memory soft-deletable entity for engine-only testing."""
+
+    def __init__(self, id_: uuid.UUID | None = None) -> None:
+        self.id: uuid.UUID = id_ or uuid.uuid4()
+        self.deleted_at: datetime | None = None
+
+
+class A(FakeEntity):
+    pass
+
+
+class B(FakeEntity):
+    pass
+
+
+class C(FakeEntity):
+    pass
+
+
+class StubCascadeService(CascadeDeleteService):
+    """``CascadeDeleteService`` with the FK-inspection layer stubbed out.
+
+    Replaces ``_fetch_active_children`` with a static lookup table so
+    we can drive the engine logic without real ORM mappers or a DB.
+    """
+
+    def __init__(
+        self,
+        session: Any,
+        children_by_parent: dict[uuid.UUID, dict[type, list[FakeEntity]]],
+    ) -> None:
+        super().__init__(session)
+        self._children = children_by_parent
+
+    async def _fetch_active_children(  # type: ignore[override]
+        self,
+        parent: SoftDeletableEntity,
+        child_cls: type,
+    ) -> list[SoftDeletableEntity]:
+        kids = self._children.get(parent.id, {}).get(child_cls, [])
+        return [k for k in kids if k.deleted_at is None]
+
+
+# ── build_cascade_map ──────────────────────────────────────────────
+
+
+class TestBuildCascadeMap:
+    def test_empty_root(self) -> None:
+        class Root:
+            pass
+
+        assert build_cascade_map(Root) == {Root: []}
+
+    def test_walks_transitive_descendants(self) -> None:
+        class Leaf:
+            pass
+
+        class Mid:
+            __cascades_soft_delete_to__: ClassVar[list[type]] = [Leaf]
+
+        class Root:
+            __cascades_soft_delete_to__: ClassVar[list[type]] = [Mid]
+
+        cmap = build_cascade_map(Root)
+        assert cmap == {Root: [Mid], Mid: [Leaf], Leaf: []}
+
+    def test_deduplicates_shared_descendants(self) -> None:
+        class Leaf:
+            pass
+
+        class Branch1:
+            __cascades_soft_delete_to__: ClassVar[list[type]] = [Leaf]
+
+        class Branch2:
+            __cascades_soft_delete_to__: ClassVar[list[type]] = [Leaf]
+
+        class Root:
+            __cascades_soft_delete_to__: ClassVar[list[type]] = [Branch1, Branch2]
+
+        cmap = build_cascade_map(Root)
+        assert set(cmap.keys()) == {Root, Branch1, Branch2, Leaf}
+        assert cmap[Leaf] == []
+
+
+# ── soft_delete_with_cascade ───────────────────────────────────────
+
+
+class TestCascadeIdempotency:
+    async def test_already_deleted_root_short_circuits(self) -> None:
+        session = AsyncMock()
+        a = A()
+        a.deleted_at = datetime(2026, 1, 1, tzinfo=UTC)
+        hook = AsyncMock()
+
+        svc = StubCascadeService(session, {})
+        await svc.soft_delete_with_cascade(a, {A: []}, on_cancel_jobs=hook)
+
+        hook.assert_not_awaited()
+        session.flush.assert_not_awaited()
+
+
+class TestCascadeDepth:
+    async def test_traverses_depth_n_tree(self) -> None:
+        a = A()
+        b1, b2 = B(), B()
+        c1, c2, c3 = C(), C(), C()
+
+        children = {
+            a.id: {B: [b1, b2]},
+            b1.id: {C: [c1, c2]},
+            b2.id: {C: [c3]},
+        }
+        cmap: dict[type, list[type]] = {A: [B], B: [C], C: []}
+
+        session = AsyncMock()
+        svc = StubCascadeService(session, children)
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+
+        await svc.soft_delete_with_cascade(a, cmap, now=ts)
+
+        for e in (a, b1, b2, c1, c2, c3):
+            assert e.deleted_at == ts
+        session.flush.assert_awaited_once()
+
+
+class TestCascadeHook:
+    async def test_hook_called_once_with_all_collected_ids(self) -> None:
+        a = A()
+        b = B()
+        children = {a.id: {B: [b]}}
+        cmap: dict[type, list[type]] = {A: [B], B: []}
+
+        session = AsyncMock()
+        svc = StubCascadeService(session, children)
+        hook = AsyncMock()
+
+        await svc.soft_delete_with_cascade(a, cmap, on_cancel_jobs=hook)
+
+        hook.assert_awaited_once()
+        passed_ids = list(hook.call_args.args[0])
+        assert sorted(passed_ids) == sorted([a.id, b.id])
+
+    async def test_hook_runs_before_writes(self) -> None:
+        """Hook must observe entities still NOT marked deleted."""
+        a = A()
+        cmap: dict[type, list[type]] = {A: []}
+        session = AsyncMock()
+        svc = StubCascadeService(session, {})
+
+        observed: list[datetime | None] = []
+
+        async def hook(_ids: list[uuid.UUID]) -> None:
+            observed.append(a.deleted_at)
+
+        await svc.soft_delete_with_cascade(a, cmap, on_cancel_jobs=hook)
+
+        assert observed == [None]
+        assert a.deleted_at is not None
+
+
+class TestCascadeAllOrNothing:
+    async def test_hook_failure_aborts_writes(self) -> None:
+        """If on_cancel_jobs raises, entities stay un-mutated and no flush."""
+        a = A()
+        cmap: dict[type, list[type]] = {A: []}
+        session = AsyncMock()
+        svc = StubCascadeService(session, {})
+
+        async def failing_hook(_ids: list[uuid.UUID]) -> None:
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await svc.soft_delete_with_cascade(a, cmap, on_cancel_jobs=failing_hook)
+
+        assert a.deleted_at is None
+        session.flush.assert_not_awaited()
+
+
+class TestCascadeCycleGuard:
+    async def test_cycle_does_not_infinite_loop(self) -> None:
+        """A cycle in cascade_map must terminate via the visited set."""
+        a = A()
+        b = B()
+        children = {a.id: {B: [b]}, b.id: {A: [a]}}
+        cmap: dict[type, list[type]] = {A: [B], B: [A]}
+
+        session = AsyncMock()
+        svc = StubCascadeService(session, children)
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+
+        await svc.soft_delete_with_cascade(a, cmap, now=ts)
+
+        assert a.deleted_at == ts
+        assert b.deleted_at == ts
+        session.flush.assert_awaited_once()

--- a/tests/unit/test_cascade_delete_service.py
+++ b/tests/unit/test_cascade_delete_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 from typing import Any, ClassVar
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -41,8 +41,10 @@ class C(FakeEntity):
 class StubCascadeService(CascadeDeleteService):
     """``CascadeDeleteService`` with the FK-inspection layer stubbed out.
 
-    Replaces ``_fetch_active_children`` with a static lookup table so
-    we can drive the engine logic without real ORM mappers or a DB.
+    Replaces ``_fetch_active_children_batch`` with a static lookup
+    table so we can drive the engine logic without real ORM mappers
+    or a DB. Real FK-resolution behaviour is exercised separately in
+    ``TestRealFKResolution`` against actual ORM models.
     """
 
     def __init__(
@@ -53,13 +55,17 @@ class StubCascadeService(CascadeDeleteService):
         super().__init__(session)
         self._children = children_by_parent
 
-    async def _fetch_active_children(  # type: ignore[override]
+    async def _fetch_active_children_batch(  # type: ignore[override]
         self,
-        parent: SoftDeletableEntity,
+        parent_cls: type,
+        parent_ids: list[uuid.UUID],
         child_cls: type,
     ) -> list[SoftDeletableEntity]:
-        kids = self._children.get(parent.id, {}).get(child_cls, [])
-        return [k for k in kids if k.deleted_at is None]
+        result: list[SoftDeletableEntity] = []
+        for pid in parent_ids:
+            kids = self._children.get(pid, {}).get(child_cls, [])
+            result.extend(k for k in kids if k.deleted_at is None)
+        return result
 
 
 # ── build_cascade_map ──────────────────────────────────────────────
@@ -214,3 +220,142 @@ class TestCascadeCycleGuard:
         assert a.deleted_at == ts
         assert b.deleted_at == ts
         session.flush.assert_awaited_once()
+
+
+# ── Real FK resolution against actual ORM models ──────────────────
+
+
+class TestRealFKResolution:
+    """Drive ``_resolve_cascade_columns`` against real ORM models.
+
+    ``StubCascadeService`` above bypasses ``_fetch_active_children_batch``
+    entirely, so the real ``sqlalchemy.inspect()``-based FK lookup and
+    the ambiguity guard would otherwise be untested. These tests fill
+    that gap. Pure mapper inspection — no DB connection involved.
+    """
+
+    def setup_method(self) -> None:
+        # Each test starts with an empty cache so behaviour is
+        # observable per-call (matters for the caching test).
+        from course_supporter.storage.cascade import _resolve_cascade_columns
+
+        _resolve_cascade_columns.cache_clear()
+
+    def test_resolves_unique_fk(self) -> None:
+        """MaterialEntry -> MaterialMacroSection via material_entry_id."""
+        from course_supporter.storage.cascade import _resolve_cascade_columns
+        from course_supporter.storage.orm import (
+            MaterialEntry,
+            MaterialMacroSection,
+        )
+
+        fk_col, deleted_at_col = _resolve_cascade_columns(
+            MaterialEntry, MaterialMacroSection
+        )
+        assert fk_col.name == "material_entry_id"
+        assert deleted_at_col.name == "deleted_at"
+        assert deleted_at_col.table.name == "material_macro_sections"
+
+    def test_resolves_self_referential_fk(self) -> None:
+        """MaterialNode -> MaterialNode via parent_materialnode_id."""
+        from course_supporter.storage.cascade import _resolve_cascade_columns
+        from course_supporter.storage.orm import MaterialNode
+
+        fk_col, deleted_at_col = _resolve_cascade_columns(MaterialNode, MaterialNode)
+        assert fk_col.name == "parent_materialnode_id"
+        assert deleted_at_col.name == "deleted_at"
+
+    def test_no_fk_raises_value_error(self) -> None:
+        """MaterialMacroSection has no FK back to tenants."""
+        from course_supporter.storage.cascade import _resolve_cascade_columns
+        from course_supporter.storage.orm import MaterialMacroSection, Tenant
+
+        with pytest.raises(
+            ValueError,
+            match=r"No foreign key from MaterialMacroSection to Tenant",
+        ):
+            _resolve_cascade_columns(Tenant, MaterialMacroSection)
+
+    def test_ambiguous_fks_raise_value_error(self) -> None:
+        """HomeworkSubmission has BOTH course_node_id AND node_id -> material_nodes.
+
+        This is the actual code-path that will fire when phase 4 wires
+        HomeworkSubmission's cascade. Surfacing it here so the failure
+        is loud and early rather than silent and wrong.
+        """
+        from course_supporter.storage.cascade import _resolve_cascade_columns
+        from course_supporter.storage.orm import HomeworkSubmission, MaterialNode
+
+        with pytest.raises(ValueError, match=r"Ambiguous foreign keys") as excinfo:
+            _resolve_cascade_columns(MaterialNode, HomeworkSubmission)
+        # Both FK column names must be in the error so the operator can
+        # decide which one to keep / split.
+        msg = str(excinfo.value)
+        assert "course_node_id" in msg
+        assert "node_id" in msg
+
+    def test_caching_returns_same_columns(self) -> None:
+        """Second call hits the cache and returns the identical objects."""
+        from course_supporter.storage.cascade import _resolve_cascade_columns
+        from course_supporter.storage.orm import (
+            MaterialEntry,
+            MaterialMacroSection,
+        )
+
+        first = _resolve_cascade_columns(MaterialEntry, MaterialMacroSection)
+        second = _resolve_cascade_columns(MaterialEntry, MaterialMacroSection)
+        assert first is second  # `is` proves cache hit, not just equality
+
+
+# ── Batched fetch wire-format ─────────────────────────────────────
+
+
+class TestBatchedFetch:
+    """Verify ``_fetch_active_children_batch`` issues a single
+    ``SELECT ... WHERE fk IN (...)`` query rather than one per parent.
+
+    Addresses the N+1 concern raised on the original implementation:
+    the engine should scale with cascade depth, not with row count.
+    """
+
+    async def test_single_query_with_in_clause(self) -> None:
+        from course_supporter.storage.orm import (
+            MaterialEntry,
+            MaterialMacroSection,
+        )
+
+        parent_ids = [uuid.uuid4(), uuid.uuid4(), uuid.uuid4()]
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = []
+        session = AsyncMock()
+        session.execute.return_value = result_mock
+
+        svc = CascadeDeleteService(session)
+        rows = await svc._fetch_active_children_batch(
+            MaterialEntry, parent_ids, MaterialMacroSection
+        )
+
+        assert rows == []
+        session.execute.assert_awaited_once()  # one query, not three
+
+        captured = session.execute.call_args.args[0]
+        compiled = str(captured.compile(compile_kwargs={"literal_binds": True}))
+        assert "material_entry_id IN" in compiled
+        assert "deleted_at IS NULL" in compiled
+
+    async def test_empty_parent_ids_short_circuits(self) -> None:
+        """Empty parent_ids must not produce an empty-IN SQL syntax error."""
+        from course_supporter.storage.orm import (
+            MaterialEntry,
+            MaterialMacroSection,
+        )
+
+        session = AsyncMock()
+        svc = CascadeDeleteService(session)
+
+        rows = await svc._fetch_active_children_batch(
+            MaterialEntry, [], MaterialMacroSection
+        )
+
+        assert rows == []
+        session.execute.assert_not_called()

--- a/tests/unit/test_soft_delete_repository.py
+++ b/tests/unit/test_soft_delete_repository.py
@@ -1,0 +1,140 @@
+"""Unit tests for SoftDeleteRepository (vision §3 KD3, KD12)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from course_supporter.storage.orm import Tenant
+from course_supporter.storage.repositories import SoftDeleteRepository
+
+
+class TenantRepository(SoftDeleteRepository[Tenant]):
+    """Concrete binding used to exercise the generic base in tests."""
+
+    model = Tenant
+
+
+def _mock_query_result(rows: list[Any]) -> MagicMock:
+    """Build a mock SQLAlchemy result whose ``.scalars().all()`` returns rows."""
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = rows
+    return result
+
+
+def _compiled_sql(stmt: Any) -> str:
+    return str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+
+# ── find_active / find_including_deleted / find_only_deleted ──────
+
+
+class TestFindFilters:
+    """Exercise the WHERE-clause shape of each find_* flavour."""
+
+    async def test_find_active_filters_deleted_at_is_null(self) -> None:
+        session = AsyncMock()
+        session.execute.return_value = _mock_query_result([])
+        repo = TenantRepository(session)
+
+        await repo.find_active()
+
+        captured_stmt = session.execute.call_args.args[0]
+        assert "deleted_at IS NULL" in _compiled_sql(captured_stmt)
+
+    async def test_find_including_deleted_has_no_deleted_at_filter(self) -> None:
+        session = AsyncMock()
+        session.execute.return_value = _mock_query_result([])
+        repo = TenantRepository(session)
+
+        await repo.find_including_deleted()
+
+        captured_stmt = session.execute.call_args.args[0]
+        compiled = _compiled_sql(captured_stmt)
+        # `deleted_at` appears in the SELECT list but not in any WHERE clause.
+        assert "deleted_at IS" not in compiled
+
+    async def test_find_only_deleted_filters_not_null(self) -> None:
+        session = AsyncMock()
+        session.execute.return_value = _mock_query_result([])
+        repo = TenantRepository(session)
+
+        await repo.find_only_deleted()
+
+        captured_stmt = session.execute.call_args.args[0]
+        assert "deleted_at IS NOT NULL" in _compiled_sql(captured_stmt)
+
+    async def test_find_active_returns_session_rows(self) -> None:
+        rows = [Tenant(name="active-1"), Tenant(name="active-2")]
+        session = AsyncMock()
+        session.execute.return_value = _mock_query_result(rows)
+        repo = TenantRepository(session)
+
+        result = await repo.find_active()
+        assert result == rows
+
+
+# ── soft_delete ───────────────────────────────────────────────────
+
+
+class TestSoftDelete:
+    """Behaviour of the idempotent ``soft_delete`` setter."""
+
+    async def test_sets_deleted_at_and_flushes(self) -> None:
+        entity = Tenant(name="t")
+        entity.id = uuid.uuid4()
+        entity.deleted_at = None
+
+        session = AsyncMock()
+        session.get = AsyncMock(return_value=entity)
+        repo = TenantRepository(session)
+
+        before = datetime.now(UTC)
+        result = await repo.soft_delete(entity.id)
+        after = datetime.now(UTC)
+
+        assert result is entity
+        assert entity.deleted_at is not None
+        assert before <= entity.deleted_at <= after
+        session.flush.assert_awaited_once()
+
+    async def test_idempotent_on_already_deleted(self) -> None:
+        already_ts = datetime(2026, 1, 1, tzinfo=UTC)
+        entity = Tenant(name="t")
+        entity.id = uuid.uuid4()
+        entity.deleted_at = already_ts
+
+        session = AsyncMock()
+        session.get = AsyncMock(return_value=entity)
+        repo = TenantRepository(session)
+
+        result = await repo.soft_delete(entity.id)
+
+        assert result is entity
+        assert entity.deleted_at == already_ts  # untouched
+        session.flush.assert_not_awaited()
+
+    async def test_returns_none_when_not_found(self) -> None:
+        session = AsyncMock()
+        session.get = AsyncMock(return_value=None)
+        repo = TenantRepository(session)
+
+        result = await repo.soft_delete(uuid.uuid4())
+
+        assert result is None
+        session.flush.assert_not_awaited()
+
+    async def test_custom_now_override(self) -> None:
+        entity = Tenant(name="t")
+        entity.id = uuid.uuid4()
+        entity.deleted_at = None
+        custom_ts = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+
+        session = AsyncMock()
+        session.get = AsyncMock(return_value=entity)
+        repo = TenantRepository(session)
+
+        await repo.soft_delete(entity.id, now=custom_ts)
+        assert entity.deleted_at == custom_ts


### PR DESCRIPTION
 ## Summary                                                                                                            
                                                                                                                        
  Task 0.1 — Soft-delete Infrastructure (vision §3 KD3, KD12).
                                                                                                                        
  Універсальний soft-delete primitive для всіх tenant-scoped моделей:                                                   
  nullable `deleted_at` колонка, partial index `ix_<table>_active`, generic
  `SoftDeleteRepository`, `CascadeDeleteService` engine + DB-level                                                      
  `BEFORE UPDATE` trigger як safety net.                                                                                
                                                                                                                        
  Без жодних concrete cascade maps — вони з'являться per-entity у тасках                                                
  фаз 1, 3, 4. Ця PR постачає лише engine + інфраструктуру.                                                             
                                                                                                                        
  ## Що зроблено  
                                                                                                                        
  Чотири послідовні commits, ORM і DB у синхроні на кожному кроці:                                                      
   
  1. **`c413ca6` — `SoftDeleteMixin` + `SoftDeleteRepository` base**                                                    
     - `SoftDeleteMixin` у `storage/orm.py`: nullable `deleted_at TIMESTAMPTZ`
       + `__cascades_soft_delete_to__: ClassVar[list[type]]` hook (порожній                                             
       у цій PR; заповнюватиметься per-entity у наступних фазах).                                                       
     - Generic `SoftDeleteRepository[ModelT: SoftDeleteMixin]` (PEP 695                                                 
       syntax) з `find_active` / `find_including_deleted` /                                                             
       `find_only_deleted` / idempotent `soft_delete`. Без commit'у —                                                   
       транзакцію контролює caller, як і решта repositories у проєкті.                                                  
                                                                                                                        
  2. **`18e9cc7` — Mixin на 9 моделей + Alembic міграція**                                                              
     - `(SoftDeleteMixin, Base)` MRO на: `Tenant`, `APIKey`, `MaterialNode`,                                            
       `MaterialEntry`, `MaterialMacroSection`, `MaterialSegment`, `Job`,                                               
       `Student`, `HomeworkSubmission`. Partial index у `__table_args__`                                                
       кожної моделі.                                                                                                   
     - Migration `b9c0d1e2f3a4` (down_revision `a8b9c0d1e2f3`): додає                                                   
       колонку + partial index на 9 таблицях, ставить **одну** plpgsql                                                  
       функцію `block_update_on_soft_deleted()` і застосовує                                                            
       `BEFORE UPDATE` trigger per-table.                                                                               
     - `ExternalServiceCall` і legacy structure/snapshot/reconciliation                                                 
       моделі **навмисно не включені** — це поза scope KD3.                                                             
                                                                                                                        
  3. **`f5d94ff` — `CascadeDeleteService` skeleton**                                                                    
     - Новий `storage/cascade.py`: `SoftDeletableEntity` Protocol,                                                      
       `OnCancelJobs` async hook type, `build_cascade_map(root)` walker,                                                
       `CascadeDeleteService.soft_delete_with_cascade(entity, cascade_map,                                              
       *, on_cancel_jobs, now)`.                                                                                        
     - FK resolution через `sqlalchemy.inspect()` з explicit                                                            
       ambiguity guard: zero або >1 FK піднімають `ValueError`.                                                         
     - Cycle-safe (`visited: set[tuple[type, UUID]]`), idempotent на                                                    
       already-deleted root.                                                                                            
                                                                                                                        
  4. **`717f6bd` — Tests**                                                                                              
     - `tests/unit/test_soft_delete_repository.py` — 8 mock-based tests.                                                
     - `tests/unit/test_cascade_delete_service.py` — 10 pure-Python tests                                               
       з `StubCascadeService` що bypass'ить FK inspection.                                                              
     - `tests/integration/test_soft_delete_db_protection.py` — 6                                                        
       `requires_db` tests, drives trigger проти живого Postgres.                                                       
                                                                                                                        
  ## Architectural decisions                                                                                            
                                                                                                                        
  Деталі див. у `refactoring-vision/sprint/tasks/0.1-soft-delete-infrastructure/POST-MR-NOTES.md`.                      
  Коротко:                                                                                                              
                                                                                                                        
  - **Одна shared plpgsql функція**, не 9 копій. Через `TG_TABLE_NAME` +                                                
    `to_jsonb(NEW) - 'deleted_at' IS DISTINCT FROM to_jsonb(OLD) -
    'deleted_at'`. Дешевше підтримувати, тривіально розширюється на нові                                                
    soft-deletable таблиці.                                                                                             
  - **Strict trigger policy**: на soft-deleted рядку дозволено змінювати                                                
    тільки `deleted_at`. Application-level idempotency у                                                                
    `SoftDeleteRepository.soft_delete` робить trigger чистою safety net.
  - **FK resolution з ambiguity guard**: alternative (явний FK у                                                        
    `__cascades_soft_delete_to__`) відкинуто як premature — більшість                                                   
    cascade'ів мають один FK. Перший ambiguous case (`HomeworkSubmission`                                               
    → `material_nodes` × 2) вирішується у Phase 4 шляхом restructure                                                    
    моделі під vision §3 KD15 (один `authored_document_id`).                                                            
  - **Single-shot pre-write hook** `on_cancel_jobs` — одне batch                                                        
    оголошення id'ів перед any UPDATE. Failing hook → клин транзакція                                                   
    rollback'ається з outer caller. Real implementation у task 0.3.                                                     
  - **Partial index задекларований у двох місцях** (ORM `__table_args__`                                                
    би drop'нути "orphan" index. Boilerplate, але чисто і без drift'у.                                                  
                                                                                                                        
  ## Test plan                                                                                                          
                                                                                                                        
  Локально перевірено:                                                                                                  
                                                                                                                        
  - [x] `uv run ruff check src/ tests/` — clean.
  - [x] `uv run ruff format --check` — clean.                                                                           
  - [x] `uv run mypy src/` — clean (147 source files).
  - [x] `make db-upgrade && make db-downgrade && make db-upgrade` —                                                     
        повний round-trip clean.                                                                                        
  - [x] Manual psql сценарій з TASK.md acceptance #5: insert + delete OK,                                               
        non-`deleted_at` UPDATE на deleted рядку → ERROR з очікуваним                                                   
        повідомленням, `deleted_at = NULL` un-delete → OK.                                                              
  - [x] `uv run pytest` — **1764 passed, 35 skipped** (default mode).                                                   
  - [x] `uv run pytest --run-db --run-redis` — **1796 passed**, 3                                                       
        pre-existing failures у `tests/integration/test_enqueue_redis.py`                                               
        (`KeyError: 'course_id'`; fixture повертає `materialnode_id`).                                                  
        Не пов'язані з цим task'ом — будуть прибрані у Phase 1.1                                                        
        (`MaterialNode → CourseNode` rename).                                                                           
  - [x] `\d+ tenants` показує `deleted_at` колонку, `ix_tenants_active`                                                 
        partial index, `trg_tenants_block_update_when_deleted` trigger.                                                 
                                                                                                                        
  ## Vision references                                                                                                  
                                                                                                                        
  - §3 KD3 — Soft-delete with content scrubbing.                                                                        
  - §3 KD12 — Three paths of deletion (explicit / cascade / pipeline).                                                  
  - §5 Phase 0 row 0.1 — stage map.                                                                                     
                                                                                                                        
  ## Out of scope (за TASK.md)                                                                                          
                                                                                                                        
  - Concrete cascade maps per-entity (фази 1, 3, 4).                                                                    
  - Job cancellation logic (task 0.3).                                                                                  
  - Content scrubbing of fields (per-entity).
  - S3 hard-delete async sweeper (task 0.3 + per-entity).                                                               
  - `content_hash` invalidation hook (task 0.2 — додасть другий hook                                                    
    `on_invalidate_hashes` до `CascadeDeleteService`).                                                                  
  - API endpoints для soft-delete (per-entity у фазах 1+).                                                              
  - UI changes (none).                                                                                                  
                                                                                                                        
  ## POST-MR-NOTES                                                                                                      
                                                                                                                        
  Чернетка з повним розбором рішень, deviations і Vision-side answers (Q1/Q2/Q3
  вирішені):                                                                                                            
  `refactoring-vision/sprint/tasks/0.1-soft-delete-infrastructure/POST-MR-NOTES.md`
                           