### PR TITLE
task(0.1): address reviewer feedback — cascade typing + migration ide…

### DIFF
--- a/migrations/versions/b9c0d1e2f3a4_0_1_soft_delete_infrastructure.py
+++ b/migrations/versions/b9c0d1e2f3a4_0_1_soft_delete_infrastructure.py
@@ -25,6 +25,7 @@ configured here; they are wired with each entity's own phase task
 (1.x, 3.x, 4.x).
 """
 
+import re
 from collections.abc import Sequence
 
 import sqlalchemy as sa
@@ -50,6 +51,26 @@ SOFT_DELETABLE_TABLES: tuple[str, ...] = (
 )
 
 TRIGGER_FUNCTION_NAME = "block_update_on_soft_deleted"
+
+# PostgreSQL DDL cannot use parameter binding for identifiers
+# (``CREATE TRIGGER $1 ON $2`` is not valid SQL — bind params attach
+# values, not object names), so trigger and table names below are
+# interpolated into raw SQL via f-strings. All names come from the
+# hardcoded ``SOFT_DELETABLE_TABLES`` whitelist or ``TRIGGER_FUNCTION_NAME``;
+# user input never reaches these strings. The assertions below make
+# that property executable: if a future contributor adds a non-plain
+# identifier to the whitelist, the migration fails on import rather
+# than emitting unsafe DDL.
+_SAFE_IDENT = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+assert all(_SAFE_IDENT.match(t) for t in SOFT_DELETABLE_TABLES), (
+    "SOFT_DELETABLE_TABLES must contain plain SQL identifiers; got: "
+    f"{[t for t in SOFT_DELETABLE_TABLES if not _SAFE_IDENT.match(t)]}"
+)
+assert _SAFE_IDENT.match(TRIGGER_FUNCTION_NAME), (
+    f"TRIGGER_FUNCTION_NAME must be a plain SQL identifier; got: "
+    f"{TRIGGER_FUNCTION_NAME!r}"
+)
 
 TRIGGER_FUNCTION_SQL = f"""
 CREATE OR REPLACE FUNCTION {TRIGGER_FUNCTION_NAME}()

--- a/src/course_supporter/storage/cascade.py
+++ b/src/course_supporter/storage/cascade.py
@@ -173,7 +173,7 @@ class CascadeDeleteService:
             )
 
         fk_col = fk_cols[0]
-        deleted_at_col: Any = child_cls.deleted_at  # type: ignore[attr-defined]
+        deleted_at_col = child_mapper.local_table.c.deleted_at
         stmt: Any = (
             select(child_cls).where(fk_col == parent.id).where(deleted_at_col.is_(None))
         )


### PR DESCRIPTION
…ntifier safety

Two reviewer-flagged points addressed in one follow-up:

1. cascade.py: tighten typing in _fetch_active_children. The raw-SQL select on the deleted_at column previously read `deleted_at_col: Any = child_cls.deleted_at  # type: ignore[attr-defined]` because `child_cls: type` does not expose the column attribute at class level. The fix routes through child_mapper, which is already in scope and already used for FK lookup — so deleted_at_col now comes from `child_mapper.local_table.c.deleted_at`. This drops both `Any` and the `# type: ignore`, and is symmetric with how fk_cols is obtained earlier in the same method.

2. migration: make the identifier-safety contract executable. PostgreSQL DDL cannot use parameter binding for identifiers (`CREATE TRIGGER $1 ON $2` is not valid SQL — bind params attach values, not object names), so the migration interpolates trigger and table names into raw SQL via f-strings. All names come from the hardcoded SOFT_DELETABLE_TABLES whitelist or TRIGGER_FUNCTION_NAME — user input never reaches these strings.

   Added a module-level regex `^[a-z_][a-z0-9_]*$` plus assertions that fail on import if a future contributor adds a non-plain identifier to the whitelist. The whitelist's safety property is now machine-verified rather than commented.

Verified: ruff + mypy strict (137 source files) clean; all 23 task tests pass; `make db-downgrade && make db-upgrade` round-trip clean with the new assertions firing on import.