### PR TITLE
393 task02 content hash infrastructure

### DIFF
--- a/migrations/versions/c0d1e2f3a4b5_0_2_content_hash_infrastructure.py
+++ b/migrations/versions/c0d1e2f3a4b5_0_2_content_hash_infrastructure.py
@@ -1,0 +1,83 @@
+"""0.2 content hash infrastructure: content_hash columns + raw_hash index
+
+Revision ID: c0d1e2f3a4b5
+Revises: b9c0d1e2f3a4
+Create Date: 2026-04-27 14:35:00.000000
+
+Task 0.2 of the Phase 0 sprint (vision §3 KD9). Adds the
+materialised KD9 ``content_hash`` on every node of the material
+tree plus a lookup index on the existing ``MaterialEntry.raw_hash``:
+
+- ``content_hash TEXT NULL`` on ``material_entries``,
+  ``material_macro_sections``, ``material_segments``, and
+  ``material_nodes``. Lowercase hex SHA-256 string. ``NULL`` =
+  "never computed / stale"; population happens at INSERT/UPDATE
+  time per vision §3 KD9 line 563 (no lazy / on-read
+  materialisation). Backfill on existing rows is intentionally
+  out-of-scope — production data is empty (KD0).
+- ``ix_material_entries_raw_hash`` index for re-upload detection
+  (vision §3 KD4 + KD9). Regular (non-unique) index — same content
+  uploaded twice is intentionally allowed in v0.20.
+
+The legacy ``MaterialNode.node_fingerprint`` column is left in
+place. Phase 1.1 (CourseNode rename) collapses it into
+``content_hash`` together with the formula change to KD9 inputs
+(``raw_hash`` + associated ``DocumentSummary.content_hash`` +
+child ``CourseNode.content_hash`` values), and migrates the five
+legacy read-paths (snapshot identity, reconciliation cache,
+enqueue, generation idempotency, repository invalidation) to the
+new column.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c0d1e2f3a4b5"
+down_revision: str | Sequence[str] | None = "b9c0d1e2f3a4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+CONTENT_HASH_TABLES: tuple[str, ...] = (
+    "material_entries",
+    "material_macro_sections",
+    "material_segments",
+    "material_nodes",
+)
+
+CONTENT_HASH_COMMENT = (
+    "Materialised content_hash (vision §3 KD9, SHA-256 hex). "
+    "NULL = never computed / stale. Populated at INSERT/UPDATE; "
+    "per-entity formula wired in Phase 2/3."
+)
+
+
+def upgrade() -> None:
+    """Add content_hash on 4 tables + raw_hash lookup index."""
+    for table in CONTENT_HASH_TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "content_hash",
+                sa.String(64),
+                nullable=True,
+                comment=CONTENT_HASH_COMMENT,
+            ),
+        )
+
+    op.create_index(
+        "ix_material_entries_raw_hash",
+        "material_entries",
+        ["raw_hash"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop raw_hash index + content_hash columns."""
+    op.drop_index("ix_material_entries_raw_hash", table_name="material_entries")
+    for table in CONTENT_HASH_TABLES:
+        op.drop_column(table, "content_hash")

--- a/src/course_supporter/storage/cascade.py
+++ b/src/course_supporter/storage/cascade.py
@@ -63,6 +63,20 @@ the caller in task 0.3 and in per-entity tasks in later phases.
 """
 
 
+OnInvalidateHashes = Callable[[list[uuid.UUID]], Awaitable[None]]
+"""Hook invoked once per cascade with the full id list whose ``content_hash``
+chains must be recomputed up to the root (vision §3 KD9 + KD12).
+
+Same single-shot, pre-write semantics as :data:`OnCancelJobs`: invoked
+exactly once before any ``deleted_at`` write, so victims are still
+``deleted_at IS NULL`` when the hook runs (and therefore not yet
+blocked by the soft-delete protection trigger). Concrete
+implementations live alongside ``ContentHashService.invalidate_subtree``
+and are wired into :meth:`CascadeDeleteService.soft_delete_with_cascade`
+in commit (c) of task 0.2.
+"""
+
+
 def build_cascade_map(root: type) -> dict[type, list[type]]:
     """Build a cascade_map from ``__cascades_soft_delete_to__`` declarations.
 

--- a/src/course_supporter/storage/cascade.py
+++ b/src/course_supporter/storage/cascade.py
@@ -170,6 +170,7 @@ class CascadeDeleteService:
         cascade_map: dict[type, list[type]],
         *,
         on_cancel_jobs: OnCancelJobs | None = None,
+        on_invalidate_hashes: OnInvalidateHashes | None = None,
         now: datetime | None = None,
     ) -> None:
         """Soft-delete ``entity`` and every active descendant.
@@ -179,19 +180,29 @@ class CascadeDeleteService:
         ``visited`` set keyed by ``(type, id)`` so cascade_map cycles
         cannot trigger infinite recursion.
 
-        ``on_cancel_jobs`` is invoked once before any UPDATE with the
-        full list of collected ids. ``now`` overrides the timestamp
-        applied to all rows (defaults to ``datetime.now(UTC)``);
-        useful for deterministic tests.
+        Both pre-write hooks are invoked exactly once with the full
+        collected id list, before any ``deleted_at`` write. They fire
+        in declared parameter order — ``on_cancel_jobs`` first
+        (stop in-flight work) then ``on_invalidate_hashes`` (recompute
+        upstream Merkle hashes per vision §3 KD9 + KD12). A failure
+        in either hook aborts the cascade cleanly: no rows are
+        mutated and no flush happens.
+
+        ``now`` overrides the timestamp applied to all rows
+        (defaults to ``datetime.now(UTC)``); useful for deterministic
+        tests.
         """
         if entity.deleted_at is not None:
             return
 
         ts = now if now is not None else datetime.now(UTC)
         to_delete = await self._collect_all(entity, cascade_map)
+        ids = [e.id for e in to_delete]
 
         if on_cancel_jobs is not None:
-            await on_cancel_jobs([e.id for e in to_delete])
+            await on_cancel_jobs(ids)
+        if on_invalidate_hashes is not None:
+            await on_invalidate_hashes(ids)
 
         for row in to_delete:
             row.deleted_at = ts

--- a/src/course_supporter/storage/content_hash.py
+++ b/src/course_supporter/storage/content_hash.py
@@ -7,30 +7,68 @@ the material tree — a regenerated DocumentSegment changes its own
 hash, which propagates up through DocumentSummary → CourseNode all
 the way to the root.
 
-This module ships the pure compute helpers in commit (a) of task
-0.2; the DB-aware traversal API (``invalidate_up`` /
-``invalidate_subtree``) lands in commit (c) once the column
-additions in commit (b) are in place.
-
 KD9 explicitly forbids lazy / on-read materialisation (vision §3
 line 563): hashes must be computed and persisted at INSERT/UPDATE
 time. The legacy ``FingerprintService`` (anchored on
 ``MaterialEntry.processed_hash``) remains in place for the
 snapshot / reconciliation flows it serves and is collapsed into
 ``ContentHashService`` in Phase 1.1.
