### PR TITLE
task(0.3): Job Model Redesign PR-398

### DIFF
--- a/migrations/versions/e2f3a4b5c6d7_0_3_job_redesign.py
+++ b/migrations/versions/e2f3a4b5c6d7_0_3_job_redesign.py
@@ -1,0 +1,98 @@
+"""0.3 task: Job model redesign — current_stage, stage_progress, drop estimated_at
+
+Revision ID: e2f3a4b5c6d7
+Revises: d1e2f3a4b5c6
+Create Date: 2026-04-27 18:00:00.000000
+
+Phase-0 task 0.3 (vision §3 KD13). This migration covers the
+column-level shape changes on ``jobs``:
+
+* ``+current_stage VARCHAR(50) NULL`` — internal pipeline stage
+  marker (``pass_1``/``pass_2a``/... per ``job_type``). Free-form;
+  validation lives at the worker level per pipeline.
+* ``+stage_progress JSONB NULL`` — per-job-type checkpoint state
+  for reactivate-resume (KD4a in-flight resume + KD13). Schema is
+  per-pipeline and intentionally not enforced at the DB level.
+* ``-estimated_at`` — never set or read by any business logic;
+  pure dead column carried from the initial schema.
+
+Commit (b) of task 0.3 will extend the same revision (in a
+follow-up edit on this file) with the
+``materialnode_id → course_node_id`` column/constraint/index
+rename. Splitting them across two commits keeps the git history
+readable; the migration stays a single atomic step on the
+``jobs`` table.
+
+NOT in 0.3 (deferred, see POST-MR-NOTES):
+
+* Drop ``depends_on`` — coupled to Phase 2.x rewrite of
+  ``methodist_orchestrator`` and ``generation_orchestrator``
+  from Job-graph to single-Job-with-stages pattern. Column
+  carries an updated DEPRECATED comment in the ORM; column
+  itself stays.
+* DB CHECK constraint on ``job_type`` — current call-sites emit
+  legacy values (``ingest``/``generate_structure``/...) outside
+  KD13's 4-value enum. Application-level validation via
+  ``JobType`` enum lands later in 0.3 (commit c); the DB CHECK
+  follows in Phase 2.x along with call-site migration.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "e2f3a4b5c6d7"
+down_revision: str | Sequence[str] | None = "d1e2f3a4b5c6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add current_stage + stage_progress; drop estimated_at."""
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "current_stage",
+            sa.String(length=50),
+            nullable=True,
+            comment=(
+                "Internal pipeline stage marker per vision §3 KD13. "
+                "Free-form per job_type (e.g. pass_1/pass_2a/pass_2b/pass_2c "
+                "for document_processing; bottomup/topdown for "
+                "node_summary_regeneration; safety/sanity/review/delivery for "
+                "homework_processing; unused for s3_cleanup). Validation lives "
+                "at the worker level per pipeline."
+            ),
+        ),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "stage_progress",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+            comment=(
+                "Per-job-type checkpoint state for resume after retry "
+                "(KD4a in-flight resume + KD13 reactivate). Schema is "
+                "per-pipeline and intentionally not enforced at the DB level."
+            ),
+        ),
+    )
+    op.drop_column("jobs", "estimated_at")
+
+
+def downgrade() -> None:
+    """Restore estimated_at; drop current_stage + stage_progress."""
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "estimated_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.drop_column("jobs", "stage_progress")
+    op.drop_column("jobs", "current_stage")

--- a/migrations/versions/e2f3a4b5c6d7_0_3_job_redesign.py
+++ b/migrations/versions/e2f3a4b5c6d7_0_3_job_redesign.py
@@ -1,11 +1,11 @@
-"""0.3 task: Job model redesign — current_stage, stage_progress, drop estimated_at
+"""0.3 task: Job model redesign — current_stage, stage_progress, drop estimated_at, rename FK
 
 Revision ID: e2f3a4b5c6d7
 Revises: d1e2f3a4b5c6
 Create Date: 2026-04-27 18:00:00.000000
 
-Phase-0 task 0.3 (vision §3 KD13). This migration covers the
-column-level shape changes on ``jobs``:
+Phase-0 task 0.3 (vision §3 KD13). This migration covers all
+schema-level changes on ``jobs`` for the redesign:
 
 * ``+current_stage VARCHAR(50) NULL`` — internal pipeline stage
   marker (``pass_1``/``pass_2a``/... per ``job_type``). Free-form;
@@ -15,13 +15,20 @@ column-level shape changes on ``jobs``:
   per-pipeline and intentionally not enforced at the DB level.
 * ``-estimated_at`` — never set or read by any business logic;
   pure dead column carried from the initial schema.
+* ``materialnode_id → course_node_id`` rename — column, FK
+  constraint (``jobs_materialnode_id_fkey`` →
+  ``jobs_course_node_id_fkey``), and index
+  (``ix_jobs_materialnode_id`` → ``ix_jobs_course_node_id``).
+  PostgreSQL handles the column rename atomically with zero data
+  movement; the constraint and index renames are independent
+  catalog updates. Names verified against the prod DB before
+  scripting.
 
-Commit (b) of task 0.3 will extend the same revision (in a
-follow-up edit on this file) with the
-``materialnode_id → course_node_id`` column/constraint/index
-rename. Splitting them across two commits keeps the git history
-readable; the migration stays a single atomic step on the
-``jobs`` table.
+Commits (a) and (b) of task 0.3 stay separate in the git history,
+but share this single migration file — the column-level changes
+land first, then the rename block is appended. Repository state
+between the two commits is partial-but-valid; the migration is
+always a single atomic step on the ``jobs`` table when applied.
 
 NOT in 0.3 (deferred, see POST-MR-NOTES):
 
@@ -51,7 +58,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    """Add current_stage + stage_progress; drop estimated_at."""
+    """Add current_stage + stage_progress; drop estimated_at; rename FK column."""
     op.add_column(
         "jobs",
         sa.Column(
@@ -83,9 +90,27 @@ def upgrade() -> None:
     )
     op.drop_column("jobs", "estimated_at")
 
+    # Rename Job.materialnode_id → Job.course_node_id (KD13).
+    # Column rename is atomic; FK constraint and index names need
+    # separate ALTER calls (Postgres does not auto-rename them when
+    # the underlying column changes).
+    op.execute("ALTER TABLE jobs RENAME COLUMN materialnode_id TO course_node_id")
+    op.execute(
+        "ALTER TABLE jobs RENAME CONSTRAINT jobs_materialnode_id_fkey "
+        "TO jobs_course_node_id_fkey"
+    )
+    op.execute("ALTER INDEX ix_jobs_materialnode_id RENAME TO ix_jobs_course_node_id")
+
 
 def downgrade() -> None:
-    """Restore estimated_at; drop current_stage + stage_progress."""
+    """Reverse FK rename; restore estimated_at; drop new columns."""
+    op.execute("ALTER INDEX ix_jobs_course_node_id RENAME TO ix_jobs_materialnode_id")
+    op.execute(
+        "ALTER TABLE jobs RENAME CONSTRAINT jobs_course_node_id_fkey "
+        "TO jobs_materialnode_id_fkey"
+    )
+    op.execute("ALTER TABLE jobs RENAME COLUMN course_node_id TO materialnode_id")
+
     op.add_column(
         "jobs",
         sa.Column(

--- a/src/course_supporter/api/routes/jobs.py
+++ b/src/course_supporter/api/routes/jobs.py
@@ -28,11 +28,18 @@ PrepDep = Annotated[TenantContext, Depends(require_scope(AuthScope.PREP))]
 
 
 class _ReenqueueDispatch(NamedTuple):
-    """ARQ task call shape resolved from a failed Job's state."""
+    """ARQ task call shape resolved from a failed Job's state.
+
+    ``args`` are positional task args passed to the ARQ function;
+    ``task_kwargs`` are keyword args (used by tasks with kw-only
+    parameters like :func:`s3_cleanup_task`); ``queue_name`` selects
+    a non-default ARQ queue (e.g. ``"homework"``).
+    """
 
     arq_function: str
     args: list[Any]
     queue_name: str | None = None
+    task_kwargs: dict[str, Any] | None = None
 
 
 def _resolve_reenqueue(job: Job) -> _ReenqueueDispatch:
@@ -110,6 +117,17 @@ def _resolve_reenqueue(job: Job) -> _ReenqueueDispatch:
                         p["phase"],
                     ],
                 )
+            case "s3_cleanup":
+                # KD13 s3_cleanup_task uses kw-only args; carried via
+                # task_kwargs rather than positional ``args``.
+                return _ReenqueueDispatch(
+                    arq_function="s3_cleanup_task",
+                    args=[],
+                    task_kwargs={
+                        "file_keys": p["file_keys"],
+                        "job_id": jid,
+                    },
+                )
             case _:
                 raise HTTPException(
                     status_code=422,
@@ -118,7 +136,7 @@ def _resolve_reenqueue(job: Job) -> _ReenqueueDispatch:
                         f"{job.job_type!r}. Supported types: ingest, "
                         f"generate_structure, reconcile_preview, generate, "
                         f"reconcile, refine, homework, methodist_bottom_up, "
-                        f"methodist_top_down."
+                        f"methodist_top_down, s3_cleanup."
                     ),
                 )
     except KeyError as exc:
@@ -201,9 +219,13 @@ async def reactivate_job(
     enqueue_kwargs: dict[str, Any] = {}
     if dispatch.queue_name is not None:
         enqueue_kwargs["_queue_name"] = dispatch.queue_name
+    task_kwargs = dispatch.task_kwargs or {}
 
     arq_job = await arq.enqueue_job(
-        dispatch.arq_function, *dispatch.args, **enqueue_kwargs
+        dispatch.arq_function,
+        *dispatch.args,
+        **task_kwargs,
+        **enqueue_kwargs,
     )
     if arq_job is not None:
         await repo.set_arq_job_id(job.id, arq_job.job_id)

--- a/src/course_supporter/api/routes/jobs.py
+++ b/src/course_supporter/api/routes/jobs.py
@@ -31,7 +31,7 @@ async def get_job(
 ) -> JobResponse:
     """Get job status by ID.
 
-    Tenant isolation enforced via job.materialnode_id → node.tenant_id,
+    Tenant isolation enforced via job.course_node_id → node.tenant_id,
     with fallback to job.tenant_id. Returns 404 if the job does
     not exist or does not belong to the current tenant.
     """

--- a/src/course_supporter/api/routes/jobs.py
+++ b/src/course_supporter/api/routes/jobs.py
@@ -1,26 +1,134 @@
-"""Job status API endpoints."""
+"""Job status + reactivate API endpoints."""
 
 from __future__ import annotations
 
 import uuid
-from typing import Annotated
+from typing import Annotated, Any, NamedTuple
 
+from arq.connections import ArqRedis
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from course_supporter.api.deps import get_session
+from course_supporter.api.deps import get_arq_redis, get_session
 from course_supporter.api.schemas import JobResponse
 from course_supporter.auth.context import TenantContext
 from course_supporter.auth.registry import AuthScope
 from course_supporter.auth.scopes import require_scope
 from course_supporter.storage.job_repository import JobRepository
+from course_supporter.storage.orm import Job
 
 router = APIRouter(tags=["jobs"])
 
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
+ArqDep = Annotated[ArqRedis, Depends(get_arq_redis)]
 SharedDep = Annotated[
     TenantContext, Depends(require_scope(AuthScope.PREP, AuthScope.CHECK))
 ]
+PrepDep = Annotated[TenantContext, Depends(require_scope(AuthScope.PREP))]
+
+
+class _ReenqueueDispatch(NamedTuple):
+    """ARQ task call shape resolved from a failed Job's state."""
+
+    arq_function: str
+    args: list[Any]
+    queue_name: str | None = None
+
+
+def _resolve_reenqueue(job: Job) -> _ReenqueueDispatch:
+    """Map ``(job.job_type, job.input_params)`` → ARQ task call shape.
+
+    Transitional dispatch over the legacy ``job_type`` strings
+    currently emitted by ``enqueue.py`` and ``methodist_orchestrator``.
+    Phase 2.x rewrite of orchestrators to KD13's 4-value :class:`JobType`
+    enum will collapse this to a 4-case match (and will likely add a
+    ``s3_cleanup`` arm — currently the ``s3_cleanup_task`` worker
+    lands in commit (g) of task 0.3 and a future commit will register
+    the ``s3_cleanup`` enum value here).
+
+    Raises :class:`HTTPException` (422) when:
+
+    * ``job.job_type`` is not in the supported set.
+    * ``job.input_params`` is missing a required field for the
+      target ARQ task.
+    """
+    p = job.input_params or {}
+    jid = str(job.id)
+
+    try:
+        match job.job_type:
+            case "ingest":
+                return _ReenqueueDispatch(
+                    arq_function="arq_ingest_material",
+                    args=[
+                        jid,
+                        p["material_id"],
+                        p["source_type"],
+                        p["source_url"],
+                        job.priority,
+                    ],
+                )
+            case "generate_structure":
+                return _ReenqueueDispatch(
+                    arq_function="arq_generate_structure",
+                    args=[
+                        jid,
+                        p["root_node_id"],
+                        p.get("target_node_id"),
+                        p["mode"],
+                    ],
+                )
+            case "generate" | "reconcile" | "refine":
+                return _ReenqueueDispatch(
+                    arq_function="arq_execute_step",
+                    args=[
+                        jid,
+                        p["root_node_id"],
+                        p["target_node_id"],
+                        p["mode"],
+                        p["step_type"],
+                    ],
+                )
+            case "reconcile_preview":
+                return _ReenqueueDispatch(
+                    arq_function="arq_reconcile_preview",
+                    args=[jid, p["node_id"]],
+                )
+            case "homework":
+                return _ReenqueueDispatch(
+                    arq_function="arq_process_homework",
+                    args=[jid, p["submission_id"]],
+                    queue_name="homework",
+                )
+            case "methodist_bottom_up" | "methodist_top_down":
+                return _ReenqueueDispatch(
+                    arq_function="arq_execute_methodist_step",
+                    args=[
+                        jid,
+                        p["materialnode_id"],
+                        p["editable_id"],
+                        p["phase"],
+                    ],
+                )
+            case _:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Reactivate not supported for job_type="
+                        f"{job.job_type!r}. Supported types: ingest, "
+                        f"generate_structure, reconcile_preview, generate, "
+                        f"reconcile, refine, homework, methodist_bottom_up, "
+                        f"methodist_top_down."
+                    ),
+                )
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Job {job.id} input_params missing required field for "
+                f"re-enqueue: {exc.args[0]!r}."
+            ),
+        ) from exc
 
 
 @router.get("/jobs/{job_id}")