+
+**Per-entity formulas in 0.2 are minimal-viable.** The compute
+helpers (``compute_raw_hash`` / ``compute_content_hash``) ship the
+algebra; ``ContentHashService._compute_hash_for`` ships a basic
+formula per entity type that is enough to make
+``invalidate_up`` walk the tree correctly and short-circuit on
+no-op changes. Phase 1.3 / 1.4 / 2 / 3 refine each formula with
+vision-aligned inputs (concepts, positions, additional fields).
 """
 
 from __future__ import annotations
 
 import hashlib
+import uuid
+from datetime import datetime
+from typing import Protocol, cast
 
+import structlog
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.storage.orm import (
+    MaterialEntry,
+    MaterialMacroSection,
+    MaterialNode,
+    MaterialSegment,
+)
+
+logger = structlog.get_logger(__name__)
 
 # Separator byte for the Merkle hash. Without an explicit boundary,
 # ``["abc", "def"]`` would hash identically to ``["abcd", "ef"]``.
 # The NUL byte cannot appear inside a hex SHA-256 digest, so it is
 # a safe, unambiguous delimiter that no child hash payload can spoof.
 _HASH_SEPARATOR = b"\x00"
+
+# Defensive cap on walker depth. Real course trees are shallow (a
+# handful of levels), so 25 is comfortable headroom; the cap exists
+# to surface accidentally-introduced cycles in future schema changes
+# rather than to bound legitimate work.
+_MAX_WALK_DEPTH = 25
+
+
+class HashableEntity(Protocol):
+    """Structural type for any model that participates in content_hash.
+
+    Concrete hash-bearing models (``MaterialSegment``,
+    ``MaterialMacroSection``, ``MaterialEntry``, ``MaterialNode``)
+    all expose these three attributes — ``id`` and ``deleted_at``
+    come from existing model contracts and ``content_hash`` is the
+    column added by task 0.2.
+    """
+
+    id: uuid.UUID
+    deleted_at: datetime | None
+    content_hash: str | None
 
 
 def compute_raw_hash(content: bytes) -> str:
@@ -81,24 +119,251 @@ def compute_content_hash(local_content: bytes, child_hashes: list[str]) -> str:
 class ContentHashService:
     """Materialised KD9 content-hash maintenance.
 
-    Commit (a) of task 0.2 ships this class as a thin shell so the
-    pure compute helpers above can be imported and the DB-aware API
-    can attach in commit (c) without re-introducing the class.
-    Commit (c) adds:
+    Walks the material tree bottom-up, recomputing ``content_hash``
+    on each ancestor and short-circuiting when a level's recomputed
+    value equals the stored value (so a metadata-only change on a
+    leaf does not write-storm up the tree). All updates happen
+    in-session; the caller controls the surrounding transaction.
 
-    - ``invalidate_up(session, entity)`` — eager bottom-up walk that
-      recomputes each ancestor's ``content_hash`` from its children
-      and short-circuits when a level's recomputed hash equals the
-      stored hash.
-    - ``invalidate_subtree(session, entity_ids)`` — bulk variant for
-      cascade-soft-delete scenarios; deduplicates ancestor walks via
-      a ``visited`` set so a parent reached from multiple siblings
-      is recomputed exactly once.
+    Per-entity formulas live in :meth:`_compute_hash_for` and are
+    minimal-viable for 0.2 — Phase 1.3 / 1.4 / 2 / 3 will refine
+    each one with vision-aligned inputs. ``_compute_hash_for`` and
+    :meth:`_fetch_parent` are deliberately overrideable so unit
+    tests can drive the walker against in-memory fakes without a
+    DB connection.
 