@@ -39,4 +147,67 @@ async def get_job(
     job = await repo.get_by_id_for_tenant(job_id, tenant.tenant_id)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
+    return JobResponse.model_validate(job)
+
+
+@router.post("/jobs/{job_id}/reactivate")
+async def reactivate_job(
+    job_id: uuid.UUID,
+    tenant: PrepDep,
+    session: SessionDep,
+    arq: ArqDep,
+) -> JobResponse:
+    """Reactivate a failed Job for retry (vision §3 KD13).
+
+    DB transition: ``status: 'failed' → 'queued'``, clears
+    ``error_message`` and run-attempt timestamps, preserves
+    ``stage_progress`` (worker resumes from KD4a checkpoint) and
+    ``queued_at`` (first-queued metadata). Then enqueues a new ARQ
+    task via the legacy-aware dispatcher and stores the new
+    ``arq_job_id`` on the Job. All in one outer transaction; failure
+    rolls back, leaving the Job in its original ``failed`` state.
+
+    **Per-entity state caveat.** Reactivate transitions only the
+    ``Job`` row — entity-level state (e.g. ``MaterialEntry`` ingestion
+    state, ``HomeworkSubmission`` review state) is NOT touched. Workers
+    must defensively reset entity-level state on task entry (e.g.
+    ``MaterialEntryRepository.set_pending`` is called by
+    ``arq_ingest_material`` itself for exactly this reason). If a
+    worker lacks this guard, entity state may diverge from Job state;
+    use the per-entity retry endpoint (e.g. ``materials.py /retry``)
+    when that semantics matters more than the ``stage_progress``
+    resume that ``reactivate`` provides.
+
+    Returns 200 with the updated Job representation. Errors:
+
+    * **404** — Job not found or not visible to current tenant.
+    * **409** — Job is in a state other than ``'failed'`` (or is
+      soft-deleted).
+    * **422** — ``job_type`` not supported by the dispatcher, or
+      ``input_params`` missing required fields for re-enqueue.
+    """
+    repo = JobRepository(session)
+    job = await repo.get_by_id_for_tenant(job_id, tenant.tenant_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    try:
+        await repo.reactivate(job.id)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    dispatch = _resolve_reenqueue(job)
+
+    enqueue_kwargs: dict[str, Any] = {}
+    if dispatch.queue_name is not None:
+        enqueue_kwargs["_queue_name"] = dispatch.queue_name
+
+    arq_job = await arq.enqueue_job(
+        dispatch.arq_function, *dispatch.args, **enqueue_kwargs
+    )
+    if arq_job is not None:
+        await repo.set_arq_job_id(job.id, arq_job.job_id)
+
+    await session.commit()
+
     return JobResponse.model_validate(job)

--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -496,7 +496,7 @@ class JobResponse(BaseModel):
     priority: str
     status: str
     tenant_id: uuid.UUID | None
-    materialnode_id: uuid.UUID | None
+    course_node_id: uuid.UUID | None
     arq_job_id: str | None
     current_stage: str | None = None
     stage_progress: dict[str, Any] | None = None

--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -498,12 +498,13 @@ class JobResponse(BaseModel):
     tenant_id: uuid.UUID | None
     materialnode_id: uuid.UUID | None
     arq_job_id: str | None
+    current_stage: str | None = None
+    stage_progress: dict[str, Any] | None = None
     result_data: dict[str, Any] | None = None
     error_message: str | None
     queued_at: datetime
     started_at: datetime | None
     completed_at: datetime | None
-    estimated_at: datetime | None
 
 
 # --- Structure Generation ---

--- a/src/course_supporter/conflict_detection.py
+++ b/src/course_supporter/conflict_detection.py
@@ -58,7 +58,7 @@ async def detect_conflict(
     target_ancestors = _ancestor_set(parent_map, target_node_id)
 
     for job in active_jobs:
-        job_node_id = job.materialnode_id
+        job_node_id = job.course_node_id
         if _scopes_overlap_fast(target_node_id, job_node_id):
             return ConflictInfo(
                 job_id=job.id,

--- a/src/course_supporter/enqueue.py
+++ b/src/course_supporter/enqueue.py
@@ -60,7 +60,7 @@ async def enqueue_ingestion(
 
     job = await job_repo.create(
         tenant_id=tenant_id,
-        materialnode_id=node_id,
+        course_node_id=node_id,
         job_type="ingest",
         priority=priority.value,
         input_params={
@@ -121,7 +121,7 @@ async def enqueue_generation(
     Returns:
         The created Job with ``arq_job_id`` set.
     """
-    # Job.materialnode_id stores the actual target (root if whole tree)
+    # Job.course_node_id stores the actual target (root if whole tree)
     effective_node_id = target_node_id or root_node_id
 
     log = structlog.get_logger().bind(
@@ -132,7 +132,7 @@ async def enqueue_generation(
 
     job = await repo.create(
         tenant_id=tenant_id,
-        materialnode_id=effective_node_id,
+        course_node_id=effective_node_id,
         job_type="generate_structure",
         depends_on=depends_on,
         input_params={
@@ -202,7 +202,7 @@ async def enqueue_reconcile_preview(
 
     job = await repo.create(
         tenant_id=tenant_id,
-        materialnode_id=node_id,
+        course_node_id=node_id,
         job_type="reconcile_preview",
         input_params=input_params,
     )
@@ -268,7 +268,7 @@ async def enqueue_step(
 
     job = await repo.create(
         tenant_id=tenant_id,
-        materialnode_id=target_node_id,
+        course_node_id=target_node_id,
         job_type=step_type,
         depends_on=validated_deps,
         input_params={

--- a/src/course_supporter/jobs/__init__.py
+++ b/src/course_supporter/jobs/__init__.py
@@ -1,0 +1,11 @@
+"""Job-domain primitives (vision §3 KD13).
+
+Re-exports the canonical :class:`JobType` enum and the
+:func:`validate_job_type` helper so callers can write::
+
+    from course_supporter.jobs import JobType, validate_job_type
+"""
+
+from course_supporter.jobs.job_type import JobType, validate_job_type
+
+__all__ = ["JobType", "validate_job_type"]

--- a/src/course_supporter/jobs/__init__.py
+++ b/src/course_supporter/jobs/__init__.py
@@ -1,11 +1,27 @@
 """Job-domain primitives (vision §3 KD13).
 
-Re-exports the canonical :class:`JobType` enum and the
-:func:`validate_job_type` helper so callers can write::
+Re-exports the canonical :class:`JobType` enum, the
+:func:`validate_job_type` helper, and the cooperative-cancel
+primitives :class:`JobCancellationChecker` /
+:class:`JobCancelledError` so callers can write::
 
-    from course_supporter.jobs import JobType, validate_job_type
+    from course_supporter.jobs import (
+        JobCancellationChecker,
+        JobCancelledError,
+        JobType,
+        validate_job_type,
+    )
 """
 
+from course_supporter.jobs.cancellation import (
+    JobCancellationChecker,
+    JobCancelledError,
+)
 from course_supporter.jobs.job_type import JobType, validate_job_type
 
-__all__ = ["JobType", "validate_job_type"]
+__all__ = [
+    "JobCancellationChecker",
+    "JobCancelledError",
+    "JobType",
+    "validate_job_type",
+]

--- a/src/course_supporter/jobs/__init__.py
+++ b/src/course_supporter/jobs/__init__.py
@@ -1,13 +1,15 @@
 """Job-domain primitives (vision §3 KD13).
 
 Re-exports the canonical :class:`JobType` enum, the
-:func:`validate_job_type` helper, and the cooperative-cancel
-primitives :class:`JobCancellationChecker` /
-:class:`JobCancelledError` so callers can write::
+:func:`validate_job_type` helper, the cooperative-cancel primitives
+:class:`JobCancellationChecker` / :class:`JobCancelledError`, and
+the cascade-bound :class:`JobCancellationService` (concrete
+``OnCancelJobs`` implementation) so callers can write::
 
     from course_supporter.jobs import (
         JobCancellationChecker,
         JobCancelledError,
+        JobCancellationService,
         JobType,
         validate_job_type,
     )
@@ -17,10 +19,12 @@ from course_supporter.jobs.cancellation import (
     JobCancellationChecker,
     JobCancelledError,
 )
+from course_supporter.jobs.cancellation_service import JobCancellationService
 from course_supporter.jobs.job_type import JobType, validate_job_type
 
 __all__ = [
     "JobCancellationChecker",
+    "JobCancellationService",
     "JobCancelledError",
     "JobType",
     "validate_job_type",

--- a/src/course_supporter/jobs/cancellation.py
+++ b/src/course_supporter/jobs/cancellation.py
@@ -1,0 +1,144 @@
+"""Cooperative Job cancellation polling for ARQ workers (vision §3 KD13).
+
+KD13 cancel-flow:
+
+1. Cascade transaction sets ``Job.status``: ``queued/running →
+   cancelled`` in the same DB transaction as ``deleted_at`` (the
+   actual flip lives in :class:`JobCancellationService`, commit (e)
+   of task 0.3).
+2. Pipeline workers poll ``status`` at every ``current_stage``
+   boundary via :meth:`JobCancellationChecker.raise_if_cancelled`;
+   on observation, they release in-flight resources, write a
+   checkpoint to ``Job.stage_progress`` (per KD4a), and exit
+   gracefully — no new ``deleted_at IS NOT NULL`` UPDATEs (which
+   the soft-delete trigger from task 0.1 would block anyway).
+
+This is **cooperative**, not native ARQ cancel. ARQ's hard-kill
+abort_job aborts the coroutine mid-await, skipping any cleanup the
+stage was about to do (release LLM client connections, finalize
+ESC rows, persist a partial checkpoint). Cooperative polling
+trades a small latency tax (one ``SELECT status`` per stage
+boundary, ≪ pipeline cost) for a clean exit window.
+
+**Worker integration is documented but NOT wired in this commit.**
+Phase 2.x rewrites the pipeline workers (``arq_ingest_material``,
+``arq_execute_methodist_step``, etc.) to call
+``await checker.raise_if_cancelled(job_id)`` between stages and
+to wrap the call in a specific ``except JobCancelledError`` that
+runs cleanup + returns gracefully (without flipping the Job to
+``failed``). The contract is fixed here so the rewrite has a
+stable API to integrate against.
+
+**Catch-order contract for workers:**
+
+```python
+try:
+    await pipeline_stage(...)
+    await checker.raise_if_cancelled(job_id)
+except JobCancelledError:
+    await release_resources()
+    await persist_checkpoint(stage_progress)
+    return  # do NOT flip status to failed
+except Exception:
+    await mark_job_failed(...)
+    raise
+```
+
+The :class:`JobCancelledError` clause MUST appear before the generic
+``except Exception`` block. Reversing the order would mark a
+deliberately-cancelled Job as ``failed`` — incorrect bookkeeping
+and noise for cost reports.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.storage.orm import Job
+
+
+class JobCancelledError(Exception):
+    """Raised by :class:`JobCancellationChecker` when a Job is cancelled.
+
+    Subclasses :class:`Exception` (not :class:`BaseException`).
+    Cooperative cancellation is anticipated control flow, not a runtime
+    bug, so a regular exception is the honest signal type. The trade-off
+    is that a generic ``except Exception:`` will catch it — workers MUST
+    have a dedicated ``except JobCancelledError:`` clause earlier in the
+    handler chain (see module docstring "Catch-order contract").
+
+    Carries ``job_id`` and a short ``reason`` string distinguishing the
+    two cancel-equivalent paths:
+
+    * ``"status=cancelled"`` — cascade transaction observed; KD13's
+      Path-1/Path-2 cancellation has fired.
+    * ``"row not found"`` — Job row absent from the table. Treated as
+      cancelled per the same "release resources + exit" semantics; see
+      :class:`JobCancellationChecker` for the design rationale.
+
+    The ``reason`` is an operator-facing diagnostic (logs, error
+    messages); workers should not branch on its value.
+    """
+
+    def __init__(self, job_id: uuid.UUID, reason: str) -> None:
+        self.job_id = job_id
+        self.reason = reason
+        super().__init__(f"Job {job_id} cancelled ({reason})")
+
+
+class JobCancellationChecker:
+    """Poll ``Job.status`` for cooperative cancellation.
+
+    Caller controls the session lifecycle — the recommended pattern
+    is a short-lived read-only session per check, separate from the
+    main pipeline transaction, so the polling SELECT does not
+    interfere with the worker's own write transaction.
+
+    Soft-deleted Jobs stay queryable: the soft-delete trigger from
+    task 0.1 blocks UPDATEs, not SELECTs, so a Job with both
+    ``status='cancelled'`` and ``deleted_at IS NOT NULL`` (the
+    end-state of a cascade) is still observable. ``is_cancelled`` /
+    ``raise_if_cancelled`` therefore intentionally do **not** filter
+    on ``deleted_at``: filtering would hide legitimately cancelled
+    rows in their soft-deleted final state.
+
+    **Missing Job is treated as cancelled.** When the SELECT returns
+    no row, both methods report cancellation. Operationally this is
+    the right answer — the worker has nothing left to write back
+    and should release resources and exit, exactly the cancellation
+    behavior. Forcing callers to handle a separate "row not found"
+    error would multiply the same handler logic. Transient DB
+    failures (connection drops, server restarts) raise distinct
+    psycopg / SQLAlchemy exceptions and are not collapsed into
+    cancellation.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def is_cancelled(self, job_id: uuid.UUID) -> bool:
+        """Return ``True`` if the Job is cancelled or its row is missing."""
+        status = await self._fetch_status(job_id)
+        return status is None or status == "cancelled"
+
+    async def raise_if_cancelled(self, job_id: uuid.UUID) -> None:
+        """Raise :class:`JobCancelledError` if cancelled or missing.
+
+        Intended as the boundary-call inside pipeline workers
+        (Phase 2.x integration). See module docstring for the
+        catch-order contract.
+        """
+        status = await self._fetch_status(job_id)
+        if status is None:
+            raise JobCancelledError(job_id, "row not found")
+        if status == "cancelled":
+            raise JobCancelledError(job_id, "status=cancelled")
+
+    async def _fetch_status(self, job_id: uuid.UUID) -> str | None:
+        """Return ``Job.status`` for ``job_id``, or ``None`` if no row."""
+        stmt = select(Job.status).where(Job.id == job_id)
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()

--- a/src/course_supporter/jobs/cancellation_service.py
+++ b/src/course_supporter/jobs/cancellation_service.py
@@ -1,0 +1,147 @@
+"""Concrete on_cancel_jobs implementation for CascadeDeleteService.
+
+Vision §3 KD13 + KD12. When a soft-delete cascade fires the
+``on_cancel_jobs`` hook with the collected victim ids, this service
+finds active Jobs that reference any of those entities — by
+``tenant_id``, ``course_node_id``, or ``input_params`` JSONB
+containment — and flips them to ``status='cancelled'`` in the same
+DB transaction. Workers then observe the new status at their next
+``current_stage`` boundary via :class:`JobCancellationChecker`
+(commit (d)) and exit gracefully.
+
+Phase 1+ entity tasks bind this as the :data:`OnCancelJobs`
+callable on their cascade declarations::
+
+    jcs = JobCancellationService(session)
+    await cascade_service.soft_delete_with_cascade(
+        entity,
+        cascade_map,
+        on_cancel_jobs=jcs.cancel_jobs_for_entities,
+    )
+
+0.3 ships the implementation only — no ``__cascades_soft_delete_to__``
+list is populated here, no entity-specific binding lands.
+
+**Performance note for POST-MR-NOTES.** The JSONB containment branch
+generates one ``Job.input_params @> '{"course_node_id": ...}'`` clause
+per victim id. PostgreSQL's ``@>`` operator does not natively check
+"any of these values for the same key", so OR-of-N is the correct
+shape. A GIN index on ``Job.input_params`` (``CREATE INDEX
+ix_jobs_input_params_gin ON jobs USING GIN (input_params jsonb_path_ops)``)
+would convert each ``@>`` from a sequential scan to an index-only
+lookup, but adding it now is premature: the migration is one round
+trip per cascade in dev/test, and real cascade widths are not yet
+known. Phase 2.x will add the GIN index once telemetry from
+production cascades shows the JSONB branch as a real bottleneck —
+ideally bundled with the call-site rewrite that drops the legacy
+``input_params["course_node_id"]`` indirection in favour of the
+direct FK.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.storage.orm import Job
+
+logger = structlog.get_logger(__name__)
+
+# Status values considered "in progress" — eligible for cancel sweep.
+# Includes both KD13's canonical "running" and the legacy "active"
+# string from the as-yet-unmigrated JOB_TRANSITIONS table (see task
+# 0.3 pre-flight: status name alignment is a separate Phase 2.x
+# chore). The third value will drop out of this tuple when that
+# rename lands and orchestrator call-sites switch to "running".
+_IN_PROGRESS_STATUSES: tuple[str, ...] = ("queued", "running", "active")
+
+
+class JobCancellationService:
+    """Concrete :data:`OnCancelJobs` implementation.
+
+    Single-shot, single-transaction: the caller (typically
+    :meth:`CascadeDeleteService.soft_delete_with_cascade` via the
+    bound hook) controls the surrounding transaction. ``flush()``
+    only happens inside; failure propagates and rolls back as part
+    of the outer transaction. Mirrors the
+    :data:`OnInvalidateHashes` shape shipped in 0.2.
+
+    Idempotent on re-run: the status filter
+    (``IN ('queued', 'running', 'active')``) excludes already-
+    cancelled / completed Jobs, so a second invocation with the
+    same ``entity_ids`` is a no-op other than the log line. The
+    ``deleted_at IS NULL`` filter further guards against the soft-
+    delete trigger from task 0.1 — without it, a Job that was
+    already cancelled-and-soft-deleted in a prior cascade would
+    raise on UPDATE (the trigger blocks any column change other
+    than ``deleted_at`` itself on soft-deleted rows).
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def cancel_jobs_for_entities(
+        self,
+        entity_ids: list[uuid.UUID],
+        *,
+        now: datetime | None = None,
+    ) -> None:
+        """Cancel all in-progress Jobs that reference any ``entity_id``.
+
+        Lookup is OR-of-paths because Jobs reference entities through
+        three different columns depending on ``job_type``:
+
+        * ``Job.tenant_id`` — tenant-wide cascades.
+        * ``Job.course_node_id`` — node-scoped jobs (KD13 canonical FK).
+        * ``Job.input_params @> {"course_node_id": ...}`` — legacy /
+          edge cases where the FK is NULL but the JSONB carries the id
+          (some pre-rewrite orchestrators emit this shape).
+
+        ``now`` overrides the ``completed_at`` timestamp for
+        deterministic tests; defaults to ``datetime.now(UTC)``.
+        Defaulted to ``None`` so the bound method matches the
+        ``OnCancelJobs`` callable shape (``Callable[[list[UUID]],
+        Awaitable[None]]``) — the cascade engine invokes it with
+        only the positional ``entity_ids`` argument.
+        """
+        if not entity_ids:
+            return
+
+        ts = now if now is not None else datetime.now(UTC)
+
+        jsonb_clauses = [
+            Job.input_params.op("@>")({"course_node_id": str(eid)})
+            for eid in entity_ids
+        ]
+
+        stmt = (
+            select(Job)
+            .where(Job.status.in_(_IN_PROGRESS_STATUSES))
+            .where(Job.deleted_at.is_(None))
+            .where(
+                or_(
+                    Job.tenant_id.in_(entity_ids),
+                    Job.course_node_id.in_(entity_ids),
+                    *jsonb_clauses,
+                )
+            )
+        )
+        result = await self._session.execute(stmt)
+        jobs = list(result.scalars().all())
+
+        for job in jobs:
+            job.status = "cancelled"
+            job.completed_at = ts
+
+        if jobs:
+            await self._session.flush()
+
+        logger.info(
+            "job_cancellation_service.cancelled",
+            entity_count=len(entity_ids),
+            cancelled_count=len(jobs),
+        )

--- a/src/course_supporter/jobs/job_type.py
+++ b/src/course_supporter/jobs/job_type.py
@@ -1,0 +1,92 @@
+"""Canonical Job type enum + transitional application-level validation.
+
+Vision §3 KD13 fixes the universe of ``Job.job_type`` values to
+exactly four:
+
+* ``document_processing`` — pipeline of one ``AuthoredDocument``
+  (stages: pass_1 → pass_2a → pass_2b → pass_2c).
+* ``node_summary_regeneration`` — bottom-up + top-down generation
+  over a ``CourseNode`` subtree.
+* ``homework_processing`` — student submission review (safety →
+  sanity → review → delivery).
+* ``s3_cleanup`` — async hard-delete of S3 files after soft-delete.
+
+The DB-level CHECK constraint that would enforce this is
+**deferred to Phase 2.x** (see task 0.3 pre-flight): current
+call-sites in ``enqueue.py``, ``methodist_orchestrator.py``,
+``generation_orchestrator.py`` emit legacy strings (``ingest``,
+``generate_structure``, ``methodist_bottomup``, etc.) outside the
+KD13 enum, and a strict CHECK would break dev/test/CI immediately.
+
+This module ships the **transitional** layer: a clean StrEnum that
+matches KD13 exactly + an opt-in validator that lets callers signal
+KD13-awareness via the enum type while accepting legacy strings
+with a one-shot ``DeprecationWarning``. Phase 2.x will rewrite the
+call-sites onto :class:`JobType` and drop the ``str`` arm of the
+union (and at that point the DB CHECK becomes safe to add).
+"""
+
+from __future__ import annotations
+
+import warnings
+from enum import StrEnum
+
+
+class JobType(StrEnum):
+    """Canonical Job types per vision §3 KD13.
+
+    Use this enum from new call-sites. The string values are stable
+    and equal to the enum members (``StrEnum``), so JSONB / DB
+    storage is unaffected by the type system change.
+    """
+
+    DOCUMENT_PROCESSING = "document_processing"
+    NODE_SUMMARY_REGENERATION = "node_summary_regeneration"
+    HOMEWORK_PROCESSING = "homework_processing"
+    S3_CLEANUP = "s3_cleanup"
+
+
+_CANONICAL_VALUES: frozenset[str] = frozenset(jt.value for jt in JobType)
+_LEGACY_JOB_TYPES_WARNED: set[str] = set()
+
+
+def validate_job_type(value: JobType | str) -> str:
+    """Normalize a ``job_type`` argument to its underlying string.
+
+    The accepted shapes:
+
+    * :class:`JobType` enum member — silent accept (KD13-canonical).
+    * ``str`` equal to one of :class:`JobType`'s values — silent
+      accept (caller used the canonical name as a string; equivalent
+      to passing the enum).
+    * Any other ``str`` — accepted with a single
+      :class:`DeprecationWarning` per distinct value per process.
+      This covers legacy ``Job.job_type`` strings (``ingest``,
+      ``generate_structure``, ``methodist_bottomup``, etc.) until
+      Phase 2.x rewrites them.
+
+    The warning is intentionally one-shot per value (module-level
+    ``set`` dedup) to keep test runs and worker logs free of noise
+    while still surfacing each distinct legacy string once. Python's
+    own ``warnings`` filter would dedup per call-site, but the same
+    legacy string is emitted from many call-sites — value-level
+    dedup matches the actual cleanup target (one Phase 2.x rewrite
+    per distinct legacy value).
+
+    Returns the underlying ``str`` for storage. Never raises — strict
+    rejection is deferred to the Phase 2.x DB CHECK constraint.
+    """
+    if isinstance(value, JobType):
+        return value.value
+    if value in _CANONICAL_VALUES:
+        return value
+    if value not in _LEGACY_JOB_TYPES_WARNED:
+        _LEGACY_JOB_TYPES_WARNED.add(value)
+        warnings.warn(
+            f"Legacy Job.job_type {value!r} accepted; rewrite to "
+            f"course_supporter.jobs.JobType in Phase 2.x. Canonical "
+            f"values: {sorted(_CANONICAL_VALUES)}.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+    return value

--- a/src/course_supporter/methodist_orchestrator.py
+++ b/src/course_supporter/methodist_orchestrator.py
@@ -240,7 +240,7 @@ async def _enqueue_methodist_step(
 
     job = await repo.create(
         tenant_id=tenant_id,
-        materialnode_id=materialnode_id,
+        course_node_id=materialnode_id,
         job_type=f"methodist_{phase}",
         depends_on=validated_deps,
         input_params={

--- a/src/course_supporter/storage/job_repository.py
+++ b/src/course_supporter/storage/job_repository.py
@@ -37,7 +37,7 @@ class JobRepository:
         self,
         *,
         tenant_id: uuid.UUID | None = None,
-        materialnode_id: uuid.UUID | None = None,
+        course_node_id: uuid.UUID | None = None,
         job_type: str,
         priority: str = "normal",
         arq_job_id: str | None = None,
@@ -47,7 +47,7 @@ class JobRepository:
         """Create a new job record."""
         job = Job(
             tenant_id=tenant_id,
-            materialnode_id=materialnode_id,
+            course_node_id=course_node_id,
             job_type=job_type,
             priority=priority,
             arq_job_id=arq_job_id,
@@ -132,13 +132,14 @@ class JobRepository:
     ) -> Job | None:
         """Get a job by ID, ensuring it belongs to the given tenant.
 
-        Joins through ``job.materialnode_id → material_node.tenant_id`` for isolation.
-        Falls back to ``job.tenant_id`` for jobs without a linked node.
+        Joins through ``job.course_node_id → material_node.tenant_id`` for
+        isolation. Falls back to ``job.tenant_id`` for jobs without a
+        linked node.
         """
         # Try node-based isolation first
         stmt = (
             select(Job)
-            .join(MaterialNode, Job.materialnode_id == MaterialNode.id)
+            .join(MaterialNode, Job.course_node_id == MaterialNode.id)
             .where(Job.id == job_id, MaterialNode.tenant_id == tenant_id)
         )
         result = await self._session.execute(stmt)
@@ -155,7 +156,10 @@ class JobRepository:
         """Get all active (queued or running) jobs for a node."""
         stmt = (
             select(Job)
-            .where(Job.materialnode_id == node_id, Job.status.in_(["queued", "active"]))
+            .where(
+                Job.course_node_id == node_id,
+                Job.status.in_(["queued", "active"]),
+            )
             .order_by(Job.queued_at)
         )
         result = await self._session.execute(stmt)
@@ -166,7 +170,7 @@ class JobRepository:
         stmt = (
             select(Job)
             .where(
-                Job.materialnode_id == node_id,
+                Job.course_node_id == node_id,
                 Job.status.in_(["queued", "active"]),
                 Job.job_type == "generate_structure",
             )
@@ -184,7 +188,7 @@ class JobRepository:
         stmt = (
             select(Job)
             .where(
-                Job.materialnode_id.in_(node_ids),
+                Job.course_node_id.in_(node_ids),
                 Job.status.in_(["queued", "active"]),
                 Job.job_type == "generate_structure",
             )

--- a/src/course_supporter/storage/job_repository.py
+++ b/src/course_supporter/storage/job_repository.py
@@ -129,6 +129,53 @@ class JobRepository:
         await self._session.execute(stmt)
         await self._session.flush()
 
+    async def reactivate(self, job_id: uuid.UUID) -> Job:
+        """Re-queue a failed Job for retry (vision §3 KD13).
+
+        Allowed only from ``status='failed'`` on a non-soft-deleted Job.
+        Other states (including soft-deleted) raise :class:`ValueError`;
+        callers map to 4xx (404 for missing, 409 for wrong state).
+
+        DB-side transition only — caller is responsible for enqueuing
+        the new ARQ task and calling :meth:`set_arq_job_id` with the
+        new id, all within the same outer transaction. Mirrors the
+        :meth:`create` / :meth:`set_arq_job_id` split used by
+        ``enqueue_ingestion`` and friends.
+
+        Cleared on transition: ``status`` (→ ``'queued'``),
+        ``error_message``, ``started_at``, ``completed_at``,
+        ``arq_job_id`` (caller will set the new one).
+
+        Preserved on transition:
+
+        * ``queued_at`` — original first-queued time is more meaningful
+          as Job metadata; per-attempt timing lives in
+          ``ExternalServiceCall`` per KD5/KD13.
+        * ``stage_progress`` — worker resumes from KD4a checkpoint.
+          This preservation is the design intent of ``reactivate``
+          (vs creating a new Job from scratch).
+        """
+        job = await self.get_by_id(job_id)
+        if job is None:
+            msg = f"Job {job_id} not found"
+            raise ValueError(msg)
+        if job.deleted_at is not None:
+            msg = f"Cannot reactivate soft-deleted Job {job_id}"
+            raise ValueError(msg)
+        if job.status != "failed":
+            msg = (
+                f"Cannot reactivate Job {job_id} in state {job.status!r}; "
+                f"only 'failed' Jobs can be reactivated."
+            )
+            raise ValueError(msg)
+        job.status = "queued"
+        job.error_message = None
+        job.started_at = None
+        job.completed_at = None
+        job.arq_job_id = None
+        await self._session.flush()
+        return job
+
     async def store_result(
         self, job_id: uuid.UUID, result_data: dict[str, Any]
     ) -> None:

--- a/src/course_supporter/storage/job_repository.py
+++ b/src/course_supporter/storage/job_repository.py
@@ -10,6 +10,7 @@ from typing import Any
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from course_supporter.jobs import JobType, validate_job_type
 from course_supporter.storage.orm import Job, MaterialNode
 
 # Valid job status transitions
@@ -38,17 +39,26 @@ class JobRepository:
         *,
         tenant_id: uuid.UUID | None = None,
         course_node_id: uuid.UUID | None = None,
-        job_type: str,
+        job_type: JobType | str,
         priority: str = "normal",
         arq_job_id: str | None = None,
         input_params: dict[str, object] | None = None,
         depends_on: list[str] | None = None,
     ) -> Job:
-        """Create a new job record."""
+        """Create a new job record.
+
+        ``job_type`` accepts either a :class:`JobType` enum (KD13
+        canonical, recommended for new code) or a legacy ``str``
+        (transitional — Phase 2.x will rewrite call-sites). Legacy
+        strings emit a one-shot :class:`DeprecationWarning` per
+        distinct value via :func:`validate_job_type`. The strict
+        DB CHECK constraint that would reject legacy values is
+        deferred to Phase 2.x along with the call-site migration.
+        """
         job = Job(
             tenant_id=tenant_id,
             course_node_id=course_node_id,
-            job_type=job_type,
+            job_type=validate_job_type(job_type),
             priority=priority,
             arq_job_id=arq_job_id,
             input_params=input_params,

--- a/src/course_supporter/storage/job_repository.py
+++ b/src/course_supporter/storage/job_repository.py
@@ -43,7 +43,6 @@ class JobRepository:
         arq_job_id: str | None = None,
         input_params: dict[str, object] | None = None,
         depends_on: list[str] | None = None,
-        estimated_at: datetime | None = None,
     ) -> Job:
         """Create a new job record."""
         job = Job(
@@ -54,7 +53,6 @@ class JobRepository:
             arq_job_id=arq_job_id,
             input_params=input_params,
             depends_on=depends_on,
-            estimated_at=estimated_at,
         )
         self._session.add(job)
         await self._session.flush()

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -1074,10 +1074,29 @@ class Job(SoftDeleteMixin, Base):
     input_params: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB, comment="JSONB of task-specific parameters"
     )
+    current_stage: Mapped[str | None] = mapped_column(
+        String(50),
+        comment="Internal pipeline stage marker per vision §3 KD13. "
+        "Free-form per job_type (e.g. pass_1/pass_2a/pass_2b/pass_2c "
+        "for document_processing; bottomup/topdown for "
+        "node_summary_regeneration; safety/sanity/review/delivery for "
+        "homework_processing; unused for s3_cleanup). Validation lives "
+        "at the worker level per pipeline.",
+    )
+    stage_progress: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB,
+        comment="Per-job-type checkpoint state for resume after retry "
+        "(KD4a in-flight resume + KD13 reactivate). Schema is "
+        "per-pipeline and intentionally not enforced at the DB level.",
+    )
     depends_on: Mapped[list[str] | None] = mapped_column(
         JSONB,
         comment="JSONB array of jobs.id UUIDs (as strings) "
-        "that must complete before this job runs",
+        "that must complete before this job runs. "
+        "DEPRECATED in v0.20 vision (KD13 — one Job = one logical "
+        "action, internal stages via current_stage). To be dropped "
+        "when methodist_orchestrator and generation_orchestrator are "
+        "rewritten to single-Job-with-stages pattern in Phase 2.x.",
     )
     result_data: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB, comment="JSONB result payload (e.g. reconciliation preview issues)"
@@ -1088,7 +1107,6 @@ class Job(SoftDeleteMixin, Base):
     )
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    estimated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     # Relationships
     tenant: Mapped["Tenant | None"] = relationship()

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -1056,10 +1056,11 @@ class Job(SoftDeleteMixin, Base):
     tenant_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("tenants.id", ondelete="SET NULL"), index=True
     )
-    materialnode_id: Mapped[uuid.UUID | None] = mapped_column(
+    course_node_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("material_nodes.id", ondelete="SET NULL"),
         index=True,
-        comment="FK to target MaterialNode. NULL for orphaned jobs",
+        comment="FK to target CourseNode (legacy table name material_nodes "
+        "until Phase 1.1 rename). NULL for orphaned jobs.",
     )
     job_type: Mapped[str] = mapped_column(String(50))
     priority: Mapped[str] = mapped_column(String(20), default="normal")

--- a/src/course_supporter/worker.py
+++ b/src/course_supporter/worker.py
@@ -24,6 +24,7 @@ from course_supporter.api.tasks import (
 )
 from course_supporter.config import get_settings
 from course_supporter.logging_config import configure_logging
+from course_supporter.workers.s3_cleanup import s3_cleanup_task
 
 WorkerCtx = dict[str, Any]
 
@@ -107,6 +108,7 @@ class WorkerSettings:
         arq_execute_step,
         arq_reconcile_preview,
         arq_execute_methodist_step,
+        s3_cleanup_task,
     ]
     on_startup = startup
     on_shutdown = shutdown

--- a/src/course_supporter/workers/__init__.py
+++ b/src/course_supporter/workers/__init__.py
@@ -1,0 +1,13 @@
+"""ARQ worker task functions.
+
+Modules in this package define ``async def arq_*`` /
+``*_task`` functions that ARQ invokes from queue messages. Each
+function is registered in ``course_supporter.worker.WorkerSettings``
+(or ``HomeworkWorkerSettings``) ``functions`` list.
+
+Per project convention, ARQ tasks live here for vision-aligned
+concerns (KD13 cancel/cleanup) — but pre-Phase-2.x pipeline
+workers still live in ``course_supporter.api.tasks`` for
+historical reasons. The Phase 2.x rewrite collapses them into
+this package.
+"""

--- a/src/course_supporter/workers/s3_cleanup.py
+++ b/src/course_supporter/workers/s3_cleanup.py
@@ -1,0 +1,117 @@
+"""S3 cleanup ARQ worker (vision §3 KD13).
+
+Async hard-delete of S3 files after a soft-delete cascade flips the
+owning entity (``AuthoredDocument`` / ``HomeworkSubmission``) to
+``deleted_at IS NOT NULL``. Per KD13:
+
+* Input is ``file_keys`` only — the task does **not** read the DB.
+  The originating record may already be scrubbed by the time this
+  worker runs; the cleanup must work from the explicit list.
+* **Idempotent**: missing object in S3 (``NoSuchKey`` / ``404`` /
+  ``NotFound``) is success — re-running with the same ``file_keys``
+  produces the same result on the second invocation.
+* **Per-key non-fatal errors** (any other ``ClientError`` returned
+  by S3, e.g. ``AccessDenied``, throttling codes like ``SlowDown``)
+  are recorded in the result's ``errors`` list and the task
+  continues; the operator inspects ``Job.result_data`` for follow-up.
+* **Connection-level failures** (``BotoCoreError``,
+  ``EndpointConnectionError``, network/timeout) are *not* caught
+  and propagate as exceptions, triggering ARQ's existing retry
+  policy. The semantic distinction is that ``ClientError`` is a
+  successful HTTP transaction with an AWS-level error code (an
+  answer from the service, even if negative), while non-
+  ``ClientError`` means we never got an answer (try again).
+
+**Cascade integration is Phase 1+ work.** When ``AuthoredDocument``
+(formerly ``MaterialEntry``) or ``HomeworkSubmission`` cascades
+soft-delete the entity row, the cascade enqueues this task with
+the entity's ``file_keys``::
+
+    await arq.enqueue_job(
+        "s3_cleanup_task",
+        file_keys=["bucket/path1", "bucket/path2"],
+        job_id="<job-uuid-str>",
+    )
+
+0.3 ships the worker only — no cascade binding lands here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from botocore.exceptions import ClientError
+
+from course_supporter.storage.s3 import S3Client
+
+logger = structlog.get_logger(__name__)
+
+# S3 / S3-compatible "object does not exist" error codes. Treated as
+# success per KD13 idempotency contract. botocore normalises some of
+# these (NoSuchKey from native AWS; "404" / "NotFound" from B2 /
+# certain S3-compatible providers).
+_NOT_FOUND_ERROR_CODES: frozenset[str] = frozenset({"NoSuchKey", "404", "NotFound"})
+
+
+async def s3_cleanup_task(
+    ctx: dict[str, Any],
+    *,
+    file_keys: list[str],
+    job_id: str,  # UUID as string (ARQ JSON serialization)
+) -> dict[str, Any]:
+    """Hard-delete S3 files for a soft-deleted entity.
+
+    See module docstring for the full error-handling contract.
+    Empty ``file_keys`` short-circuits to a no-op return; otherwise
+    iterates the list, attempting one delete per key.
+
+    ``job_id`` is logged for audit traceability only — the task does
+    NOT read or write the ``Job`` row (the row may have been scrubbed
+    by the cascade transaction by the time this task executes).
+
+    Returns:
+        A dict ``{"deleted": [<key>, ...], "errors": [{"key": <key>,
+        "error": <str>}, ...]}``. ``deleted`` includes both
+        successfully-deleted keys and keys that were already missing
+        from S3 (idempotent).
+    """
+    log = logger.bind(job_id=job_id, file_keys_count=len(file_keys))
+
+    if not file_keys:
+        log.info("s3_cleanup.noop")
+        return {"deleted": [], "errors": []}
+
+    s3: S3Client = ctx["s3_client"]
+    deleted: list[str] = []
+    errors: list[dict[str, str]] = []
+
+    for key in file_keys:
+        try:
+            await s3.delete_object(key)
+            deleted.append(key)
+        except ClientError as exc:
+            error_code = str(exc.response.get("Error", {}).get("Code", ""))
+            if error_code in _NOT_FOUND_ERROR_CODES:
+                # Idempotent: missing file is success per KD13.
+                deleted.append(key)
+                log.debug("s3_cleanup.already_deleted", key=key, error_code=error_code)
+            else:
+                # Per-key error: AWS responded with an error code that
+                # retry won't fix (AccessDenied) or signals throttling
+                # (SlowDown). Record and continue; the operator sees
+                # these in Job.result_data for triage.
+                errors.append({"key": key, "error": f"{error_code}: {exc}"})
+                log.warning(
+                    "s3_cleanup.client_error",
+                    key=key,
+                    error_code=error_code,
+                    error=str(exc),
+                )
+
+    log.info(
+        "s3_cleanup.complete",
+        deleted_count=len(deleted),
+        error_count=len(errors),
+    )
+    return {"deleted": deleted, "errors": errors}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -122,8 +122,12 @@ async def committed_seeds(
 ) -> AsyncGenerator[dict[str, uuid.UUID]]:
     """Create Tenant + root MaterialNode + MaterialEntry with real commits.
 
-    Returns dict with ``tenant_id``, ``materialnode_id``, ``material_id``.
-    Cleans up after the test via DELETE in reverse FK order.
+    Returns dict with ``tenant_id``, ``course_node_id``, ``material_id``.
+    The ``course_node_id`` key matches the v0.20 column name on
+    ``Job.course_node_id`` (KD13 — renamed from legacy
+    ``materialnode_id`` in task 0.3); the underlying row is still a
+    ``MaterialNode`` and will be re-typed to ``CourseNode`` only in
+    Phase 1.1. Cleans up after the test via DELETE in reverse FK order.
     """
     async with session_factory() as session:
         tenant = Tenant(name=f"test-tenant-{uuid.uuid4().hex[:8]}")
@@ -149,25 +153,28 @@ async def committed_seeds(
 
         ids: dict[str, uuid.UUID] = {
             "tenant_id": tenant.id,
-            "materialnode_id": node.id,
+            "course_node_id": node.id,
             "material_id": entry.id,
         }
 
     yield ids
 
-    # Cleanup: delete in reverse FK order
+    # Cleanup: delete in reverse FK order. Note that
+    # ``MaterialEntry.materialnode_id`` and ``MaterialNode.id`` are
+    # still legacy column names — they get renamed in Phase 1.1
+    # along with the table-level MaterialNode → CourseNode rename.
     async with session_factory() as session:
         await session.execute(
-            Job.__table__.delete().where(Job.materialnode_id == ids["materialnode_id"])
+            Job.__table__.delete().where(Job.course_node_id == ids["course_node_id"])
         )
         await session.execute(
             MaterialEntry.__table__.delete().where(
-                MaterialEntry.materialnode_id == ids["materialnode_id"]
+                MaterialEntry.materialnode_id == ids["course_node_id"]
             )
         )
         await session.execute(
             MaterialNode.__table__.delete().where(
-                MaterialNode.id == ids["materialnode_id"]
+                MaterialNode.id == ids["course_node_id"]
             )
         )
         await session.execute(
@@ -186,7 +193,7 @@ async def committed_job_and_material(
     Pre-transitions the records to the state expected before
     ``IngestionCallback.on_success`` / ``on_failure``.
 
-    Returns dict with ``job_id``, ``material_id``, ``materialnode_id``, ``tenant_id``.
+    Returns dict with ``job_id``, ``material_id``, ``course_node_id``, ``tenant_id``.
     """
     from course_supporter.storage.job_repository import JobRepository
     from course_supporter.storage.material_entry_repository import (
@@ -199,7 +206,7 @@ async def committed_job_and_material(
 
         job = await job_repo.create(
             tenant_id=committed_seeds["tenant_id"],
-            materialnode_id=committed_seeds["materialnode_id"],
+            course_node_id=committed_seeds["course_node_id"],
             job_type="ingest",
         )
         await job_repo.update_status(job.id, "active")
@@ -209,7 +216,7 @@ async def committed_job_and_material(
     yield {
         "job_id": job.id,
         "material_id": committed_seeds["material_id"],
-        "materialnode_id": committed_seeds["materialnode_id"],
+        "course_node_id": committed_seeds["course_node_id"],
         "tenant_id": committed_seeds["tenant_id"],
     }
 

--- a/tests/integration/test_arq_task_e2e.py
+++ b/tests/integration/test_arq_task_e2e.py
@@ -97,14 +97,14 @@ class TestArqIngestMaterialE2E:
         """
         mid = committed_seeds["material_id"]
         tid = committed_seeds["tenant_id"]
-        nid = committed_seeds["materialnode_id"]
+        nid = committed_seeds["course_node_id"]
 
         # Create job in DB
         async with session_factory() as session:
             job_repo = JobRepository(session)
             job = await job_repo.create(
                 tenant_id=tid,
-                materialnode_id=nid,
+                course_node_id=nid,
                 job_type="ingest",
             )
             await session.commit()
@@ -164,13 +164,13 @@ class TestArqIngestMaterialE2E:
         """
         mid = committed_seeds["material_id"]
         tid = committed_seeds["tenant_id"]
-        nid = committed_seeds["materialnode_id"]
+        nid = committed_seeds["course_node_id"]
 
         async with session_factory() as session:
             job_repo = JobRepository(session)
             job = await job_repo.create(
                 tenant_id=tid,
-                materialnode_id=nid,
+                course_node_id=nid,
                 job_type="ingest",
             )
             await session.commit()
@@ -226,13 +226,13 @@ class TestArqIngestMaterialE2E:
         """
         mid = committed_seeds["material_id"]
         tid = committed_seeds["tenant_id"]
-        nid = committed_seeds["materialnode_id"]
+        nid = committed_seeds["course_node_id"]
 
         async with session_factory() as session:
             job_repo = JobRepository(session)
             job = await job_repo.create(
                 tenant_id=tid,
-                materialnode_id=nid,
+                course_node_id=nid,
                 job_type="ingest",
             )
             await session.commit()

--- a/tests/integration/test_enqueue_redis.py
+++ b/tests/integration/test_enqueue_redis.py
@@ -35,7 +35,8 @@ class TestEnqueueIngestion:
             job = await enqueue_ingestion(
                 redis=arq_redis,
                 session=session,
-                course_id=committed_seeds["course_id"],
+                tenant_id=committed_seeds["tenant_id"],
+                node_id=committed_seeds["course_node_id"],
                 material_id=committed_seeds["material_id"],
                 source_type="web",
                 source_url="https://example.com/test",
@@ -64,7 +65,8 @@ class TestEnqueueIngestion:
             job = await enqueue_ingestion(
                 redis=arq_redis,
                 session=session,
-                course_id=committed_seeds["course_id"],
+                tenant_id=committed_seeds["tenant_id"],
+                node_id=committed_seeds["course_node_id"],
                 material_id=committed_seeds["material_id"],
                 source_type="web",
                 source_url="https://example.com/test",
@@ -92,7 +94,8 @@ class TestEnqueueIngestion:
             job = await enqueue_ingestion(
                 redis=arq_redis,
                 session=session,
-                course_id=committed_seeds["course_id"],
+                tenant_id=committed_seeds["tenant_id"],
+                node_id=committed_seeds["course_node_id"],
                 material_id=committed_seeds["material_id"],
                 source_type="web",
                 source_url="https://example.com/input-params",

--- a/tests/integration/test_job_cancellation_service_db.py
+++ b/tests/integration/test_job_cancellation_service_db.py
@@ -1,0 +1,232 @@
+"""Integration tests for JobCancellationService against real PostgreSQL.
+
+Verifies the OR-of-paths SELECT, status filter (queued/running/active),
+defensive deleted_at IS NULL filter, scope isolation, and idempotency
+that JobCancellationService relies on for the on_cancel_jobs cascade
+hook (vision §3 KD13 + KD12). The unit-test sibling
+``tests/unit/test_job_cancellation_service.py`` covers only the API
+contract surface (empty-input no-op, OnCancelJobs callable shape,
+return-None contract); the SQL behaviour is exercised here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.jobs.cancellation_service import JobCancellationService
+from course_supporter.storage.orm import Job, MaterialNode, Tenant
+
+pytestmark = pytest.mark.requires_db
+
+
+FIXED_TS = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+async def _seed_two_tenants_two_nodes(
+    session: AsyncSession,
+) -> tuple[Tenant, Tenant, MaterialNode, MaterialNode]:
+    """Two tenants x two nodes for OR-of-paths + isolation testing."""
+    t1 = Tenant(name=f"jcs-t1-{uuid.uuid4().hex[:6]}")
+    t2 = Tenant(name=f"jcs-t2-{uuid.uuid4().hex[:6]}")
+    session.add_all([t1, t2])
+    await session.flush()
+    n1 = MaterialNode(tenant_id=t1.id, title="n1", order=0)
+    n2 = MaterialNode(tenant_id=t2.id, title="n2", order=0)
+    session.add_all([n1, n2])
+    await session.flush()
+    return t1, t2, n1, n2
+
+
+class TestLookupPaths:
+    """All three OR-of-paths reach matching active Jobs."""
+
+    async def test_tenant_id_match_cancels(self, db_session: AsyncSession) -> None:
+        t1, _, _, _ = await _seed_two_tenants_two_nodes(db_session)
+        job = Job(
+            tenant_id=t1.id,
+            course_node_id=None,
+            job_type="ingest",
+            status="queued",
+        )
+        db_session.add(job)
+        await db_session.flush()
+
+        await JobCancellationService(db_session).cancel_jobs_for_entities(
+            [t1.id], now=FIXED_TS
+        )
+        await db_session.refresh(job)
+
+        assert job.status == "cancelled"
+        assert job.completed_at == FIXED_TS
+
+    async def test_course_node_id_match_cancels(self, db_session: AsyncSession) -> None:
+        _, t2, n1, _ = await _seed_two_tenants_two_nodes(db_session)
+        job = Job(
+            tenant_id=t2.id,
+            course_node_id=n1.id,
+            job_type="ingest",
+            status="running",
+        )
+        db_session.add(job)
+        await db_session.flush()
+
+        await JobCancellationService(db_session).cancel_jobs_for_entities(
+            [n1.id], now=FIXED_TS
+        )
+        await db_session.refresh(job)
+
+        assert job.status == "cancelled"
+        assert job.completed_at == FIXED_TS
+
+    async def test_input_params_jsonb_match_cancels(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Jobs whose input_params @> {'course_node_id': <id>} also cancel.
+
+        Covers legacy callsites where Job.course_node_id FK is NULL but
+        the JSONB carries the entity reference. Status here is the legacy
+        'active' alias (still in scope per pre-flight scope agreement).
+        """
+        _, t2, n1, _ = await _seed_two_tenants_two_nodes(db_session)
+        job = Job(
+            tenant_id=t2.id,
+            course_node_id=None,
+            job_type="ingest",
+            status="active",
+            input_params={"course_node_id": str(n1.id), "extra": "x"},
+        )
+        db_session.add(job)
+        await db_session.flush()
+
+        await JobCancellationService(db_session).cancel_jobs_for_entities(
+            [n1.id], now=FIXED_TS
+        )
+        await db_session.refresh(job)
+
+        assert job.status == "cancelled"
+        assert job.completed_at == FIXED_TS
+
+
+class TestExclusions:
+    """Status filter + deleted_at filter exclude correct rows."""
+
+    async def test_completed_not_touched(self, db_session: AsyncSession) -> None:
+        t1, _, _, _ = await _seed_two_tenants_two_nodes(db_session)
+        job = Job(
+            tenant_id=t1.id,
+            course_node_id=None,
+            job_type="ingest",
+            status="completed",
+        )
+        db_session.add(job)
+        await db_session.flush()
+
+        await JobCancellationService(db_session).cancel_jobs_for_entities([t1.id])
+        await db_session.refresh(job)
+
+        assert job.status == "completed"
+
+    async def test_already_cancelled_idempotent(self, db_session: AsyncSession) -> None:
+        """Re-running over an already-cancelled Job: completed_at unchanged."""
+        t1, _, _, _ = await _seed_two_tenants_two_nodes(db_session)
+        original_ts = datetime(2020, 1, 1, tzinfo=UTC)
+        job = Job(
+            tenant_id=t1.id,
+            course_node_id=None,
+            job_type="ingest",
+            status="cancelled",
+            completed_at=original_ts,
+        )
+        db_session.add(job)
+        await db_session.flush()
+
+        await JobCancellationService(db_session).cancel_jobs_for_entities(
+            [t1.id], now=FIXED_TS
+        )
+        await db_session.refresh(job)
+
+        assert job.status == "cancelled"
+        # Critical: NOT FIXED_TS — the row was excluded by the status filter
+        assert job.completed_at == original_ts
+
+    async def test_soft_deleted_not_touched(self, db_session: AsyncSession) -> None:
+        """Defensive deleted_at filter avoids 0.1 trigger collision.
+
+        Without the filter, attempting to UPDATE a soft-deleted row would
+        be blocked by ``block_update_on_soft_deleted`` (the 0.1 trigger)
+        because we'd try to mutate ``status``/``completed_at`` while
+        ``deleted_at IS NOT NULL``.
+        """
+        t1, _, _, _ = await _seed_two_tenants_two_nodes(db_session)
+        job = Job(
+            tenant_id=t1.id,
+            course_node_id=None,
+            job_type="ingest",
+            status="active",
+            deleted_at=datetime(2020, 1, 1, tzinfo=UTC),
+        )
+        db_session.add(job)
+        await db_session.flush()
+
+        # Must not raise (row excluded from SELECT, no UPDATE attempted)
+        await JobCancellationService(db_session).cancel_jobs_for_entities([t1.id])
+        await db_session.refresh(job)
+
+        assert job.status == "active"
+
+
+class TestScopeIsolation:
+    """Lookup is correctly scoped to the supplied entity_ids."""
+
+    async def test_unrelated_tenant_node_not_touched(
+        self, db_session: AsyncSession
+    ) -> None:
+        t1, t2, _, n2 = await _seed_two_tenants_two_nodes(db_session)
+        job = Job(
+            tenant_id=t2.id,
+            course_node_id=n2.id,
+            job_type="ingest",
+            status="queued",
+        )
+        db_session.add(job)
+        await db_session.flush()
+
+        # Cascade for t1 only — t2/n2 must not be touched
+        await JobCancellationService(db_session).cancel_jobs_for_entities([t1.id])
+        await db_session.refresh(job)
+
+        assert job.status == "queued"
+
+
+class TestIdempotency:
+    """Re-run with the same entity_ids → no-op (status filter excludes)."""
+
+    async def test_rerun_does_not_modify_first_run_results(
+        self, db_session: AsyncSession
+    ) -> None:
+        t1, _, _, _ = await _seed_two_tenants_two_nodes(db_session)
+        job = Job(
+            tenant_id=t1.id,
+            course_node_id=None,
+            job_type="ingest",
+            status="queued",
+        )
+        db_session.add(job)
+        await db_session.flush()
+
+        # First run cancels with FIXED_TS
+        await JobCancellationService(db_session).cancel_jobs_for_entities(
+            [t1.id], now=FIXED_TS
+        )
+        # Second run with a different ts: row now 'cancelled' → excluded
+        await JobCancellationService(db_session).cancel_jobs_for_entities(
+            [t1.id], now=datetime(2027, 2, 2, tzinfo=UTC)
+        )
+        await db_session.refresh(job)
+
+        # completed_at remains the FIRST run's ts, not the second
+        assert job.completed_at == FIXED_TS

--- a/tests/integration/test_job_redesign_db.py
+++ b/tests/integration/test_job_redesign_db.py
@@ -20,9 +20,11 @@ what the worker wrote on its last checkpoint (KD4a + KD13).
 from __future__ import annotations
 
 import uuid
+from collections.abc import Generator
 
 import pytest
 from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -33,7 +35,7 @@ pytestmark = pytest.mark.requires_db
 
 
 @pytest.fixture()
-def sync_engine():  # type: ignore[no-untyped-def]
+def sync_engine() -> Generator[Engine]:
     """Sync engine for catalog inspection (pg_constraint, pg_indexes)."""
     engine = create_engine(get_settings().database_url)
     yield engine
@@ -43,29 +45,29 @@ def sync_engine():  # type: ignore[no-untyped-def]
 class TestSchemaShape:
     """Migration ``e2f3a4b5c6d7`` shipped the expected schema."""
 
-    def test_current_stage_column_exists(self, sync_engine) -> None:  # type: ignore[no-untyped-def]
+    def test_current_stage_column_exists(self, sync_engine: Engine) -> None:
         cols = {c["name"]: c for c in inspect(sync_engine).get_columns("jobs")}
         assert "current_stage" in cols
         # VARCHAR(50) per migration
         assert cols["current_stage"]["nullable"] is True
 
-    def test_stage_progress_column_exists_as_jsonb(self, sync_engine) -> None:  # type: ignore[no-untyped-def]
+    def test_stage_progress_column_exists_as_jsonb(self, sync_engine: Engine) -> None:
         cols = {c["name"]: c for c in inspect(sync_engine).get_columns("jobs")}
         assert "stage_progress" in cols
         assert cols["stage_progress"]["nullable"] is True
         # JSONB type (psycopg / SQLA reports it as JSONB)
         assert "JSON" in str(cols["stage_progress"]["type"]).upper()
 
-    def test_estimated_at_column_dropped(self, sync_engine) -> None:  # type: ignore[no-untyped-def]
+    def test_estimated_at_column_dropped(self, sync_engine: Engine) -> None:
         col_names = {c["name"] for c in inspect(sync_engine).get_columns("jobs")}
         assert "estimated_at" not in col_names
 
-    def test_course_node_id_column_renamed(self, sync_engine) -> None:  # type: ignore[no-untyped-def]
+    def test_course_node_id_column_renamed(self, sync_engine: Engine) -> None:
         col_names = {c["name"] for c in inspect(sync_engine).get_columns("jobs")}
         assert "course_node_id" in col_names
         assert "materialnode_id" not in col_names
 
-    def test_fk_constraint_renamed(self, sync_engine) -> None:  # type: ignore[no-untyped-def]
+    def test_fk_constraint_renamed(self, sync_engine: Engine) -> None:
         """``jobs_course_node_id_fkey`` exists; legacy name does not."""
         with sync_engine.connect() as conn:
             rows = conn.execute(
@@ -78,7 +80,7 @@ class TestSchemaShape:
         assert "jobs_course_node_id_fkey" in names
         assert "jobs_materialnode_id_fkey" not in names
 
-    def test_index_renamed(self, sync_engine) -> None:  # type: ignore[no-untyped-def]
+    def test_index_renamed(self, sync_engine: Engine) -> None:
         """``ix_jobs_course_node_id`` exists; legacy name does not."""
         with sync_engine.connect() as conn:
             rows = conn.execute(

--- a/tests/integration/test_job_redesign_db.py
+++ b/tests/integration/test_job_redesign_db.py
@@ -1,0 +1,189 @@
+"""Integration tests for the 0.3 Job schema redesign (vision §3 KD13).
+
+Verifies the post-migration on-disk shape of the ``jobs`` table:
+
+* ``current_stage`` (varchar) and ``stage_progress`` (jsonb) columns exist.
+* ``estimated_at`` is dropped.
+* ``materialnode_id`` is renamed to ``course_node_id`` — column, FK
+  constraint (``jobs_course_node_id_fkey``), and index
+  (``ix_jobs_course_node_id``) all carry the new names.
+
+ORM-level assertions live in the unit suite; this file confirms
+the migration actually shipped these changes (a class of bug where
+the migration is missing or partial would slip past the unit tests).
+
+Plus a JSONB round-trip: ``stage_progress`` must persist nested
+structures verbatim because reactivate-resume reads back exactly
+what the worker wrote on its last checkpoint (KD4a + KD13).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.config import get_settings
+from course_supporter.storage.orm import Job, MaterialNode, Tenant
+
+pytestmark = pytest.mark.requires_db
+
+
+@pytest.fixture()
+def sync_engine():  # type: ignore[no-untyped-def]
+    """Sync engine for catalog inspection (pg_constraint, pg_indexes)."""
+    engine = create_engine(get_settings().database_url)
+    yield engine
+    engine.dispose()
+
+
+class TestSchemaShape:
+    """Migration ``e2f3a4b5c6d7`` shipped the expected schema."""
+
+    def test_current_stage_column_exists(self, sync_engine) -> None:  # type: ignore[no-untyped-def]
+        cols = {c["name"]: c for c in inspect(sync_engine).get_columns("jobs")}
+        assert "current_stage" in cols
+        # VARCHAR(50) per migration
+        assert cols["current_stage"]["nullable"] is True
+
+    def test_stage_progress_column_exists_as_jsonb(self, sync_engine) -> None:  # type: ignore[no-untyped-def]
+        cols = {c["name"]: c for c in inspect(sync_engine).get_columns("jobs")}
+        assert "stage_progress" in cols
+        assert cols["stage_progress"]["nullable"] is True
+        # JSONB type (psycopg / SQLA reports it as JSONB)
+        assert "JSON" in str(cols["stage_progress"]["type"]).upper()
+
+    def test_estimated_at_column_dropped(self, sync_engine) -> None:  # type: ignore[no-untyped-def]
+        col_names = {c["name"] for c in inspect(sync_engine).get_columns("jobs")}
+        assert "estimated_at" not in col_names
+
+    def test_course_node_id_column_renamed(self, sync_engine) -> None:  # type: ignore[no-untyped-def]
+        col_names = {c["name"] for c in inspect(sync_engine).get_columns("jobs")}
+        assert "course_node_id" in col_names
+        assert "materialnode_id" not in col_names
+
+    def test_fk_constraint_renamed(self, sync_engine) -> None:  # type: ignore[no-untyped-def]
+        """``jobs_course_node_id_fkey`` exists; legacy name does not."""
+        with sync_engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT conname FROM pg_constraint "
+                    "WHERE conrelid = 'jobs'::regclass AND contype = 'f'"
+                )
+            ).all()
+        names = {r[0] for r in rows}
+        assert "jobs_course_node_id_fkey" in names
+        assert "jobs_materialnode_id_fkey" not in names
+
+    def test_index_renamed(self, sync_engine) -> None:  # type: ignore[no-untyped-def]
+        """``ix_jobs_course_node_id`` exists; legacy name does not."""
+        with sync_engine.connect() as conn:
+            rows = conn.execute(
+                text("SELECT indexname FROM pg_indexes WHERE tablename = 'jobs'")
+            ).all()
+        names = {r[0] for r in rows}
+        assert "ix_jobs_course_node_id" in names
+        assert "ix_jobs_materialnode_id" not in names
+
+
+class TestStageProgressRoundTrip:
+    """``stage_progress`` round-trips arbitrary nested JSONB structures."""
+
+    async def test_string_round_trip_for_current_stage(
+        self, db_session: AsyncSession
+    ) -> None:
+        """``current_stage`` writes/reads a free-form string identifier."""
+        tenant = Tenant(name=f"jrd-{uuid.uuid4().hex[:6]}")
+        db_session.add(tenant)
+        await db_session.flush()
+        job = Job(
+            tenant_id=tenant.id,
+            job_type="ingest",
+            current_stage="pass_2b",
+        )
+        db_session.add(job)
+        await db_session.flush()
+        await db_session.refresh(job)
+        assert job.current_stage == "pass_2b"
+
+    async def test_nested_dict_round_trip_for_stage_progress(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Nested checkpoint payload reads back byte-identical."""
+        tenant = Tenant(name=f"jrd-{uuid.uuid4().hex[:6]}")
+        db_session.add(tenant)
+        await db_session.flush()
+        # Realistic shape: per-pipeline checkpoint state
+        progress = {
+            "completed_segments": ["seg-1", "seg-2"],
+            "next_offset": 12345,
+            "pass_2": {
+                "summary_done": True,
+                "outline_done": False,
+                "metrics": {"tokens_in": 1500, "tokens_out": 320},
+            },
+        }
+        job = Job(
+            tenant_id=tenant.id,
+            job_type="ingest",
+            stage_progress=progress,
+        )
+        db_session.add(job)
+        await db_session.flush()
+        await db_session.refresh(job)
+        assert job.stage_progress == progress
+
+    async def test_both_default_null(self, db_session: AsyncSession) -> None:
+        """Newly created Job has both fields NULL by default."""
+        tenant = Tenant(name=f"jrd-{uuid.uuid4().hex[:6]}")
+        db_session.add(tenant)
+        await db_session.flush()
+        job = Job(tenant_id=tenant.id, job_type="ingest")
+        db_session.add(job)
+        await db_session.flush()
+        await db_session.refresh(job)
+        assert job.current_stage is None
+        assert job.stage_progress is None
+
+
+class TestForeignKeyEnforcement:
+    """Renamed FK still enforces referential integrity."""
+
+    async def test_invalid_course_node_id_raises_integrity_error(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Inserting a Job with a non-existent course_node_id is rejected."""
+        tenant = Tenant(name=f"jrd-{uuid.uuid4().hex[:6]}")
+        db_session.add(tenant)
+        await db_session.flush()
+        job = Job(
+            tenant_id=tenant.id,
+            course_node_id=uuid.uuid4(),  # not in material_nodes
+            job_type="ingest",
+        )
+        db_session.add(job)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_valid_course_node_id_accepted(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Job with a real CourseNode FK persists cleanly."""
+        tenant = Tenant(name=f"jrd-{uuid.uuid4().hex[:6]}")
+        db_session.add(tenant)
+        await db_session.flush()
+        node = MaterialNode(tenant_id=tenant.id, title="n", order=0)
+        db_session.add(node)
+        await db_session.flush()
+        job = Job(
+            tenant_id=tenant.id,
+            course_node_id=node.id,
+            job_type="ingest",
+        )
+        db_session.add(job)
+        await db_session.flush()
+        await db_session.refresh(job)
+        assert job.course_node_id == node.id

--- a/tests/integration/test_job_repository.py
+++ b/tests/integration/test_job_repository.py
@@ -28,7 +28,7 @@ class TestJobCreate:
         repo = JobRepository(db_session)
         job = await repo.create(
             tenant_id=seed_root_node.tenant_id,
-            materialnode_id=seed_root_node.id,
+            course_node_id=seed_root_node.id,
             job_type="ingest",
         )
 
@@ -47,7 +47,7 @@ class TestJobCreate:
         repo = JobRepository(db_session)
         job = await repo.create(
             tenant_id=seed_root_node.tenant_id,
-            materialnode_id=seed_root_node.id,
+            course_node_id=seed_root_node.id,
             job_type="ingest",
             input_params=params,
         )
@@ -63,7 +63,7 @@ class TestJobCreate:
         repo = JobRepository(db_session)
         job = await repo.create(
             tenant_id=seed_root_node.tenant_id,
-            materialnode_id=seed_root_node.id,
+            course_node_id=seed_root_node.id,
             job_type="ingest",
         )
 
@@ -89,7 +89,7 @@ class TestJobLifecycleSuccess:
         repo = JobRepository(db_session)
         job = await repo.create(
             tenant_id=seed_root_node.tenant_id,
-            materialnode_id=seed_root_node.id,
+            course_node_id=seed_root_node.id,
             job_type="ingest",
         )
         assert job.status == "queued"
@@ -113,7 +113,7 @@ class TestJobLifecycleSuccess:
         repo = JobRepository(db_session)
         job = await repo.create(
             tenant_id=seed_root_node.tenant_id,
-            materialnode_id=seed_root_node.id,
+            course_node_id=seed_root_node.id,
             job_type="ingest",
         )
 
@@ -134,7 +134,7 @@ class TestJobLifecycleFailureRetry:
         repo = JobRepository(db_session)
         job = await repo.create(
             tenant_id=seed_root_node.tenant_id,
-            materialnode_id=seed_root_node.id,
+            course_node_id=seed_root_node.id,
             job_type="ingest",
         )
 
@@ -164,7 +164,7 @@ class TestJobTransitionValidation:
         repo = JobRepository(db_session)
         job = await repo.create(
             tenant_id=seed_root_node.tenant_id,
-            materialnode_id=seed_root_node.id,
+            course_node_id=seed_root_node.id,
             job_type="ingest",
         )
 
@@ -185,7 +185,7 @@ class TestJobQueries:
         repo = JobRepository(db_session)
         job = await repo.create(
             tenant_id=seed_tenant.id,
-            materialnode_id=seed_root_node.id,
+            course_node_id=seed_root_node.id,
             job_type="ingest",
         )
 
@@ -202,7 +202,7 @@ class TestJobQueries:
         repo = JobRepository(db_session)
         job = await repo.create(
             tenant_id=seed_root_node.tenant_id,
-            materialnode_id=seed_root_node.id,
+            course_node_id=seed_root_node.id,
             job_type="ingest",
         )
 
@@ -223,14 +223,14 @@ class TestJobQueries:
         for _ in range(3):
             await repo.create(
                 tenant_id=seed_root_node.tenant_id,
-                materialnode_id=seed_root_node.id,
+                course_node_id=seed_root_node.id,
                 job_type="ingest",
             )
 
         # Add 1 active (not counted)
         job_active = await repo.create(
             tenant_id=seed_root_node.tenant_id,
-            materialnode_id=seed_root_node.id,
+            course_node_id=seed_root_node.id,
             job_type="ingest",
         )
         await repo.update_status(job_active.id, "active")
@@ -245,7 +245,7 @@ class TestJobQueries:
         repo = JobRepository(db_session)
         job = await repo.create(
             tenant_id=seed_root_node.tenant_id,
-            materialnode_id=seed_root_node.id,
+            course_node_id=seed_root_node.id,
             job_type="ingest",
         )
         assert job.arq_job_id is None

--- a/tests/integration/test_job_repository.py
+++ b/tests/integration/test_job_repository.py
@@ -255,3 +255,163 @@ class TestJobQueries:
         fetched = await repo.get_by_id(job.id)
         assert fetched is not None
         assert fetched.arq_job_id == "arq:test:abc123"
+
+
+class TestJobReactivate:
+    """``reactivate`` re-queues failed Jobs for retry (vision §3 KD13).
+
+    Covers happy-path field semantics (cleared vs preserved) and the
+    rejection branches the API layer maps to 4xx (404 / 409). Resume
+    semantics live in ``stage_progress``: it MUST survive reactivate
+    because that is the field the worker reads to skip already-done
+    pipeline stages on retry.
+    """
+
+    async def test_failed_to_queued_clears_run_attempt_state(
+        self,
+        db_session: AsyncSession,
+        seed_root_node: MaterialNode,
+    ) -> None:
+        """status, error_message, started_at, completed_at, arq_job_id reset."""
+        repo = JobRepository(db_session)
+        job = await repo.create(
+            tenant_id=seed_root_node.tenant_id,
+            course_node_id=seed_root_node.id,
+            job_type="ingest",
+        )
+        await repo.set_arq_job_id(job.id, "arq:old:xyz")
+        await repo.update_status(job.id, "active")
+        await repo.update_status(job.id, "failed", error_message="boom")
+
+        # Sanity: pre-state is failed with all the run-attempt fields set
+        before = await repo.get_by_id(job.id)
+        assert before is not None
+        assert before.status == "failed"
+        assert before.error_message == "boom"
+        assert before.started_at is not None
+        assert before.completed_at is not None
+        assert before.arq_job_id == "arq:old:xyz"
+
+        reactivated = await repo.reactivate(job.id)
+
+        assert reactivated.status == "queued"
+        assert reactivated.error_message is None
+        assert reactivated.started_at is None
+        assert reactivated.completed_at is None
+        # New ARQ job_id is the caller's responsibility — reactivate clears
+        # the old one so a stale value can't leak into the next attempt.
+        assert reactivated.arq_job_id is None
+
+    async def test_preserves_stage_progress_and_queued_at(
+        self,
+        db_session: AsyncSession,
+        seed_root_node: MaterialNode,
+    ) -> None:
+        """``stage_progress`` + ``queued_at`` survive reactivate.
+
+        Worker resumes from KD4a checkpoint, so dropping ``stage_progress``
+        would re-do already-completed pipeline stages.
+        """
+        repo = JobRepository(db_session)
+        job = await repo.create(
+            tenant_id=seed_root_node.tenant_id,
+            course_node_id=seed_root_node.id,
+            job_type="ingest",
+        )
+        # Simulate worker writing a checkpoint mid-flight
+        progress = {"completed_segments": ["s1"], "next_offset": 4096}
+        job.stage_progress = progress
+        await db_session.flush()
+        original_queued_at = job.queued_at
+
+        await repo.update_status(job.id, "active")
+        await repo.update_status(job.id, "failed")
+
+        reactivated = await repo.reactivate(job.id)
+
+        # The whole point of reactivate (vs creating a new Job): resume
+        assert reactivated.stage_progress == progress
+        # First-queued metadata is more meaningful than per-attempt time
+        assert reactivated.queued_at == original_queued_at
+
+    async def test_missing_job_raises_value_error(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Non-existent job_id → ValueError (API maps to 404)."""
+        repo = JobRepository(db_session)
+        with pytest.raises(ValueError, match="not found"):
+            await repo.reactivate(uuid.uuid4())
+
+    @pytest.mark.parametrize("blocking_status", ["queued", "active", "complete"])
+    async def test_rejects_non_failed_states(
+        self,
+        db_session: AsyncSession,
+        seed_root_node: MaterialNode,
+        blocking_status: str,
+    ) -> None:
+        """Only ``failed`` reactivates — every other state is a 409.
+
+        ``cancelled`` is a deliberate omission: rerunning the worker for
+        a cancelled Job would defeat the cancel signal.
+        """
+        repo = JobRepository(db_session)
+        job = await repo.create(
+            tenant_id=seed_root_node.tenant_id,
+            course_node_id=seed_root_node.id,
+            job_type="ingest",
+        )
+        if blocking_status == "active":
+            await repo.update_status(job.id, "active")
+        elif blocking_status == "complete":
+            await repo.update_status(job.id, "active")
+            await repo.update_status(job.id, "complete")
+        # else: blocking_status == "queued" → no transitions needed
+
+        with pytest.raises(ValueError, match="Cannot reactivate Job"):
+            await repo.reactivate(job.id)
+
+    async def test_rejects_cancelled(
+        self,
+        db_session: AsyncSession,
+        seed_root_node: MaterialNode,
+    ) -> None:
+        """Reactivating a cancelled Job would defeat the cancel signal."""
+        repo = JobRepository(db_session)
+        job = await repo.create(
+            tenant_id=seed_root_node.tenant_id,
+            course_node_id=seed_root_node.id,
+            job_type="ingest",
+        )
+        await repo.update_status(job.id, "cancelled")
+        with pytest.raises(ValueError, match="Cannot reactivate Job"):
+            await repo.reactivate(job.id)
+
+    async def test_rejects_soft_deleted(
+        self,
+        db_session: AsyncSession,
+        seed_root_node: MaterialNode,
+    ) -> None:
+        """Soft-deleted Job → ValueError even if status would otherwise allow.
+
+        The check fires before the status check; reactivating a
+        soft-deleted row would also collide with the 0.1
+        ``block_update_on_soft_deleted`` trigger when the worker
+        attempts its first ``update_status``.
+        """
+        from datetime import UTC, datetime
+
+        repo = JobRepository(db_session)
+        job = await repo.create(
+            tenant_id=seed_root_node.tenant_id,
+            course_node_id=seed_root_node.id,
+            job_type="ingest",
+        )
+        await repo.update_status(job.id, "active")
+        await repo.update_status(job.id, "failed")
+        # Soft-delete via direct attribute write (cascade service is 0.1
+        # scope; here we just need the deleted_at to be set).
+        job.deleted_at = datetime(2026, 1, 1, tzinfo=UTC)
+        await db_session.flush()
+
+        with pytest.raises(ValueError, match="soft-deleted"):
+            await repo.reactivate(job.id)

--- a/tests/unit/test_api/test_generation_routes.py
+++ b/tests/unit/test_api/test_generation_routes.py
@@ -60,12 +60,13 @@ def _make_job(
     job.tenant_id = tenant_id or STUB_TENANT.tenant_id
     job.materialnode_id = node_id or NODE_ID
     job.arq_job_id = f"arq:{job.id}"
+    job.current_stage = None
+    job.stage_progress = None
     job.result_data = None
     job.error_message = None
     job.queued_at = NOW
     job.started_at = None
     job.completed_at = None
-    job.estimated_at = None
     return job
 
 

--- a/tests/unit/test_api/test_generation_routes.py
+++ b/tests/unit/test_api/test_generation_routes.py
@@ -58,7 +58,7 @@ def _make_job(
     job.priority = "normal"
     job.status = status
     job.tenant_id = tenant_id or STUB_TENANT.tenant_id
-    job.materialnode_id = node_id or NODE_ID
+    job.course_node_id = node_id or NODE_ID
     job.arq_job_id = f"arq:{job.id}"
     job.current_stage = None
     job.stage_progress = None

--- a/tests/unit/test_api/test_job_status.py
+++ b/tests/unit/test_api/test_job_status.py
@@ -192,10 +192,18 @@ class TestGetJobTenantIsolation:
 # ── POST /api/v1/jobs/{job_id}/reactivate ─────────────────────────
 
 
-def _make_failed_ingest_job(*, node_id: uuid.UUID | None = None) -> MagicMock:
-    """Failed ``ingest`` job with input_params sufficient for the dispatcher."""
+def _make_failed_ingest_job(
+    *, node_id: uuid.UUID | None = None, job_type: str = "ingest"
+) -> MagicMock:
+    """Failed Job with ``input_params`` sufficient for the ingest dispatcher.
+
+    ``job_type`` defaults to ``"ingest"`` (the happy-path dispatcher arm);
+    pass another string to exercise the unsupported-type branch directly
+    instead of patching the attribute on the returned mock.
+    """
     job = _make_job_mock(
         status="failed",
+        job_type=job_type,
         node_id=node_id or uuid.uuid4(),
         error_message="boom",
         completed_at=datetime.now(UTC),
@@ -297,8 +305,7 @@ class TestReactivateJobInputParamsMissing:
 
     async def test_unsupported_job_type_returns_422(self, client: AsyncClient) -> None:
         """job_type outside the dispatcher's match set → 422 with supported list."""
-        job = _make_failed_ingest_job()
-        job.job_type = "unknown_future_type"
+        job = _make_failed_ingest_job(job_type="unknown_future_type")
         with (
             patch.object(JobRepository, "get_by_id_for_tenant", return_value=job),
             patch.object(JobRepository, "reactivate", return_value=job),

--- a/tests/unit/test_api/test_job_status.py
+++ b/tests/unit/test_api/test_job_status.py
@@ -44,7 +44,7 @@ def _make_job_mock(
     job.status = status
     job.tenant_id = uuid.uuid4()
     job.course_id = None  # removed field
-    job.materialnode_id = node_id
+    job.course_node_id = node_id
     job.arq_job_id = arq_job_id
     job.current_stage = None
     job.stage_progress = None

--- a/tests/unit/test_api/test_job_status.py
+++ b/tests/unit/test_api/test_job_status.py
@@ -35,7 +35,6 @@ def _make_job_mock(
     queued_at: datetime | None = None,
     started_at: datetime | None = None,
     completed_at: datetime | None = None,
-    estimated_at: datetime | None = None,
 ) -> MagicMock:
     """Create a mock Job ORM object."""
     job = MagicMock()
@@ -47,12 +46,13 @@ def _make_job_mock(
     job.course_id = None  # removed field
     job.materialnode_id = node_id
     job.arq_job_id = arq_job_id
+    job.current_stage = None
+    job.stage_progress = None
     job.result_data = None
     job.error_message = error_message
     job.queued_at = queued_at or datetime.now(UTC)
     job.started_at = started_at
     job.completed_at = completed_at
-    job.estimated_at = estimated_at
     return job
 
 

--- a/tests/unit/test_api/test_job_status.py
+++ b/tests/unit/test_api/test_job_status.py
@@ -1,14 +1,14 @@
-"""Tests for GET /api/v1/jobs/{job_id}."""
+"""Tests for GET /api/v1/jobs/{job_id} and POST /api/v1/jobs/{job_id}/reactivate."""
 
 import uuid
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from course_supporter.api.app import app
-from course_supporter.api.deps import get_current_tenant
+from course_supporter.api.deps import get_arq_redis, get_current_tenant
 from course_supporter.auth.context import TenantContext
 from course_supporter.storage.database import get_session
 from course_supporter.storage.job_repository import JobRepository
@@ -58,13 +58,26 @@ def _make_job_mock(
 
 @pytest.fixture()
 def mock_session() -> MagicMock:
-    return MagicMock()
+    session = MagicMock()
+    # commit() is awaited by the reactivate route at the end of the handler
+    session.commit = AsyncMock()
+    return session
 
 
 @pytest.fixture()
-async def client(mock_session: MagicMock) -> AsyncClient:
+def mock_arq() -> MagicMock:
+    arq = MagicMock()
+    enqueued = MagicMock()
+    enqueued.job_id = "arq:new:reactivated"
+    arq.enqueue_job = AsyncMock(return_value=enqueued)
+    return arq
+
+
+@pytest.fixture()
+async def client(mock_session: MagicMock, mock_arq: MagicMock) -> AsyncClient:
     app.dependency_overrides[get_session] = lambda: mock_session
     app.dependency_overrides[get_current_tenant] = lambda: STUB_TENANT
+    app.dependency_overrides[get_arq_redis] = lambda: mock_arq
     async with AsyncClient(
         transport=ASGITransport(app=app),
         base_url="http://test",
@@ -174,3 +187,122 @@ class TestGetJobTenantIsolation:
         ) as mock_get:
             await client.get(f"/api/v1/jobs/{job.id}")
         mock_get.assert_called_once_with(job.id, STUB_TENANT.tenant_id)
+
+
+# ── POST /api/v1/jobs/{job_id}/reactivate ─────────────────────────
+
+
+def _make_failed_ingest_job(*, node_id: uuid.UUID | None = None) -> MagicMock:
+    """Failed ``ingest`` job with input_params sufficient for the dispatcher."""
+    job = _make_job_mock(
+        status="failed",
+        node_id=node_id or uuid.uuid4(),
+        error_message="boom",
+        completed_at=datetime.now(UTC),
+    )
+    job.input_params = {
+        "material_id": str(uuid.uuid4()),
+        "source_type": "web",
+        "source_url": "https://example.com",
+    }
+    return job
+
+
+class TestReactivateJobHappyPath:
+    """POST /jobs/{id}/reactivate — success returns 200 + enqueues new ARQ task."""
+
+    async def test_returns_200_for_failed_job(
+        self, client: AsyncClient, mock_arq: MagicMock
+    ) -> None:
+        """Failed job → 200 with updated JobResponse + ARQ enqueue called once."""
+        job = _make_failed_ingest_job()
+        with (
+            patch.object(JobRepository, "get_by_id_for_tenant", return_value=job),
+            patch.object(JobRepository, "reactivate", return_value=job),
+            patch.object(JobRepository, "set_arq_job_id", return_value=None),
+        ):
+            response = await client.post(f"/api/v1/jobs/{job.id}/reactivate")
+        assert response.status_code == 200
+        assert response.json()["id"] == str(job.id)
+        # Exactly one ARQ task enqueued — no duplicate dispatch
+        mock_arq.enqueue_job.assert_called_once()
+
+    async def test_arq_called_with_resolved_function_and_args(
+        self, client: AsyncClient, mock_arq: MagicMock
+    ) -> None:
+        """``ingest`` dispatcher calls ``arq_ingest_material`` with positional args."""
+        job = _make_failed_ingest_job()
+        with (
+            patch.object(JobRepository, "get_by_id_for_tenant", return_value=job),
+            patch.object(JobRepository, "reactivate", return_value=job),
+            patch.object(JobRepository, "set_arq_job_id", return_value=None),
+        ):
+            await client.post(f"/api/v1/jobs/{job.id}/reactivate")
+
+        call_args = mock_arq.enqueue_job.call_args
+        assert call_args.args[0] == "arq_ingest_material"
+        # First positional arg after function name is jid (str)
+        assert call_args.args[1] == str(job.id)
+
+
+class TestReactivateJobNotFound:
+    """404 / 422 / 409 error branches."""
+
+    async def test_missing_job_returns_404(self, client: AsyncClient) -> None:
+        """Job not found (or tenant mismatch) → 404."""
+        with patch.object(JobRepository, "get_by_id_for_tenant", return_value=None):
+            response = await client.post(f"/api/v1/jobs/{uuid.uuid4()}/reactivate")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Job not found"
+
+    async def test_invalid_uuid_returns_422(self, client: AsyncClient) -> None:
+        """Invalid UUID in path → 422 from FastAPI's path parser."""
+        response = await client.post("/api/v1/jobs/not-a-uuid/reactivate")
+        assert response.status_code == 422
+
+    async def test_non_failed_state_returns_409(self, client: AsyncClient) -> None:
+        """``reactivate`` raises ValueError → 409 (wrong state)."""
+        job = _make_failed_ingest_job()
+        # Repo returns the job (so it's visible), but reactivate rejects it
+        with (
+            patch.object(JobRepository, "get_by_id_for_tenant", return_value=job),
+            patch.object(
+                JobRepository,
+                "reactivate",
+                side_effect=ValueError("Cannot reactivate Job ... in state 'queued'"),
+            ),
+        ):
+            response = await client.post(f"/api/v1/jobs/{job.id}/reactivate")
+        assert response.status_code == 409
+        assert "Cannot reactivate" in response.json()["detail"]
+
+
+class TestReactivateJobInputParamsMissing:
+    """Dispatcher 422 — Job exists and is failed but input_params incomplete."""
+
+    async def test_missing_required_input_param_returns_422(
+        self, client: AsyncClient
+    ) -> None:
+        """Stripped input_params → dispatcher KeyError → HTTPException(422)."""
+        job = _make_failed_ingest_job()
+        # Strip a key the ingest dispatcher requires
+        job.input_params = {"material_id": str(uuid.uuid4())}
+        with (
+            patch.object(JobRepository, "get_by_id_for_tenant", return_value=job),
+            patch.object(JobRepository, "reactivate", return_value=job),
+        ):
+            response = await client.post(f"/api/v1/jobs/{job.id}/reactivate")
+        assert response.status_code == 422
+        assert "input_params missing" in response.json()["detail"]
+
+    async def test_unsupported_job_type_returns_422(self, client: AsyncClient) -> None:
+        """job_type outside the dispatcher's match set → 422 with supported list."""
+        job = _make_failed_ingest_job()
+        job.job_type = "unknown_future_type"
+        with (
+            patch.object(JobRepository, "get_by_id_for_tenant", return_value=job),
+            patch.object(JobRepository, "reactivate", return_value=job),
+        ):
+            response = await client.post(f"/api/v1/jobs/{job.id}/reactivate")
+        assert response.status_code == 422
+        assert "Reactivate not supported" in response.json()["detail"]

--- a/tests/unit/test_api/test_reconciliation_routes.py
+++ b/tests/unit/test_api/test_reconciliation_routes.py
@@ -49,12 +49,13 @@ def _make_job(
     job.tenant_id = STUB_TENANT.tenant_id
     job.materialnode_id = NODE_ID
     job.arq_job_id = f"arq:{job.id}"
+    job.current_stage = None
+    job.stage_progress = None
     job.result_data = None
     job.error_message = None
     job.queued_at = NOW
     job.started_at = None
     job.completed_at = None
-    job.estimated_at = None
     return job
 
 

--- a/tests/unit/test_api/test_reconciliation_routes.py
+++ b/tests/unit/test_api/test_reconciliation_routes.py
@@ -47,7 +47,7 @@ def _make_job(
     job.priority = "normal"
     job.status = status
     job.tenant_id = STUB_TENANT.tenant_id
-    job.materialnode_id = NODE_ID
+    job.course_node_id = NODE_ID
     job.arq_job_id = f"arq:{job.id}"
     job.current_stage = None
     job.stage_progress = None
@@ -413,6 +413,9 @@ class TestReconcileApply:
 
         assert resp.status_code == 200
         data = resp.json()
+        # NOTE: EditableTreeResponse.materialnode_id refers to
+        # StructureNodeEditable.materialnode_id, not Job.course_node_id.
+        # Renames for that field are Phase 1.1 (MaterialNode → CourseNode).
         assert data["materialnode_id"] == str(NODE_ID)
 
     async def test_422_no_accepted_issues(self, client: AsyncClient) -> None:

--- a/tests/unit/test_conflict_detection.py
+++ b/tests/unit/test_conflict_detection.py
@@ -20,7 +20,7 @@ def _mock_job(
     """Create a mock Job with id and node_id."""
     job = MagicMock()
     job.id = job_id or uuid.uuid4()
-    job.materialnode_id = node_id
+    job.course_node_id = node_id
     return job
 
 

--- a/tests/unit/test_enqueue.py
+++ b/tests/unit/test_enqueue.py
@@ -59,7 +59,7 @@ class TestEnqueueIngestion:
         create_kwargs = repo_cls.return_value.create.call_args.kwargs
         assert create_kwargs["job_type"] == "ingest"
         assert create_kwargs["tenant_id"] == tenant_id
-        assert create_kwargs["materialnode_id"] == node_id
+        assert create_kwargs["course_node_id"] == node_id
         assert create_kwargs["priority"] == "normal"
 
     async def test_enqueues_with_correct_args(self) -> None:
@@ -195,7 +195,7 @@ class TestEnqueueGeneration:
         create_kwargs = repo_cls.return_value.create.call_args.kwargs
         assert create_kwargs["job_type"] == "generate_structure"
         assert create_kwargs["tenant_id"] == tenant_id
-        assert create_kwargs["materialnode_id"] == target_node_id
+        assert create_kwargs["course_node_id"] == target_node_id
         assert create_kwargs["depends_on"] == deps
         assert create_kwargs["input_params"]["root_node_id"] == str(root_node_id)
         assert create_kwargs["input_params"]["target_node_id"] == str(target_node_id)
@@ -259,7 +259,7 @@ class TestEnqueueGeneration:
 
         create_kwargs = repo_cls.return_value.create.call_args.kwargs
         # effective_node_id falls back to root_node_id when target is None
-        assert create_kwargs["materialnode_id"] == root_node_id
+        assert create_kwargs["course_node_id"] == root_node_id
         assert create_kwargs["input_params"]["target_node_id"] is None
 
     async def test_sets_arq_job_id(self) -> None:
@@ -333,7 +333,7 @@ class TestEnqueueStep:
         kw = repo_cls.return_value.create.call_args.kwargs
         assert kw["job_type"] == "reconcile"
         assert kw["tenant_id"] == tenant_id
-        assert kw["materialnode_id"] == target_id
+        assert kw["course_node_id"] == target_id
         assert kw["input_params"]["step_type"] == "reconcile"
         assert kw["input_params"]["mode"] == "guided"
 

--- a/tests/unit/test_job_cancellation_checker.py
+++ b/tests/unit/test_job_cancellation_checker.py
@@ -1,0 +1,99 @@
+"""Unit tests for JobCancellationChecker (vision §3 KD13)."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from course_supporter.jobs.cancellation import (
+    JobCancellationChecker,
+    JobCancelledError,
+)
+
+
+def _make_session_returning(status: str | None) -> AsyncMock:
+    """Build an AsyncSession mock whose execute().scalar_one_or_none() == status."""
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=status)
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+class TestIsCancelled:
+    """JobCancellationChecker.is_cancelled returns True for cancelled or missing."""
+
+    async def test_queued_returns_false(self) -> None:
+        chk = JobCancellationChecker(_make_session_returning("queued"))
+        assert await chk.is_cancelled(uuid.uuid4()) is False
+
+    async def test_running_returns_false(self) -> None:
+        chk = JobCancellationChecker(_make_session_returning("running"))
+        assert await chk.is_cancelled(uuid.uuid4()) is False
+
+    async def test_completed_returns_false(self) -> None:
+        chk = JobCancellationChecker(_make_session_returning("completed"))
+        assert await chk.is_cancelled(uuid.uuid4()) is False
+
+    async def test_cancelled_returns_true(self) -> None:
+        chk = JobCancellationChecker(_make_session_returning("cancelled"))
+        assert await chk.is_cancelled(uuid.uuid4()) is True
+
+    async def test_missing_row_returns_true(self) -> None:
+        """Missing Job (scalar_one_or_none → None) treated as cancelled."""
+        chk = JobCancellationChecker(_make_session_returning(None))
+        assert await chk.is_cancelled(uuid.uuid4()) is True
+
+
+class TestRaiseIfCancelled:
+    """raise_if_cancelled raises JobCancelledError with reason field."""
+
+    async def test_queued_does_not_raise(self) -> None:
+        chk = JobCancellationChecker(_make_session_returning("queued"))
+        await chk.raise_if_cancelled(uuid.uuid4())  # no-op
+
+    async def test_running_does_not_raise(self) -> None:
+        chk = JobCancellationChecker(_make_session_returning("running"))
+        await chk.raise_if_cancelled(uuid.uuid4())  # no-op
+
+    async def test_cancelled_raises_with_status_reason(self) -> None:
+        job_id = uuid.uuid4()
+        chk = JobCancellationChecker(_make_session_returning("cancelled"))
+        with pytest.raises(JobCancelledError) as exc_info:
+            await chk.raise_if_cancelled(job_id)
+        assert exc_info.value.job_id == job_id
+        assert exc_info.value.reason == "status=cancelled"
+
+    async def test_missing_raises_with_not_found_reason(self) -> None:
+        job_id = uuid.uuid4()
+        chk = JobCancellationChecker(_make_session_returning(None))
+        with pytest.raises(JobCancelledError) as exc_info:
+            await chk.raise_if_cancelled(job_id)
+        assert exc_info.value.job_id == job_id
+        assert exc_info.value.reason == "row not found"
+
+
+class TestJobCancelledError:
+    """JobCancelledError carries job_id + reason and formats nicely."""
+
+    def test_attributes_accessible(self) -> None:
+        jid = uuid.uuid4()
+        err = JobCancelledError(jid, "status=cancelled")
+        assert err.job_id == jid
+        assert err.reason == "status=cancelled"
+
+    def test_str_includes_id_and_reason(self) -> None:
+        jid = uuid.uuid4()
+        err = JobCancelledError(jid, "row not found")
+        assert str(jid) in str(err)
+        assert "row not found" in str(err)
+
+    def test_subclasses_exception(self) -> None:
+        """Honest signal type — workers can catch with except JobCancelledError.
+
+        Specifically NOT BaseException (asyncio.CancelledError model);
+        JobCancelledError should be catchable by user-friendly except patterns.
+        """
+        assert issubclass(JobCancelledError, Exception)

--- a/tests/unit/test_job_cancellation_service.py
+++ b/tests/unit/test_job_cancellation_service.py
@@ -1,0 +1,100 @@
+"""Unit tests for JobCancellationService input/contract surface.
+
+SQL semantics (OR-of-paths lookup, status filter, deleted_at filter,
+idempotency) are covered against real PostgreSQL in
+``tests/integration/test_job_cancellation_service_db.py``. This file
+locks down the API contract so cascade engine bindings stay valid.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+from course_supporter.jobs.cancellation_service import JobCancellationService
+from course_supporter.storage.cascade import OnCancelJobs
+
+
+class TestEmptyInput:
+    async def test_empty_entity_ids_noop(self) -> None:
+        """Empty entity_ids returns immediately without DB calls."""
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.flush = AsyncMock()
+
+        svc = JobCancellationService(session)
+        result = await svc.cancel_jobs_for_entities([])
+
+        # Empty input must not touch the session at all
+        session.execute.assert_not_called()
+        session.flush.assert_not_called()
+        # And must return None (not an empty list etc.)
+        assert result is None
+
+
+class TestSignatureContract:
+    """cancel_jobs_for_entities matches the OnCancelJobs callable shape.
+
+    Cascade engine invokes the hook with one positional ``list[UUID]``
+    argument (no kwargs). The service's bound method must satisfy that
+    shape so it can be passed directly as ``on_cancel_jobs=...``.
+    """
+
+    async def test_callable_with_only_positional_arg(self) -> None:
+        """Bound method invocable with positional list[UUID] only."""
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.flush = AsyncMock()
+
+        svc = JobCancellationService(session)
+        # Cascade-engine-style invocation: positional list, no kwargs
+        await svc.cancel_jobs_for_entities([])
+
+    def test_bound_method_satisfies_on_cancel_jobs_protocol(self) -> None:
+        """The bound method must be assignable to the OnCancelJobs alias.
+
+        This is the binding shape Phase 1+ entity tasks use::
+
+            cascade_service.soft_delete_with_cascade(
+                ..., on_cancel_jobs=svc.cancel_jobs_for_entities,
+            )
+
+        Locking it down here prevents accidental signature drift breaking
+        all future cascade wiring at once.
+        """
+        session = AsyncMock()
+        svc = JobCancellationService(session)
+        hook: OnCancelJobs = svc.cancel_jobs_for_entities
+        assert callable(hook)
+
+    async def test_now_kwarg_optional_for_test_determinism(self) -> None:
+        """``now`` is keyword-only with default None; cascade never passes it.
+
+        Test code can supply ``now`` explicitly for deterministic timestamps,
+        but production cascade callers omit it.
+        """
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.flush = AsyncMock()
+
+        svc = JobCancellationService(session)
+        # Both invocations must work identically on empty input
+        await svc.cancel_jobs_for_entities([])
+        await svc.cancel_jobs_for_entities([], now=datetime(2026, 1, 1, tzinfo=UTC))
+
+
+class TestReturnType:
+    async def test_returns_none(self) -> None:
+        """Hook returns None — never a list/dict/etc.
+
+        Locked down because cascade engine ignores the return value;
+        a non-None return would suggest the API conveys data when it
+        does not (the side-effect is the whole point).
+        """
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.flush = AsyncMock()
+
+        svc = JobCancellationService(session)
+        empty_result = await svc.cancel_jobs_for_entities([])
+        assert empty_result is None

--- a/tests/unit/test_job_model.py
+++ b/tests/unit/test_job_model.py
@@ -15,7 +15,7 @@ class TestJobModel:
         expected = {
             "id",
             "tenant_id",
-            "materialnode_id",
+            "course_node_id",
             "job_type",
             "priority",
             "status",
@@ -44,7 +44,7 @@ class TestJobModel:
         for idx in Job.__table__.indexes:
             for col in idx.columns:
                 indexed_cols.add(col.name)
-        assert "materialnode_id" in indexed_cols
+        assert "course_node_id" in indexed_cols
         assert "status" in indexed_cols
         assert "tenant_id" in indexed_cols
 

--- a/tests/unit/test_job_model.py
+++ b/tests/unit/test_job_model.py
@@ -21,12 +21,13 @@ class TestJobModel:
             "status",
             "arq_job_id",
             "input_params",
+            "current_stage",
+            "stage_progress",
             "depends_on",
             "error_message",
             "queued_at",
             "started_at",
             "completed_at",
-            "estimated_at",
         }
         assert expected.issubset(columns)
 

--- a/tests/unit/test_s3012_node_based_routing.py
+++ b/tests/unit/test_s3012_node_based_routing.py
@@ -388,7 +388,7 @@ class TestEnqueueGenerationEffectiveNodeId:
             )
 
         create_kw = repo_cls.return_value.create.call_args.kwargs
-        assert create_kw["materialnode_id"] == target_id
+        assert create_kw["course_node_id"] == target_id
 
     async def test_none_target_uses_root(self) -> None:
         """When target_node_id=None, Job.node_id = root_node_id."""
@@ -423,7 +423,7 @@ class TestEnqueueGenerationEffectiveNodeId:
             )
 
         create_kw = repo_cls.return_value.create.call_args.kwargs
-        assert create_kw["materialnode_id"] == root_id
+        assert create_kw["course_node_id"] == root_id
 
     async def test_input_params_store_both_ids(self) -> None:
         """input_params stores root_node_id and target_node_id separately."""
@@ -489,7 +489,7 @@ def _mock_job(
 ) -> MagicMock:
     job = MagicMock()
     job.id = uuid.uuid4()
-    job.materialnode_id = node_id
+    job.course_node_id = node_id
     return job
 
 

--- a/tests/unit/test_s3_cleanup_task.py
+++ b/tests/unit/test_s3_cleanup_task.py
@@ -1,0 +1,142 @@
+"""Unit tests for s3_cleanup_task (vision §3 KD13).
+
+Covers the three-tier error policy from the worker module:
+
+* ``ClientError`` with ``NoSuchKey`` / ``404`` / ``NotFound`` →
+  counted as deleted (idempotent).
+* Other ``ClientError`` (e.g. ``AccessDenied``, throttling
+  ``SlowDown``) → recorded per-key in ``errors[]``; task continues.
+* Non-``ClientError`` (e.g. ``EndpointConnectionError``) → propagates
+  so ARQ's existing retry policy fires.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from botocore.exceptions import ClientError, EndpointConnectionError
+
+from course_supporter.workers.s3_cleanup import s3_cleanup_task
+
+
+def _make_client_error(code: str) -> ClientError:
+    """Build a ClientError carrying the given AWS error code."""
+    return ClientError(
+        error_response={"Error": {"Code": code, "Message": "mocked"}},
+        operation_name="DeleteObject",
+    )
+
+
+def _make_ctx(s3_mock: AsyncMock) -> dict[str, Any]:
+    return {"s3_client": s3_mock}
+
+
+class TestEmpty:
+    async def test_empty_file_keys_returns_noop(self) -> None:
+        """Empty input short-circuits without calling S3 at all."""
+        s3 = AsyncMock()
+        s3.delete_object = AsyncMock()
+        result = await s3_cleanup_task(
+            _make_ctx(s3), file_keys=[], job_id=str(uuid.uuid4())
+        )
+        assert result == {"deleted": [], "errors": []}
+        s3.delete_object.assert_not_called()
+
+
+class TestHappyPath:
+    async def test_all_keys_deleted_in_order(self) -> None:
+        s3 = AsyncMock()
+        s3.delete_object = AsyncMock(return_value=None)
+        keys = ["a", "b", "c"]
+        result = await s3_cleanup_task(
+            _make_ctx(s3), file_keys=keys, job_id=str(uuid.uuid4())
+        )
+        assert result["deleted"] == keys
+        assert result["errors"] == []
+        assert s3.delete_object.call_count == 3
+
+
+class TestIdempotency:
+    """Missing S3 object is success per KD13 (cross-provider variants)."""
+
+    async def test_no_such_key_counted_as_deleted(self) -> None:
+        s3 = AsyncMock()
+        s3.delete_object = AsyncMock(side_effect=_make_client_error("NoSuchKey"))
+        result = await s3_cleanup_task(
+            _make_ctx(s3), file_keys=["missing"], job_id=str(uuid.uuid4())
+        )
+        assert result["deleted"] == ["missing"]
+        assert result["errors"] == []
+
+    async def test_404_code_counted_as_deleted(self) -> None:
+        """B2 / S3-compatible providers may return code='404' instead."""
+        s3 = AsyncMock()
+        s3.delete_object = AsyncMock(side_effect=_make_client_error("404"))
+        result = await s3_cleanup_task(
+            _make_ctx(s3), file_keys=["x"], job_id=str(uuid.uuid4())
+        )
+        assert result["deleted"] == ["x"]
+        assert result["errors"] == []
+
+    async def test_not_found_code_counted_as_deleted(self) -> None:
+        s3 = AsyncMock()
+        s3.delete_object = AsyncMock(side_effect=_make_client_error("NotFound"))
+        result = await s3_cleanup_task(
+            _make_ctx(s3), file_keys=["x"], job_id=str(uuid.uuid4())
+        )
+        assert result["deleted"] == ["x"]
+        assert result["errors"] == []
+
+
+class TestPerKeyClientError:
+    """Other ClientError codes recorded per-key; task does not abort."""
+
+    async def test_access_denied_in_errors_others_continue(self) -> None:
+        """Mid-batch ClientError doesn't abort — surrounding keys still process."""
+        s3 = AsyncMock()
+
+        async def side_effect(key: str) -> None:
+            if key == "denied":
+                raise _make_client_error("AccessDenied")
+
+        s3.delete_object = AsyncMock(side_effect=side_effect)
+
+        result = await s3_cleanup_task(
+            _make_ctx(s3),
+            file_keys=["ok1", "denied", "ok2"],
+            job_id=str(uuid.uuid4()),
+        )
+        assert result["deleted"] == ["ok1", "ok2"]
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["key"] == "denied"
+        assert "AccessDenied" in result["errors"][0]["error"]
+
+    async def test_throttling_slowdown_recorded_as_error(self) -> None:
+        """Throttling-coded ClientError lands in errors[] (ARQ retry triggers
+        only on non-ClientError; throttling without retry-friendly resolution
+        becomes operator-visible via Job.result_data)."""
+        s3 = AsyncMock()
+        s3.delete_object = AsyncMock(side_effect=_make_client_error("SlowDown"))
+        result = await s3_cleanup_task(
+            _make_ctx(s3), file_keys=["t"], job_id=str(uuid.uuid4())
+        )
+        assert result["deleted"] == []
+        assert len(result["errors"]) == 1
+        assert "SlowDown" in result["errors"][0]["error"]
+
+
+class TestPropagation:
+    """Non-ClientError exceptions propagate so ARQ's retry policy fires."""
+
+    async def test_endpoint_connection_error_propagates(self) -> None:
+        s3 = AsyncMock()
+        s3.delete_object = AsyncMock(
+            side_effect=EndpointConnectionError(endpoint_url="http://example.com")
+        )
+        with pytest.raises(EndpointConnectionError):
+            await s3_cleanup_task(
+                _make_ctx(s3), file_keys=["x"], job_id=str(uuid.uuid4())
+            )


### PR DESCRIPTION
## Task 0.3 — Job Model Redesign

Closes #397

Реалізація vision §3 KD13 — повна переробка моделі `Job`: нова структура полів, перейменування FK-колонки, інфраструктура для cooperative cancel cascade, retry-via-reactivate workflow, async S3 cleanup worker.

## Що зроблено

8 інкрементальних commits, кожен individually-revertable:

| # | Commit | Опис |
|---|---|---|
| (a) | `7760dfc` | Додано `current_stage` + `stage_progress` JSONB; видалено `estimated_at` |
| (b) | `2ce6bc6` | Перейменовано `materialnode_id` → `course_node_id` (column + FK + index); оновлено всі call-sites |
| (c) | `6906c3b` | Додано `JobType` StrEnum + application-level валідація через `validate_job_type()` |
| (d) | `645ad4d` | Cooperative cancel mechanism — `JobCancellationChecker` + `JobCancelledError` |
| (e) | `74fa8ab` | Реалізація `on_cancel_jobs` cascade hook — `JobCancellationService` |
| (f) | `87004f5` | Reactivate workflow — `JobRepository.reactivate()` + `POST /api/v1/jobs/{id}/reactivate` |
| (g) | `a7a0d6a` | `s3_cleanup` ARQ worker з three-tier error policy |
| (h) | `de6baf8` | Повний test suite — 25 unit + 19 integration + 12 extension тестів |

## Vision references

- `refactoring-vision/vision.md` §3 KD13 (повна Job-специфікація)
- `refactoring-vision/vision.md` §3 KD3 + KD12 (cascade context)
- `refactoring-vision/vision.md` §5 Phase 0 row 0.3

## Detailed POST-MR-NOTES

`refactoring-vision/sprint/tasks/0.3-job-model-redesign/POST-MR-NOTES.md`

Включає 8 секцій: built (8 commits), 3 deviations (depends_on / DB CHECK / status drift — всі deferred до Phase 2.x з обгрунтуванням), 5 нових insights, 6 forward-looking notes для Phase 1+/2.x, pain points, vision-side sign-off.

## Scope deviations (узгоджені у pre-flight)

Три зміни scope, всі — **відкладення** ризикованих змін:

- **`Job.depends_on` НЕ дропнуто.** 25+ live references у `methodist_orchestrator` + `generation_orchestrator` (Job-graph orchestration). Дроп — частина Phase 2.x rewrite.
- **DB CHECK на `job_type` НЕ додано.** Нуль перетину між поточними значеннями (`ingest`, `generate_structure`, `methodist_*`, etc.) і KD13-enum (4 значення). DB CHECK зламав би всі тести. Application-level валідація через `validate_job_type()` — bridging layer до Phase 2.x.
- **Status name drift `active` vs `running` НЕ виправлено.** `_IN_PROGRESS_STATUSES = (queued, running, active)` — transitional. Phase 2.x rename.

## Forward-looking notes (для майбутніх tasks)

1. **Phase 1+ cascade scrub policy** має зберегти `Job.input_params` — `s3_cleanup` worker читає `file_keys` з task args, не з DB.
2. **GIN index на `Job.input_params`** — defer до Phase 2.x (telemetry-driven).
3. **Status name alignment** (`active` → `running`) — окремий chore або Phase 2.x.
4. **DB CHECK на `job_type`** — після callsite migration у Phase 2.x.
5. **Worker integration `JobCancellationChecker`** — Phase 2.x wiring у pipeline workers.
6. **`_resolve_reenqueue` 6-case match** колапсує до 4-case match у Phase 2.x.

## Pre-existing rot resolved

3 failing тести у `tests/integration/test_enqueue_redis.py` мали два bugs одночасно: wrong fixture key (`course_id` замість `course_node_id`) + missing `tenant_id` parameter. Обидва виправлено разом з rename — тести тепер passing.

## Quality gates

- ✅ ruff check src/ tests/ — clean
- ✅ mypy --strict src/ — 144 source files (+5 нових), no issues
- ✅ pytest — 1890 passed, 38 skipped, 0 regressions
- ✅ alembic up → down → up — round-trip clean
- ✅ Schema verified via `\d+ jobs` у psql
- ✅ Smoke tests проти live PostgreSQL для всіх critical paths
- ✅ Endpoint tests через FastAPI test client + ARQ mock

## Test coverage