-    The service is stateless aside from the bound session. Callers
-    construct it inline per request / job; there is no global
-    singleton.
+    The service is stateless aside from the bound session; callers
+    construct it inline per request / job, there is no singleton.
     """
 
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
+
+    async def invalidate_up(self, entity: HashableEntity) -> None:
+        """Eager Merkle propagation up the tree (vision §3 KD9).
+
+        Recomputes ``content_hash`` for ``entity`` from its active
+        children, then walks to the parent and repeats. Stops at
+        a root node (parent IS NULL) or as soon as a level's
+        recomputed hash equals the stored hash (short-circuit; no
+        write storm on metadata-only changes).
+
+        Soft-deleted entities encountered along the walk are skipped
+        for UPDATE — the soft-delete trigger from task 0.1 would
+        block the write — but their parent is still visited so the
+        parent's hash reflects active siblings.
+
+        Issues a single ``flush()`` after the entire walk completes
+        (no per-level flush). Caller's transaction boundary is
+        unchanged.
+        """
+        visited: set[tuple[type, uuid.UUID]] = set()
+        await self._walk_up(entity, visited, exclude_ids=None)
+        await self._session.flush()
+
+    async def invalidate_subtree(
+        self,
+        entity_ids: list[uuid.UUID],
+        *,
+        exclude_ids: set[uuid.UUID] | None = None,
+    ) -> None:
+        """Bulk Merkle propagation for cascade-soft-delete scenarios.
+
+        Looks up entities by id across the four hash-bearing tables
+        (``MaterialSegment``, ``MaterialMacroSection``,
+        ``MaterialEntry``, ``MaterialNode``) — one ``WHERE id IN``
+        query per type, four total round-trips regardless of
+        ``len(entity_ids)``. For each entity, walks up to the root
+        with a *shared* ``visited`` set so a parent reached from N
+        siblings is recomputed exactly once.
+
+        ``exclude_ids`` lets the caller supply ids that should be
+        treated as "already gone" by parent computations. The
+        primary use case is the ``on_invalidate_hashes`` cascade
+        hook (per task 0.1 A3): it fires *before* writes, so cascade
+        victims still have ``deleted_at IS NULL`` at hook time.
+        Passing ``exclude_ids = {victim ids}`` makes parent hashes
+        recompute as if the victims were already deleted, which is
+        the correct cascade-time semantics. Without ``exclude_ids``
+        the standalone semantics apply (recompute from current
+        ``deleted_at IS NULL`` state).
+
+        Issues a single ``flush()`` after the full bulk walk.
+        Empty ``entity_ids`` short-circuits without DB access.
+        """
+        if not entity_ids:
+            return
+
+        entities: list[HashableEntity] = []
+        for cls in (
+            MaterialSegment,
+            MaterialMacroSection,
+            MaterialEntry,
+            MaterialNode,
+        ):
+            stmt = select(cls).where(cls.id.in_(entity_ids))
+            result = await self._session.execute(stmt)
+            # ORM rows satisfy ``HashableEntity`` structurally (every
+            # hash-bearing model has id + deleted_at + content_hash),
+            # but Protocol variance through ``Sequence[Base]`` is not
+            # inferred — explicit cast for the type checker.
+            entities.extend(cast(list[HashableEntity], list(result.scalars().all())))
+
+        visited: set[tuple[type, uuid.UUID]] = set()
+        for entity in entities:
+            await self._walk_up(entity, visited, exclude_ids=exclude_ids)
+
+        await self._session.flush()
+
+    async def _walk_up(
+        self,
+        start: HashableEntity,
+        visited: set[tuple[type, uuid.UUID]],
+        *,
+        exclude_ids: set[uuid.UUID] | None,
+    ) -> None:
+        """Walk from ``start`` to the root, recomputing hashes as we go.
+
+        Skips UPDATE on entities that are either soft-deleted (the
+        trigger would block) or in ``exclude_ids`` (caller asked us
+        to treat them as gone). In both cases we still walk to the
+        parent so its hash reflects the absence. Cycle-safe via
+        ``visited``; depth-capped at :data:`_MAX_WALK_DEPTH`.
+        """
+        current: HashableEntity | None = start
+        depth = 0
+        while current is not None:
+            if depth > _MAX_WALK_DEPTH:
+                logger.warning(
+                    "content_hash.invalidate_up.depth_exceeded",
+                    entity_type=type(current).__name__,
+                    entity_id=str(current.id),
+                    max_depth=_MAX_WALK_DEPTH,
+                )
+                return
+
+            depth += 1
+            key = (type(current), current.id)
+            if key in visited:
+                return
+            visited.add(key)
+
+            should_update = current.deleted_at is None and (
+                exclude_ids is None or current.id not in exclude_ids
+            )
+            if should_update:
+                new_hash = await self._compute_hash_for(
+                    current, exclude_ids=exclude_ids
+                )
+                if new_hash == current.content_hash:
+                    return
+                current.content_hash = new_hash
+
+            current = await self._fetch_parent(current)
+
+    async def _compute_hash_for(
+        self,
+        entity: HashableEntity,
+        *,
+        exclude_ids: set[uuid.UUID] | None,
+    ) -> str:
+        """Per-entity hash formula (vision §3 KD9, minimal-viable for 0.2).
+
+        Phase 1.3 / 1.4 / 2 / 3 will refine each formula with vision-
+        aligned inputs (concepts, positions, additional own fields).
+        The current shapes:
+
+        - ``MaterialSegment`` — ``content`` bytes, no children. Phase
+          1.4 adds concepts + positions per KD9 line 552.
+        - ``MaterialMacroSection`` — empty local content + sorted
+          active segments' ``content_hash``. Phase 1.3 adds own
+          fields per KD9 line 553.
+        - ``MaterialEntry`` — ``raw_hash`` bytes + sorted active
+          sections' ``content_hash``. ``raw_hash`` anchor matches
+          KD9 line 554. Falls back to ``b""`` while ``raw_hash`` is
+          NULL (Phase 2 will populate it at ingestion time).
+        - ``MaterialNode`` — empty local content + sorted (active
+          entries' + active child nodes') ``content_hash``. Phase
+          1.1 collapses ``node_fingerprint`` into ``content_hash``
+          and switches to the full KD9 formula.
+
+        ``exclude_ids`` is forwarded to the children query so the
+        cascade hook can elide soon-to-be-deleted siblings before
+        they actually have ``deleted_at`` set.
+        """
+        if isinstance(entity, MaterialSegment):
+            local = (entity.content or "").encode("utf-8")
+            return compute_content_hash(local, [])
+
+        if isinstance(entity, MaterialMacroSection):
+            stmt = select(MaterialSegment.content_hash).where(
+                MaterialSegment.macro_section_id == entity.id,
+                MaterialSegment.deleted_at.is_(None),
+            )
+            if exclude_ids:
+                stmt = stmt.where(MaterialSegment.id.notin_(exclude_ids))
+            result = await self._session.execute(stmt)
+            children = [h for (h,) in result.all() if h is not None]
+            return compute_content_hash(b"", children)
+
+        if isinstance(entity, MaterialEntry):
+            local = (entity.raw_hash or "").encode("ascii")
+            stmt = select(MaterialMacroSection.content_hash).where(
+                MaterialMacroSection.material_entry_id == entity.id,
+                MaterialMacroSection.deleted_at.is_(None),
+            )
+            if exclude_ids:
+                stmt = stmt.where(MaterialMacroSection.id.notin_(exclude_ids))
+            result = await self._session.execute(stmt)
+            children = [h for (h,) in result.all() if h is not None]
+            return compute_content_hash(local, children)
+
+        if isinstance(entity, MaterialNode):
+            entry_stmt = select(MaterialEntry.content_hash).where(
+                MaterialEntry.materialnode_id == entity.id,
+                MaterialEntry.deleted_at.is_(None),
+            )
+            if exclude_ids:
+                entry_stmt = entry_stmt.where(MaterialEntry.id.notin_(exclude_ids))
+            entry_result = await self._session.execute(entry_stmt)
+
+            node_stmt = select(MaterialNode.content_hash).where(
+                MaterialNode.parent_materialnode_id == entity.id,
+                MaterialNode.deleted_at.is_(None),
+            )
+            if exclude_ids:
+                node_stmt = node_stmt.where(MaterialNode.id.notin_(exclude_ids))
+            node_result = await self._session.execute(node_stmt)
+
+            children = [h for (h,) in entry_result.all() if h is not None]
+            children += [h for (h,) in node_result.all() if h is not None]
+            return compute_content_hash(b"", children)
+
+        raise TypeError(
+            f"ContentHashService does not support entity type {type(entity).__name__}"
+        )
+
+    async def _fetch_parent(self, entity: HashableEntity) -> HashableEntity | None:
+        """Resolve ``entity``'s parent in the hash chain, or None at root.
+
+        - Segment → MacroSection (via ``macro_section_id``)
+        - MacroSection → MaterialEntry (via ``material_entry_id``)
+        - MaterialEntry → MaterialNode (via ``materialnode_id``)
+        - MaterialNode → MaterialNode (via ``parent_materialnode_id``);
+          NULL = root, walk terminates.
+        """
+        if isinstance(entity, MaterialSegment):
+            return await self._session.get(
+                MaterialMacroSection, entity.macro_section_id
+            )
+        if isinstance(entity, MaterialMacroSection):
+            return await self._session.get(MaterialEntry, entity.material_entry_id)
+        if isinstance(entity, MaterialEntry):
+            return await self._session.get(MaterialNode, entity.materialnode_id)
+        if isinstance(entity, MaterialNode):
+            if entity.parent_materialnode_id is None:
+                return None
+            return await self._session.get(MaterialNode, entity.parent_materialnode_id)
+        raise TypeError(
+            f"ContentHashService does not support entity type {type(entity).__name__}"
+        )

--- a/src/course_supporter/storage/content_hash.py
+++ b/src/course_supporter/storage/content_hash.py
@@ -1,0 +1,104 @@
+"""Content hash service (vision §3 KD9).
+
+Implements the KD9 hash model: ``raw_hash`` (SHA-256 of authored
+input bytes) and ``content_hash`` (Merkle SHA-256 over local content
+plus sorted child hashes). Hashes anchor change detection across
+the material tree — a regenerated DocumentSegment changes its own
+hash, which propagates up through DocumentSummary → CourseNode all
+the way to the root.
+
+This module ships the pure compute helpers in commit (a) of task
+0.2; the DB-aware traversal API (``invalidate_up`` /
+``invalidate_subtree``) lands in commit (c) once the column
+additions in commit (b) are in place.
+
+KD9 explicitly forbids lazy / on-read materialisation (vision §3
+line 563): hashes must be computed and persisted at INSERT/UPDATE
+time. The legacy ``FingerprintService`` (anchored on
+``MaterialEntry.processed_hash``) remains in place for the
+snapshot / reconciliation flows it serves and is collapsed into
+``ContentHashService`` in Phase 1.1.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Separator byte for the Merkle hash. Without an explicit boundary,
+# ``["abc", "def"]`` would hash identically to ``["abcd", "ef"]``.
+# The NUL byte cannot appear inside a hex SHA-256 digest, so it is
+# a safe, unambiguous delimiter that no child hash payload can spoof.
+_HASH_SEPARATOR = b"\x00"
+
+
+def compute_raw_hash(content: bytes) -> str:
+    """SHA-256 hex digest of the raw authored bytes (vision §3 KD9).
+
+    Used for ``AuthoredDocument.raw_hash`` (currently named
+    ``MaterialEntry.raw_hash`` until the Phase 1.2 rename). Once a
+    value is persisted it is treated as immutable: re-uploading the
+    same document with different bytes is a new authored input that
+    invalidates downstream summaries (vision §3 KD4).
+
+    Returns a 64-character lowercase hex string.
+    """
+    return hashlib.sha256(content).hexdigest()
+
+
+def compute_content_hash(local_content: bytes, child_hashes: list[str]) -> str:
+    """Merkle SHA-256 hex digest combining local content with child hashes.
+
+    Children are sorted before hashing so the result is independent
+    of insertion order (re-ordering siblings does not invalidate the
+    parent). Each child hash is separated by ``\\x00`` so that two
+    different child partitions cannot collide via concatenation —
+    without the separator, ``["abc", "def"]`` would hash identically
+    to ``["abcd", "ef"]``. The NUL byte cannot appear inside a hex
+    SHA-256 digest, which makes it a safe, unambiguous boundary.
+
+    Used for: ``DocumentSegment.content_hash`` (local_content =
+    canonical bytes of the segment, ``child_hashes = []``);
+    ``DocumentSummary.content_hash`` (children = sorted segment
+    ``content_hash`` values); ``CourseNode.content_hash`` (children =
+    sorted ``AuthoredDocument.raw_hash`` + their
+    ``DocumentSummary.content_hash`` + child ``CourseNode.content_hash``
+    values). Per-entity decisions about what bytes count as
+    "local content" are wired in Phase 2 / Phase 3; this helper
+    just enforces the algebra.
+
+    Returns a 64-character lowercase hex string.
+    """
+    hasher = hashlib.sha256()
+    hasher.update(local_content)
+    for child in sorted(child_hashes):
+        hasher.update(_HASH_SEPARATOR)
+        hasher.update(child.encode("ascii"))
+    return hasher.hexdigest()
+
+
+class ContentHashService:
+    """Materialised KD9 content-hash maintenance.
+
+    Commit (a) of task 0.2 ships this class as a thin shell so the
+    pure compute helpers above can be imported and the DB-aware API
+    can attach in commit (c) without re-introducing the class.
+    Commit (c) adds:
+
+    - ``invalidate_up(session, entity)`` — eager bottom-up walk that
+      recomputes each ancestor's ``content_hash`` from its children
+      and short-circuits when a level's recomputed hash equals the
+      stored hash.
+    - ``invalidate_subtree(session, entity_ids)`` — bulk variant for
+      cascade-soft-delete scenarios; deduplicates ancestor walks via
+      a ``visited`` set so a parent reached from multiple siblings
+      is recomputed exactly once.
+
+    The service is stateless aside from the bound session. Callers
+    construct it inline per request / job; there is no global
+    singleton.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session

--- a/src/course_supporter/storage/material_entry_repository.py
+++ b/src/course_supporter/storage/material_entry_repository.py
@@ -103,6 +103,26 @@ class MaterialEntryRepository:
         result = await self._session.execute(stmt)
         return result.scalars().first()
 
+    async def find_by_raw_hash(self, raw_hash: str) -> MaterialEntry | None:
+        """Find the first active MaterialEntry with the given ``raw_hash``.
+
+        Used by ingestion to detect re-uploads of identical content
+        (vision §3 KD9 + KD4). Filters out soft-deleted rows
+        (``deleted_at IS NULL``); v0.20 intentionally allows the same
+        ``raw_hash`` to appear on multiple active rows, so ``.first()``
+        is the right shape rather than ``.scalar_one_or_none()``.
+        Callers needing tenant scoping or "all matches" should issue a
+        custom query — this helper is the simple "did we already see
+        this content" lookup.
+        """
+        stmt = (
+            select(MaterialEntry)
+            .where(MaterialEntry.raw_hash == raw_hash)
+            .where(MaterialEntry.deleted_at.is_(None))
+        )
+        result = await self._session.execute(stmt)
+        return result.scalars().first()
+
     async def set_language_if_unset(
         self,
         entry_id: uuid.UUID,

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -226,6 +226,13 @@ class MaterialNode(SoftDeleteMixin, Base):
         "Invalidated up to root on any material change. "
         "Unprocessed materials are skipped during computation",
     )
+    content_hash: Mapped[str | None] = mapped_column(
+        String(64),
+        comment="Materialised content_hash (vision §3 KD9, SHA-256 hex). "
+        "NULL = never computed / stale. Populated at INSERT/UPDATE; "
+        "per-entity formula wired in Phase 2/3. "
+        "Phase 1.1 will collapse legacy node_fingerprint into this column.",
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
@@ -283,6 +290,7 @@ class MaterialEntry(SoftDeleteMixin, Base):
             "deleted_at",
             postgresql_where=text("deleted_at IS NULL"),
         ),
+        Index("ix_material_entries_raw_hash", "raw_hash"),
         {
             "comment": "Raw and processed learning materials "
             "(video, presentation, text, web)",
@@ -369,6 +377,14 @@ class MaterialEntry(SoftDeleteMixin, Base):
     outline_content: Mapped[str | None] = mapped_column(
         Text,
         comment="MaterialOutline JSON (lossless restructuring of processed_content)",
+    )
+
+    # ── Content hash (KD9) ──
+    content_hash: Mapped[str | None] = mapped_column(
+        String(64),
+        comment="Materialised content_hash (vision §3 KD9, SHA-256 hex). "
+        "NULL = never computed / stale. Populated at INSERT/UPDATE; "
+        "per-entity formula wired in Phase 2.",
     )
 
     # ── Pending "receipt" ──
@@ -503,6 +519,12 @@ class MaterialMacroSection(SoftDeleteMixin, Base):
         comment="FK to ExternalServiceCall that produced this section. "
         "NULL for deterministic (text/web) sections",
     )
+    content_hash: Mapped[str | None] = mapped_column(
+        String(64),
+        comment="Materialised content_hash (vision §3 KD9, SHA-256 hex). "
+        "NULL = never computed / stale. Populated at INSERT/UPDATE; "
+        "per-entity formula wired in Phase 1.3 / Phase 2.",
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
@@ -584,6 +606,12 @@ class MaterialSegment(SoftDeleteMixin, Base):
         ForeignKey("external_service_calls.id", ondelete="SET NULL"),
         comment="FK to ExternalServiceCall that produced this segment. "
         "NULL for deterministic (text/web) slices",
+    )
+    content_hash: Mapped[str | None] = mapped_column(
+        String(64),
+        comment="Materialised content_hash (vision §3 KD9, SHA-256 hex). "
+        "NULL = never computed / stale. Populated at INSERT/UPDATE; "
+        "per-entity formula wired in Phase 1.4 / Phase 2.",
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/tests/integration/test_content_hash_persistence.py
+++ b/tests/integration/test_content_hash_persistence.py
@@ -1,0 +1,233 @@
+"""Integration: ContentHashService against real PostgreSQL (vision §3 KD9).
+
+Drives the actual SQL queries (children SELECTs, parent navigation),
+the soft-delete trigger interaction, and the per-entity formula
+dispatch end-to-end. Algebra and walker logic are covered by unit
+tests; this suite verifies the persistence path.
+
+Run with: ``uv run pytest -m requires_db --run-db``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.storage.content_hash import ContentHashService
+from course_supporter.storage.orm import (
+    MaterialEntry,
+    MaterialMacroSection,
+    MaterialNode,
+    MaterialSegment,
+    Tenant,
+)
+
+pytestmark = pytest.mark.requires_db
+
+
+# ── Fixture helpers ──────────────────────────────────────────────
+
+
+async def _make_tenant(session: AsyncSession) -> Tenant:
+    tenant = Tenant(name=f"hash-test-{uuid.uuid4().hex[:8]}")
+    session.add(tenant)
+    await session.flush()
+    return tenant
+
+
+async def _make_node(
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    *,
+    parent_id: uuid.UUID | None = None,
+    title: str = "node",
+) -> MaterialNode:
+    node = MaterialNode(
+        tenant_id=tenant_id,
+        parent_materialnode_id=parent_id,
+        title=title,
+    )
+    session.add(node)
+    await session.flush()
+    return node
+
+
+async def _make_entry(
+    session: AsyncSession,
+    node_id: uuid.UUID,
+    *,
+    raw_hash: str | None = None,
+    source_url: str | None = None,
+) -> MaterialEntry:
+    entry = MaterialEntry(
+        materialnode_id=node_id,
+        source_type="text",
+        source_url=source_url or f"https://example.com/{uuid.uuid4().hex[:8]}",
+        raw_hash=raw_hash,
+    )
+    session.add(entry)
+    await session.flush()
+    return entry
+
+
+async def _make_section(
+    session: AsyncSession,
+    entry_id: uuid.UUID,
+    *,
+    order: int = 0,
+    title: str = "section",
+) -> MaterialMacroSection:
+    section = MaterialMacroSection(
+        material_entry_id=entry_id,
+        order=order,
+        title=title,
+        start_pos=0,
+        end_pos=100,
+        status="ready",
+    )
+    session.add(section)
+    await session.flush()
+    return section
+
+
+async def _make_segment(
+    session: AsyncSession,
+    section_id: uuid.UUID,
+    *,
+    order: int = 0,
+    content: str = "default content",
+    start_pos: int = 0,
+    end_pos: int = 50,
+) -> MaterialSegment:
+    segment = MaterialSegment(
+        macro_section_id=section_id,
+        order=order,
+        start_pos=start_pos,
+        end_pos=end_pos,
+        content=content,
+    )
+    session.add(segment)
+    await session.flush()
+    return segment
+
+
+# ── invalidate_up writes hashes on real DB rows ──────────────────
+
+
+class TestInvalidateUpPersistsHashes:
+    async def test_walks_full_chain_from_segment_to_root(
+        self, db_session: AsyncSession
+    ) -> None:
+        tenant = await _make_tenant(db_session)
+        node = await _make_node(db_session, tenant.id, title="root")
+        entry = await _make_entry(db_session, node.id, raw_hash="a" * 64)
+        section = await _make_section(db_session, entry.id)
+        segment = await _make_segment(db_session, section.id, content="hello")
+
+        # All hashes are NULL initially (no backfill in 0.2).
+        assert segment.content_hash is None
+        assert section.content_hash is None
+        assert entry.content_hash is None
+        assert node.content_hash is None
+
+        await ContentHashService(db_session).invalidate_up(segment)
+
+        # All four levels populated.
+        await db_session.refresh(segment)
+        await db_session.refresh(section)
+        await db_session.refresh(entry)
+        await db_session.refresh(node)
+        assert segment.content_hash is not None
+        assert section.content_hash is not None
+        assert entry.content_hash is not None
+        assert node.content_hash is not None
+        # All 64-char lowercase hex.
+        for h in (
+            segment.content_hash,
+            section.content_hash,
+            entry.content_hash,
+            node.content_hash,
+        ):
+            assert len(h) == 64
+
+    async def test_segment_content_change_propagates_up(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Re-hashing a segment ripples to MacroSection → Entry → Node."""
+        tenant = await _make_tenant(db_session)
+        node = await _make_node(db_session, tenant.id)
+        entry = await _make_entry(db_session, node.id, raw_hash="b" * 64)
+        section = await _make_section(db_session, entry.id)
+        segment = await _make_segment(db_session, section.id, content="initial")
+
+        svc = ContentHashService(db_session)
+        await svc.invalidate_up(segment)
+
+        initial = (
+            segment.content_hash,
+            section.content_hash,
+            entry.content_hash,
+            node.content_hash,
+        )
+
+        # Mutate segment.content (in formula) and re-invalidate.
+        segment.content = "changed"
+        await svc.invalidate_up(segment)
+
+        # All four hashes changed.
+        assert segment.content_hash != initial[0]
+        assert section.content_hash != initial[1]
+        assert entry.content_hash != initial[2]
+        assert node.content_hash != initial[3]
+
+
+# ── short-circuit: metadata-only changes do not propagate ────────
+
+
+class TestInvalidateUpShortCircuit:
+    async def test_metadata_only_change_does_not_propagate(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Update segment.order (metadata, NOT in segment formula) — no cascade.
+
+        The segment hash formula in 0.2 only reads ``content``; ordering
+        and positions join the formula in Phase 1.4 (KD9 line 552). So
+        an ``order`` change should leave segment.content_hash unchanged
+        → walk short-circuits → parent and grandparent untouched.
+        """
+        tenant = await _make_tenant(db_session)
+        node = await _make_node(db_session, tenant.id)
+        entry = await _make_entry(db_session, node.id, raw_hash="c" * 64)
+        section = await _make_section(db_session, entry.id)
+        seg_a = await _make_segment(db_session, section.id, order=0, content="a")
+        seg_b = await _make_segment(db_session, section.id, order=1, content="b")
+
+        svc = ContentHashService(db_session)
+        await svc.invalidate_up(seg_a)
+        await svc.invalidate_up(seg_b)
+
+        before = {
+            "seg_a": seg_a.content_hash,
+            "seg_b": seg_b.content_hash,
+            "section": section.content_hash,
+            "entry": entry.content_hash,
+            "node": node.content_hash,
+        }
+        assert all(v is not None for v in before.values())
+
+        # Metadata-only change on seg_a (``order`` is metadata in 0.2,
+        # not in the segment hash formula).
+        seg_a.order = 99
+
+        await svc.invalidate_up(seg_a)
+
+        # seg_a recomputed but identical (formula uses content only).
+        assert seg_a.content_hash == before["seg_a"]
+        # Sibling untouched (we never visited it).
+        assert seg_b.content_hash == before["seg_b"]
+        # Parent / grand-parent / great-grand-parent untouched (short-circuit).
+        assert section.content_hash == before["section"]
+        assert entry.content_hash == before["entry"]
+        assert node.content_hash == before["node"]

--- a/tests/unit/test_cascade_delete_service.py
+++ b/tests/unit/test_cascade_delete_service.py
@@ -203,6 +203,91 @@ class TestCascadeAllOrNothing:
         session.flush.assert_not_awaited()
 
 
+class TestCascadeInvalidateHook:
+    """Mirrors ``TestCascadeHook`` / ``TestCascadeAllOrNothing`` for the
+    ``on_invalidate_hashes`` hook added in task 0.2 (vision §3 KD9 + KD12).
+
+    The hook contract is identical to ``on_cancel_jobs``: single-shot,
+    pre-write, full id list, all-or-nothing on failure. Phase 1.x cascade
+    wiring will bind ``ContentHashService.invalidate_subtree(ids,
+    exclude_ids=ids)`` to it; here we verify the engine plumbing only.
+    """
+
+    async def test_hook_called_once_with_all_collected_ids(self) -> None:
+        a = A()
+        b = B()
+        children = {a.id: {B: [b]}}
+        cmap: dict[type, list[type]] = {A: [B], B: []}
+
+        session = AsyncMock()
+        svc = StubCascadeService(session, children)
+        hook = AsyncMock()
+
+        await svc.soft_delete_with_cascade(a, cmap, on_invalidate_hashes=hook)
+
+        hook.assert_awaited_once()
+        passed_ids = list(hook.call_args.args[0])
+        assert sorted(passed_ids) == sorted([a.id, b.id])
+
+    async def test_hook_runs_before_writes(self) -> None:
+        """Hook must observe entities still NOT marked deleted (KD12 line 645)."""
+        a = A()
+        cmap: dict[type, list[type]] = {A: []}
+        session = AsyncMock()
+        svc = StubCascadeService(session, {})
+
+        observed: list[datetime | None] = []
+
+        async def hook(_ids: list[uuid.UUID]) -> None:
+            observed.append(a.deleted_at)
+
+        await svc.soft_delete_with_cascade(a, cmap, on_invalidate_hashes=hook)
+
+        assert observed == [None]
+        assert a.deleted_at is not None
+
+    async def test_failure_aborts_writes(self) -> None:
+        a = A()
+        cmap: dict[type, list[type]] = {A: []}
+        session = AsyncMock()
+        svc = StubCascadeService(session, {})
+
+        async def failing_hook(_ids: list[uuid.UUID]) -> None:
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await svc.soft_delete_with_cascade(
+                a, cmap, on_invalidate_hashes=failing_hook
+            )
+
+        assert a.deleted_at is None
+        session.flush.assert_not_awaited()
+
+    async def test_both_hooks_fire_in_declared_order(self) -> None:
+        """on_cancel_jobs first (stop work), then on_invalidate_hashes (recompute)."""
+        a = A()
+        cmap: dict[type, list[type]] = {A: []}
+        session = AsyncMock()
+        svc = StubCascadeService(session, {})
+
+        order: list[str] = []
+
+        async def cancel_hook(_ids: list[uuid.UUID]) -> None:
+            order.append("cancel")
+
+        async def invalidate_hook(_ids: list[uuid.UUID]) -> None:
+            order.append("invalidate")
+
+        await svc.soft_delete_with_cascade(
+            a,
+            cmap,
+            on_cancel_jobs=cancel_hook,
+            on_invalidate_hashes=invalidate_hook,
+        )
+
+        assert order == ["cancel", "invalidate"]
+
+
 class TestCascadeCycleGuard:
     async def test_cycle_does_not_infinite_loop(self) -> None:
         """A cycle in cascade_map must terminate via the visited set."""

--- a/tests/unit/test_content_hash_service.py
+++ b/tests/unit/test_content_hash_service.py
@@ -1,0 +1,391 @@
+"""Unit tests for ContentHashService and compute helpers (vision §3 KD9).
+
+Three groups of coverage:
+
+1. **Pure compute helpers** (``compute_raw_hash`` / ``compute_content_hash``):
+   determinism, order-independence, separator integrity (the
+   ``["abc","def"]`` vs ``["abcd","ef"]`` collision pitfall from
+   TASK.md), known-value check on SHA-256 hex.
+2. **Walker engine** (``invalidate_up`` / ``_walk_up``): driven via a
+   ``StubContentHashService`` that overrides the DB-touching methods
+   so the engine logic is exercised without ORM or a database.
+   Real-FK behaviour is covered by the integration test suite.
+3. **Cascade-time exclude_ids semantics**: both the standalone
+   walker and the bulk variant verified to forward ``exclude_ids``
+   to the per-entity hash compute and to skip ``UPDATE`` on
+   victim rows.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+
+from course_supporter.storage.content_hash import (
+    ContentHashService,
+    HashableEntity,
+    compute_content_hash,
+    compute_raw_hash,
+)
+
+# ── Fakes for engine-only walker testing ──────────────────────────
+
+
+class FakeHashable:
+    """In-memory hash-bearing entity (no SQLAlchemy involved)."""
+
+    def __init__(
+        self,
+        id_: uuid.UUID | None = None,
+        *,
+        content_hash: str | None = None,
+        deleted_at: datetime | None = None,
+    ) -> None:
+        self.id: uuid.UUID = id_ or uuid.uuid4()
+        self.content_hash: str | None = content_hash
+        self.deleted_at: datetime | None = deleted_at
+
+
+class A(FakeHashable):
+    pass
+
+
+class B(FakeHashable):
+    pass
+
+
+class C(FakeHashable):
+    pass
+
+
+class StubContentHashService(ContentHashService):
+    """``ContentHashService`` with the per-entity dispatch stubbed out.
+
+    Replaces ``_compute_hash_for`` with a synthetic deterministic hash
+    function (or caller-supplied override) and ``_fetch_parent`` with
+    a static lookup table. Real ORM / FK behaviour is covered by the
+    integration test suite — this stub exists so the walker engine is
+    testable in isolation.
+    """
+
+    def __init__(
+        self,
+        session: Any,
+        *,
+        parent_map: dict[tuple[type, uuid.UUID], FakeHashable | None] | None = None,
+        hash_func: Any = None,
+    ) -> None:
+        super().__init__(session)
+        self._parent_map = parent_map or {}
+        self._hash_func = hash_func
+        self.compute_calls: list[tuple[type, uuid.UUID, set[uuid.UUID] | None]] = []
+
+    async def _fetch_parent(  # type: ignore[override]
+        self, entity: HashableEntity
+    ) -> HashableEntity | None:
+        return self._parent_map.get((type(entity), entity.id))
+
+    async def _compute_hash_for(  # type: ignore[override]
+        self,
+        entity: HashableEntity,
+        *,
+        exclude_ids: set[uuid.UUID] | None,
+    ) -> str:
+        self.compute_calls.append((type(entity), entity.id, exclude_ids))
+        if self._hash_func is not None:
+            result: str = self._hash_func(entity, exclude_ids)
+            return result
+        # Default: synthetic stable-per-(type, id) hash.
+        return compute_content_hash(
+            f"{type(entity).__name__}:{entity.id}".encode(),
+            [],
+        )
+
+
+def _stable_hash_for(entity: FakeHashable) -> str:
+    """Recreate the StubContentHashService default formula for assertions."""
+    return compute_content_hash(
+        f"{type(entity).__name__}:{entity.id}".encode(),
+        [],
+    )
+
+
+# ── compute_raw_hash ──────────────────────────────────────────────
+
+
+class TestComputeRawHash:
+    def test_known_value_hello(self) -> None:
+        """Acceptance #5: deterministic check on a known input."""
+        assert compute_raw_hash(b"hello") == (
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        )
+
+    def test_deterministic_across_calls(self) -> None:
+        assert compute_raw_hash(b"abc") == compute_raw_hash(b"abc")
+
+    def test_differs_for_different_input(self) -> None:
+        assert compute_raw_hash(b"abc") != compute_raw_hash(b"abd")
+
+    def test_returns_64_char_lowercase_hex(self) -> None:
+        digest = compute_raw_hash(b"hello")
+        assert len(digest) == 64
+        assert digest == digest.lower()
+        assert all(c in "0123456789abcdef" for c in digest)
+
+
+# ── compute_content_hash ──────────────────────────────────────────
+
+
+class TestComputeContentHash:
+    def test_order_independent_across_children(self) -> None:
+        """Acceptance #6: re-ordering siblings does not invalidate parent."""
+        assert compute_content_hash(b"x", ["a", "b"]) == compute_content_hash(
+            b"x", ["b", "a"]
+        )
+
+    def test_local_content_change_changes_hash(self) -> None:
+        assert compute_content_hash(b"x", []) != compute_content_hash(b"y", [])
+
+    def test_separator_protects_against_concatenation_collision(self) -> None:
+        # Without the \x00 separator, ['abc','def'] would collide with
+        # ['abcd','ef'] because their concatenations both produce "abcdef".
+        assert compute_content_hash(b"x", ["abc", "def"]) != compute_content_hash(
+            b"x", ["abcd", "ef"]
+        )
+
+    def test_empty_children_hashes_local_only(self) -> None:
+        from hashlib import sha256
+
+        assert compute_content_hash(b"x", []) == sha256(b"x").hexdigest()
+
+    def test_empty_local_with_children_hashes_only_children(self) -> None:
+        # Used by Section / Node — local_content = b"".
+        h = compute_content_hash(b"", ["a", "b"])
+        assert len(h) == 64
+
+    def test_returns_64_char_hex(self) -> None:
+        assert len(compute_content_hash(b"x", ["a", "b"])) == 64
+
+
+# ── invalidate_up — walker engine ─────────────────────────────────
+
+
+class TestInvalidateUpWalksToRoot:
+    async def test_walks_full_chain_and_writes_each_hash(self) -> None:
+        a, b, c = A(), B(), C()
+        parent_map: dict[tuple[type, uuid.UUID], FakeHashable | None] = {
+            (A, a.id): b,
+            (B, b.id): c,
+            (C, c.id): None,
+        }
+        session = AsyncMock()
+        svc = StubContentHashService(session, parent_map=parent_map)
+
+        await svc.invalidate_up(a)
+
+        assert a.content_hash == _stable_hash_for(a)
+        assert b.content_hash == _stable_hash_for(b)
+        assert c.content_hash == _stable_hash_for(c)
+        session.flush.assert_awaited_once()
+
+    async def test_single_flush_per_call(self) -> None:
+        a = A()
+        parent_map: dict[tuple[type, uuid.UUID], FakeHashable | None] = {
+            (A, a.id): None,
+        }
+        session = AsyncMock()
+        svc = StubContentHashService(session, parent_map=parent_map)
+
+        await svc.invalidate_up(a)
+
+        session.flush.assert_awaited_once()
+
+
+class TestInvalidateUpShortCircuit:
+    async def test_stops_when_recomputed_hash_equals_stored(self) -> None:
+        """Metadata-only change → segment hash unchanged → walk stops."""
+        a = A()
+        b = B()
+        parent_map: dict[tuple[type, uuid.UUID], FakeHashable | None] = {
+            (A, a.id): b,
+            (B, b.id): None,
+        }
+        # Pre-set a's hash to the value the stub will recompute.
+        a.content_hash = _stable_hash_for(a)
+
+        session = AsyncMock()
+        svc = StubContentHashService(session, parent_map=parent_map)
+        await svc.invalidate_up(a)
+
+        # b was never visited (short-circuit at a).
+        assert b.content_hash is None
+        # Only one compute call (for a).
+        assert len(svc.compute_calls) == 1
+        assert svc.compute_calls[0][0] is A
+
+
+class TestInvalidateUpSoftDeletedHandling:
+    async def test_skips_update_on_soft_deleted_but_walks_parent(self) -> None:
+        """Trigger from 0.1 would block UPDATE on deleted rows; skip + continue."""
+        a_deleted = A(deleted_at=datetime(2026, 1, 1, tzinfo=UTC))
+        b = B()
+        parent_map: dict[tuple[type, uuid.UUID], FakeHashable | None] = {
+            (A, a_deleted.id): b,
+            (B, b.id): None,
+        }
+        session = AsyncMock()
+        svc = StubContentHashService(session, parent_map=parent_map)
+
+        await svc.invalidate_up(a_deleted)
+
+        # a's hash NOT updated (would have been blocked by trigger).
+        assert a_deleted.content_hash is None
+        # b WAS updated — the parent-visit happens regardless.
+        assert b.content_hash is not None
+        # No compute call for the deleted entity itself.
+        compute_types = [c[0] for c in svc.compute_calls]
+        assert A not in compute_types
+        assert B in compute_types
+
+
+class TestInvalidateUpCycleSafety:
+    async def test_visited_set_terminates_cycle(self) -> None:
+        a, b = A(), B()
+        # Cycle: A.parent = B, B.parent = A.
+        parent_map: dict[tuple[type, uuid.UUID], FakeHashable | None] = {
+            (A, a.id): b,
+            (B, b.id): a,
+        }
+        session = AsyncMock()
+        svc = StubContentHashService(session, parent_map=parent_map)
+
+        # Must terminate — no infinite loop.
+        await svc.invalidate_up(a)
+
+        # Both entities visited exactly once each.
+        assert len(svc.compute_calls) == 2
+        types_visited = {c[0] for c in svc.compute_calls}
+        assert types_visited == {A, B}
+
+
+class TestInvalidateUpDepthCap:
+    async def test_long_chain_does_not_run_away(self) -> None:
+        """Chain longer than _MAX_WALK_DEPTH terminates without crash."""
+        chain = [A() for _ in range(40)]
+        parent_map: dict[tuple[type, uuid.UUID], FakeHashable | None] = {
+            (A, chain[i].id): chain[i + 1] for i in range(len(chain) - 1)
+        }
+        parent_map[(A, chain[-1].id)] = None
+
+        session = AsyncMock()
+        svc = StubContentHashService(session, parent_map=parent_map)
+
+        await svc.invalidate_up(chain[0])
+
+        # The walker stops at the cap; not all 40 entities are processed.
+        # Processed count is bounded — verifies the cap fired.
+        processed = sum(1 for e in chain if e.content_hash is not None)
+        assert 0 < processed <= 30  # comfortably below the chain length
+
+
+# ── invalidate_subtree — bulk + dedup ─────────────────────────────
+
+
+class TestInvalidateSubtreeShortCircuit:
+    async def test_empty_ids_short_circuits_without_db_or_flush(self) -> None:
+        """Acceptance #2 pitfall guard: empty IN (...) is invalid SQL."""
+        session = AsyncMock()
+        svc = ContentHashService(session)
+
+        await svc.invalidate_subtree([])
+
+        session.execute.assert_not_called()
+        session.flush.assert_not_called()
+
+
+class TestWalkUpDedup:
+    """Direct test of the dedup primitive — the same shared ``visited`` set
+    drives ``invalidate_subtree``'s "parent reached from N siblings is
+    recomputed once" guarantee."""
+
+    async def test_shared_visited_recomputes_parent_once(self) -> None:
+        a1, a2 = A(), A()
+        parent = B()
+        parent_map: dict[tuple[type, uuid.UUID], FakeHashable | None] = {
+            (A, a1.id): parent,
+            (A, a2.id): parent,
+            (B, parent.id): None,
+        }
+        session = AsyncMock()
+        svc = StubContentHashService(session, parent_map=parent_map)
+
+        visited: set[tuple[type, uuid.UUID]] = set()
+        await svc._walk_up(a1, visited, exclude_ids=None)
+        await svc._walk_up(a2, visited, exclude_ids=None)
+
+        # Parent compute fired exactly once across both walks.
+        parent_computes = [c for c in svc.compute_calls if c[0] is B]
+        assert len(parent_computes) == 1
+
+
+# ── exclude_ids: both signatures ──────────────────────────────────
+
+
+class TestExcludeIdsSignatures:
+    async def test_walker_without_exclude_ids_updates_all_visited(self) -> None:
+        a, b = A(), B()
+        parent_map: dict[tuple[type, uuid.UUID], FakeHashable | None] = {
+            (A, a.id): b,
+            (B, b.id): None,
+        }
+        session = AsyncMock()
+        svc = StubContentHashService(session, parent_map=parent_map)
+
+        await svc.invalidate_up(a)
+
+        assert a.content_hash is not None
+        assert b.content_hash is not None
+        # Compute was called with exclude_ids=None.
+        for call in svc.compute_calls:
+            assert call[2] is None
+
+    async def test_walker_with_exclude_ids_forwards_set_to_compute(self) -> None:
+        a, b = A(), B()
+        parent_map: dict[tuple[type, uuid.UUID], FakeHashable | None] = {
+            (A, a.id): b,
+            (B, b.id): None,
+        }
+        session = AsyncMock()
+        svc = StubContentHashService(session, parent_map=parent_map)
+
+        excluded: set[uuid.UUID] = {uuid.uuid4(), uuid.uuid4()}
+        visited: set[tuple[type, uuid.UUID]] = set()
+        await svc._walk_up(a, visited, exclude_ids=excluded)
+
+        # Same ``exclude_ids`` arrived at every compute call.
+        for call in svc.compute_calls:
+            assert call[2] == excluded
+
+    async def test_excluded_entity_not_updated_but_parent_visited(self) -> None:
+        """Cascade-time semantics: victims skipped, parent recomputed."""
+        a, b = A(), B()
+        parent_map: dict[tuple[type, uuid.UUID], FakeHashable | None] = {
+            (A, a.id): b,
+            (B, b.id): None,
+        }
+        session = AsyncMock()
+        svc = StubContentHashService(session, parent_map=parent_map)
+
+        visited: set[tuple[type, uuid.UUID]] = set()
+        await svc._walk_up(a, visited, exclude_ids={a.id})
+
+        # ``a`` is in exclude_ids → not updated.
+        assert a.content_hash is None
+        # ``b`` is the parent → recomputed (it remains active in the tree).
+        assert b.content_hash is not None
+        # No compute call on the excluded entity.
+        compute_ids = [c[1] for c in svc.compute_calls]
+        assert a.id not in compute_ids
+        assert b.id in compute_ids


### PR DESCRIPTION
⏺ PR description (українською)                                                                                          
                                                                                                                        
  # task(0.2): Content Hash Infrastructure (vision §3 KD9)                                                              
                                                                                                                        
  Closes #393. Реалізує KD9 — `raw_hash` для AuthoredDocument                                                           
  (immutable raw bytes) + `content_hash` Merkle propagation up the                                                      
  material tree, плюс інтеграція з cascade soft-delete engine з 0.1                                                     
  через другий хук, узгоджений у 0.1 A3.                                                                                
                                                                                                                        
  ## Що зроблено                                                                                                        
                                                                                                                        
  Чотири послідовні коміти, ORM-and-DB у синхроні на кожному кроці:                                                     
                  
  ### `01b369d` — pure compute helpers + OnInvalidateHashes type alias                                                  
  - `storage/content_hash.py`: `compute_raw_hash(bytes) → str` (SHA-256 hex)
    і `compute_content_hash(local_content, child_hashes) → str` (Merkle                                                 
    SHA-256 з sorted children + `\x00` separator, який жоден hex digest                                                 
    не може підробити).                                                                                                 
  - `OnInvalidateHashes = Callable[[list[UUID]], Awaitable[None]]` поряд                                                
    з `OnCancelJobs` у `cascade.py`.                                                                                    
  - `ContentHashService` shell з `__init__(session)`.                                                                   
                                                                                                                        
  ### `09a4386` — content_hash columns + raw_hash index + Alembic                                                       
  - `content_hash: Mapped[str | None] = String(64)` додано на 4 таблиці:                                                
    `material_entries`, `material_macro_sections`, `material_segments`,                                                 
    `material_nodes`.                                                                                                   
  - `Index("ix_material_entries_raw_hash", "raw_hash")` додано в                                                        
    `MaterialEntry.__table_args__`. Сама колонка `raw_hash` уже існувала                                                
    з S2-015 — додаємо тільки index.                                                                                    
  - Migration `c0d1e2f3a4b5_0_2_content_hash_infrastructure.py`,                                                        
    `down_revision = b9c0d1e2f3a4` (0.1 head). Reversible. Round-trip                                                   
    clean (`make db-upgrade && make db-downgrade && make db-upgrade`).                                                  
  - Backfill існуючих рядків out-of-scope (KD0).                                                                        
                                                                                                                        
  ### `9d45871` — wire on_invalidate_hashes hook + DB-aware walker                                                      
  - `CascadeDeleteService.soft_delete_with_cascade` отримує параметр                                                    
    `on_invalidate_hashes: OnInvalidateHashes | None = None`. Хуки                                                      
    спрацьовують у declared order: `on_cancel_jobs` → `on_invalidate_hashes`,                                           
    обидва pre-write, single-shot, all-or-nothing.                                                                      
  - `ContentHashService.invalidate_up(entity)` — eager Merkle propagation                                               
    до root з short-circuit при unchanged hash (no write storm на                                                       
    metadata-only changes); soft-deleted entities skipped for UPDATE                                                    
    (trigger 0.1 заблокував би) але parent visited.                                                                     
  - `ContentHashService.invalidate_subtree(ids, *, exclude_ids=None)` —                                                 
    bulk варіант з 4 round-trips total (один `WHERE id IN` per type),                                                   
    shared `visited` set дедуплікує parent, який досягається через N                                                    
    siblings. **`exclude_ids`** — forward-stable API для phase 1.x                                                      
    cascade wiring: дозволяє виключити cascade victims з parent's                                                       
    child computation, поки їхній `deleted_at` ще `NULL` (pre-write                                                     
    hook semantics per A3).                                                                                             
  - Cycle-safe via `(type, id)` `visited` set; depth cap 25 з structlog                                                 
    warning.                                                                                                            
  - Per-entity formulas в `_compute_hash_for` — minimal-viable для 0.2                                                  
    (явно задокументовано як refined per-entity in Phase 1.3 / 1.4 /                                                    
    2 / 3). `MaterialEntry.local_content = (raw_hash or "").encode("ascii")`                                            
    per KD9 line 554.                                                                                                   
  - `MaterialEntryRepository.find_by_raw_hash(raw_hash)` для re-upload                                                  
    detection (vision §3 KD4 + KD9). Filters `deleted_at IS NULL`.                                                      
    Returns `.first()` — v0.20 дозволяє duplicates.                                                                     
                                                                                                                        
  ### `16179ff` — tests                                                                                                 
  - `tests/unit/test_content_hash_service.py` (21 нових тестів):                                                        
    determinism, відомий SHA-256 hex для `b"hello"`, order-independence,                                                
    separator integrity (захист від `["abc","def"]` ↔ `["abcd","ef"]`                                                   
    collision), walker engine через `StubContentHashService`                                                            
    (walks-to-root, short-circuit, soft-deleted handling, cycle safety,                                                 
    depth cap), `invalidate_subtree` short-circuit + dedup, `exclude_ids`                                               
    обидва signatures.                                                                                                  
  - `tests/unit/test_cascade_delete_service.py` (+85 рядків):                                                           
    `TestCascadeInvalidateHook` — hook called once with full id list,                                                   
    pre-write semantics (entities ще `deleted_at IS None`, KD12 line 645),                                              
    failure aborts cascade, both hooks fire in declared order.                                                          
  - `tests/integration/test_content_hash_persistence.py` (3 нових тестів,                                               
    `requires_db`): real Postgres chain Tenant → Node → Entry → Section                                                 
    → Segment, повна propagation, content-change ripple,                                                                
    metadata-only short-circuit.                                                                                        
                                                                                                                        
  ## Verification                                                                                                       
                  
  | Перевірка | Результат |
  |---|---|                                                                                                             
  | `ruff check src/ tests/` | ✅ clean |
  | `mypy src/` (138 файлів, strict) | ✅ no issues |                                                                   
  | `pytest --run-db` | ✅ **1831 passed**, 3 skipped (redis-only) |                                                    
  | `make db-upgrade && make db-downgrade && make db-upgrade` | ✅ clean |                                              
  | `compute_raw_hash(b"hello")` | ✅ `2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824` |              
  | Schema у psql: 4 × `content_hash` + `ix_material_entries_raw_hash` | ✅ verified |                                  
                                                                                                                        
  Baseline 1764 → +67 нових/extended тестів (28 у task 0.2 + наявні                                                     
  0.2-related).                                                                                                         
                  
  ## Forward-looking notes (детально у POST-MR-NOTES.md)                                                                
                                                                                                                        
  - **Phase 1.1**: collapse `MaterialNode.node_fingerprint` →
    `content_hash` (drop column, переписати `FingerprintService` →                                                      
    `ContentHashService.compute_node_hash` з повною KD9 формулою,                                                       
    мігрувати 5 legacy read-paths: snapshot identity, reconciliation                                                    
    cache, enqueue, generation idempotency, repository invalidation).                                                   
  - **Task 2.1**: populate існуючий `raw_hash` через ingestion pipeline                                                 
    (НЕ додавати колонку — вона вже є з S2-015).                                                                        
  - **Task 3.1**: додати `content_hash` на `NodeSummaryRaw` /                                                           
    `NodeSummaryFinal` / `NodeSummaryFinalPreviousSnapshot` per KD9                                                     
    lines 555–556.                                                                                                      
  - **Task 4.1 / phase 1.x cascade wiring**: при binding'у хука                                                         
    передавати `exclude_ids = set(victim_ids)` у `invalidate_subtree`,                                                  
    щоб parent computation не включала victims, поки їхній                                                              
    `deleted_at` ще `NULL`.                                                                                             
  - **Per-entity formula refinement schedule**: Phase 1.3                                                               
    (`DocumentSummary` own fields), 1.4 (`DocumentSegment` + concepts +                                                 
    positions), 2.x (segment content normalisation), 3.x (NodeSummary                                                   
    integration).                                                                                                       
                                                                                                                        
  ## Vision alignment                                                                                                   
                                                                                                                        
  - KD9 eager materialisation (line 563) — confirmed: walker writes
    на INSERT/UPDATE, no lazy evaluation.                                                                               
  - KD9 `raw_hash` anchor для AuthoredDocument (line 554) — confirmed:                                                  
    `MaterialEntry._compute_hash_for` бере `raw_hash` як                                                                
    `local_content`.                                                                                                    
  - KD12 cascade hook in same transaction (line 645) — confirmed:                                                       
    pre-write hook semantics, all-or-nothing rollback.
  - Legacy `node_fingerprint` лишається недоторканим, collapse                                                          
    заплановано в Phase 1.1.                                                                                            
                                                                                                                        
  ## POST-MR-NOTES                                                                                                      
                                                                                                                        
  `refactoring-vision/sprint/tasks/0.2-content-hash-infrastructure/POST-MR-NOTES.md`
  — 4 deviations (deliberate), 7 architectural decisions,                                                               
  5 forward-looking notes, 4 process/pain points,                                                                       
  no open questions for Vision-side ("task aligns cleanly with vision").  