### PR TITLE
task(0.7): optional date filter on cost endpoints with tenant fallback

### DIFF
--- a/src/course_supporter/api/routes/cost.py
+++ b/src/course_supporter/api/routes/cost.py
@@ -9,12 +9,23 @@ Two read-only endpoints scoped to the calling tenant via the API key:
 Both responses are cached in Redis for 5 minutes (
 :data:`cost_cache.TTL_SECONDS`); ``?no_cache=true`` bypasses both read
 and write paths (admin/debug helper, hidden from OpenAPI).
+
+## Optional date range (0.7)
+
+``from`` / ``to`` are optional. When omitted, lower bound resolves to
+``Tenant.created_at`` (cast to ``date``) and upper bound to
+``datetime.now(UTC).date()``. Resolution happens in-handler via the
+existing session dependency, *not* by extending ``TenantContext``: the
+fallback is needed only on these two cost endpoints, so a one-row
+lookup keeps the auth context lean (KD-B: YAGNI). Cache keys carry
+the resolved values so a "no params" request collides with the
+explicit-dates request that produces the same bounds (KD-F).
 """
 
 from __future__ import annotations
 
 import uuid
-from datetime import date
+from datetime import UTC, date, datetime
 from typing import Annotated
 
 import structlog
@@ -42,6 +53,7 @@ from course_supporter.services.cost_cache import (
 )
 from course_supporter.storage.database import get_session
 from course_supporter.storage.material_node_repository import MaterialNodeRepository
+from course_supporter.storage.orm import Tenant
 from course_supporter.storage.repositories import ExternalServiceCallRepository
 
 logger = structlog.get_logger()
@@ -53,13 +65,48 @@ SharedDep = Annotated[
 ]
 
 
+async def _resolve_date_range(
+    *,
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    from_: date | None,
+    to_: date | None,
+) -> tuple[date, date]:
+    """Resolve optional ``from``/``to`` to concrete date bounds.
+
+    * ``from_ is None`` → load ``Tenant`` by id, cast ``created_at`` to
+      ``date`` (``Tenant.created_at`` is ``DateTime(timezone=True)``;
+      day precision is enough — the lower bound includes the entire
+      day the tenant was created).
+    * ``to_ is None`` → ``datetime.now(UTC).date()``. UTC matches the
+      project-wide ``datetime.now(UTC)`` convention used by every
+      other timestamp callsite (``api/deps.py``, ``api/app.py``,
+      ``storage/*_repository.py``, etc.); ``date.today()`` would
+      silently bind to local timezone.
+
+    The tenant lookup never returns ``None`` in practice because the
+    caller's ``TenantContext`` was already authenticated against the
+    same DB. The ``assert`` narrows the type for ``mypy --strict``
+    rather than papering over a real failure mode.
+    """
+    if from_ is None:
+        tenant_record = await session.get(Tenant, tenant_id)
+        assert tenant_record is not None, (
+            "Tenant must exist when TenantContext was authenticated against the same DB"
+        )
+        from_ = tenant_record.created_at.date()
+    if to_ is None:
+        to_ = datetime.now(UTC).date()
+    return from_, to_
+
+
 @router.get("/cost/summary", response_model=CostSummaryResponse)
 async def get_cost_summary(
     tenant: SharedDep,
     session: Annotated[AsyncSession, Depends(get_session)],
     redis: Annotated[ArqRedis, Depends(get_arq_redis)],
-    from_: Annotated[date, Query(alias="from")],
-    to_: Annotated[date, Query(alias="to")],
+    from_: Annotated[date | None, Query(alias="from")] = None,
+    to_: Annotated[date | None, Query(alias="to")] = None,
     limit_courses: Annotated[int, Query(ge=0, le=500)] = 50,
     offset_courses: Annotated[int, Query(ge=0)] = 0,
     limit_providers: Annotated[int, Query(ge=0, le=500)] = 50,
@@ -67,6 +114,11 @@ async def get_cost_summary(
     no_cache: Annotated[bool, Query(include_in_schema=False)] = False,
 ) -> CostSummaryResponse:
     """Tenant-wide cost summary for the requested date range.
+
+    ``from``/``to`` are optional — see module docstring for fallback
+    semantics. The ``from > to`` guard runs on resolved values so the
+    ordering invariant survives both omitted-params and explicit-params
+    callers identically.
 
     The by_course breakdown groups by direct ``Job.course_node_id``
     (Variant D per KD5 §5 row 0.4 deliberation). Jobs targeting
@@ -85,6 +137,12 @@ async def get_cost_summary(
     Phase 1+ follow-up — natural fit alongside the admin-scope work
     that KD5 defers.
     """
+    from_, to_ = await _resolve_date_range(
+        session=session,
+        tenant_id=tenant.tenant_id,
+        from_=from_,
+        to_=to_,
+    )
     if from_ > to_:
         raise HTTPException(status_code=422, detail="from must be <= to")
     if no_cache:
@@ -169,8 +227,8 @@ async def get_cost_course(
     tenant: SharedDep,
     session: Annotated[AsyncSession, Depends(get_session)],
     redis: Annotated[ArqRedis, Depends(get_arq_redis)],
-    from_: Annotated[date, Query(alias="from")],
-    to_: Annotated[date, Query(alias="to")],
+    from_: Annotated[date | None, Query(alias="from")] = None,
+    to_: Annotated[date | None, Query(alias="to")] = None,
     limit_nodes: Annotated[int, Query(ge=0, le=500)] = 50,
     offset_nodes: Annotated[int, Query(ge=0)] = 0,
     limit_actions: Annotated[int, Query(ge=0, le=500)] = 50,
@@ -179,11 +237,20 @@ async def get_cost_course(
 ) -> CourseCostResponse:
     """Cost drill-down for a single course (subtree drill-down).
 
+    ``from``/``to`` are optional with the same fallback semantics as
+    ``/cost/summary`` — see module docstring.
+
     Security: ``?no_cache=true`` always hits the DB and additionally
     re-runs the recursive descendant CTE in ``get_descendant_ids``.
     Same rate-limit boundedness + audit-log story as ``/cost/summary``;
     see that endpoint's docstring.
     """
+    from_, to_ = await _resolve_date_range(
+        session=session,
+        tenant_id=tenant.tenant_id,
+        from_=from_,
+        to_=to_,
+    )
     if from_ > to_:
         raise HTTPException(status_code=422, detail="from must be <= to")
     if no_cache:

--- a/tests/integration/test_cost_endpoints_db.py
+++ b/tests/integration/test_cost_endpoints_db.py
@@ -47,6 +47,11 @@ pytestmark = [pytest.mark.requires_db, pytest.mark.requires_redis]
 PERIOD_FROM = "2026-01-01"
 PERIOD_TO = "2026-12-31"
 SAMPLE_TIMESTAMP = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+# Anchor the seeded Tenant.created_at to a date that precedes
+# SAMPLE_TIMESTAMP so omitted-``from`` requests (which fall back to
+# ``tenant.created_at``) cover the full ESC seed without depending on
+# wall-clock time at test runtime.
+TENANT_CREATED_AT = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture()
@@ -77,7 +82,15 @@ async def cost_seed(
     recursive-CTE descendant path covering all three nodes.
     """
     async with session_factory() as session:
-        tenant = Tenant(name=f"cost-e2e-{uuid.uuid4().hex[:6]}")
+        # Pin ``created_at`` so the 0.7 omitted-``from`` fallback
+        # (resolved to ``tenant.created_at.date()``) is deterministic
+        # and precedes ``SAMPLE_TIMESTAMP`` — otherwise the DB
+        # server-default ``now()`` would produce a tenant younger than
+        # the seeded ESCs and exclude them from the all-time aggregate.
+        tenant = Tenant(
+            name=f"cost-e2e-{uuid.uuid4().hex[:6]}",
+            created_at=TENANT_CREATED_AT,
+        )
         session.add(tenant)
         await session.flush()
 
@@ -542,3 +555,58 @@ class TestCostCourseE2E:
                     Tenant.__table__.delete().where(Tenant.id == intruder_tenant_id)
                 )
                 await session.commit()
+
+
+# ── Optional date filter (0.7) ─────────────────────────────────────
+
+
+class TestCostEndpointsFallbackE2E:
+    """Omitted ``from``/``to`` resolves to ``[tenant.created_at, today]``.
+
+    The seed pins ``Tenant.created_at`` to ``TENANT_CREATED_AT``
+    (2026-01-01) and ``ExternalServiceCall.created_at`` to
+    ``SAMPLE_TIMESTAMP`` (2026-04-01), so the resolved range covers
+    every seeded ESC regardless of wall-clock time at test runtime.
+    The endpoint's ``to`` fallback is real ``datetime.now(UTC).date()``
+    (no monkeypatch in integration suite) — assertions only require
+    that ``to`` is on or after the seeded ESC date.
+    """
+
+    async def test_summary_no_params_returns_full_aggregate(
+        self, cost_client: AsyncClient, cost_seed: dict[str, object]
+    ) -> None:
+        response = await cost_client.get(
+            "/api/v1/cost/summary",
+            params={"no_cache": "true"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        # Resolved bounds reach the response body via Pydantic alias.
+        assert data["from"] == str(TENANT_CREATED_AT.date())
+        assert data["to"] >= str(SAMPLE_TIMESTAMP.date())
+        # Aggregate matches the explicit-dates baseline (KD-F: same
+        # logical period regardless of how it was specified).
+        assert data["total_usd"] == pytest.approx(cost_seed["expected_total"])
+        assert data["unattributed_cost_usd"] == pytest.approx(
+            cost_seed["expected_unattributed"]
+        )
+
+    async def test_course_no_params_returns_full_subtree(
+        self, cost_client: AsyncClient, cost_seed: dict[str, object]
+    ) -> None:
+        response = await cost_client.get(
+            f"/api/v1/cost/course/{cost_seed['root_id']}",
+            params={"no_cache": "true"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["from"] == str(TENANT_CREATED_AT.date())
+        assert data["to"] >= str(SAMPLE_TIMESTAMP.date())
+        # Subtree total = root (85) + lesson (30) + concept (25) = 140.
+        assert data["total_usd"] == pytest.approx(140.0)
+        node_ids = {n["course_node_id"] for n in data["by_node"]}
+        assert node_ids == {
+            str(cost_seed["root_id"]),
+            str(cost_seed["lesson_id"]),
+            str(cost_seed["concept_id"]),
+        }

--- a/tests/unit/test_api/test_cost_routes.py
+++ b/tests/unit/test_api/test_cost_routes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,6 +23,7 @@ from course_supporter.api.routes import cost as cost_module
 from course_supporter.auth.context import TenantContext
 from course_supporter.storage.database import get_session
 from course_supporter.storage.material_node_repository import MaterialNodeRepository
+from course_supporter.storage.orm import Tenant
 from course_supporter.storage.repositories import (
     ByActionRow,
     ByCourseRow,
@@ -147,8 +149,9 @@ class TestCostSummaryValidation:
         ("params", "expected_msg"),
         [
             # Pydantic-shaped 422s — actual v2 message strings.
-            ({"to": "2026-04-28"}, "Field required"),  # missing from
-            ({"from": "2026-01-01"}, "Field required"),  # missing to
+            # NOTE: missing-`from` and missing-`to` cases removed in 0.7
+            # — both are now optional with tenant-scoped fallback. See
+            # TestCostSummaryFallback for the new contract.
             (
                 {"from": "2026-01-01", "to": "2026-04-28", "limit_courses": "501"},
                 "Input should be less than or equal to 500",
@@ -356,8 +359,9 @@ class TestCostCourseValidation:
         ("params", "expected_msg"),
         [
             # Pydantic-shaped 422s — actual v2 message strings.
-            ({"to": "2026-04-28"}, "Field required"),  # missing from
-            ({"from": "2026-01-01"}, "Field required"),  # missing to
+            # NOTE: missing-`from` and missing-`to` cases removed in 0.7
+            # — both are now optional with tenant-scoped fallback. See
+            # TestCostCourseFallback for the new contract.
             (
                 {"from": "2026-01-01", "to": "2026-04-28", "limit_nodes": "501"},
                 "Input should be less than or equal to 500",
@@ -432,3 +436,252 @@ class TestCostCourseCache:
         node_mock.assert_awaited_once()
         descendants_mock.assert_not_awaited()
         set_cached_mock.assert_not_awaited()
+
+
+# ── Optional date filter (0.7) ─────────────────────────────────────
+
+
+# Fallback tests use a deterministic Tenant.created_at and a frozen
+# clock so cache keys + response shapes are reproducible. The Tenant
+# lookup is wired into ``app.dependency_overrides[get_session]`` rather
+# than mocked at the helper boundary — exercising the same code path
+# the request handler runs in production (KD-B: in-handler resolution).
+TENANT_CREATED_AT = datetime(2026, 1, 1, 10, 30, 0, tzinfo=UTC)
+FROZEN_NOW = datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC)
+
+
+class _FrozenClock:
+    """Drop-in replacement for ``datetime`` exposing a fixed ``now``.
+
+    Only ``now`` is stubbed — every other ``datetime`` use in
+    ``cost.py`` would have to come from this class too, but the
+    handler only calls ``datetime.now(UTC)``. Using ``__future__``
+    annotations across the project means runtime type lookups won't
+    hit this stub.
+    """
+
+    @classmethod
+    def now(cls, tz: Any = None) -> datetime:
+        return FROZEN_NOW.astimezone(tz) if tz is not None else FROZEN_NOW
+
+
+@pytest.fixture()
+async def client_with_tenant_session() -> AsyncGenerator[AsyncClient]:
+    """Client whose ``session.get(Tenant, ...)`` returns a fixed Tenant.
+
+    Mirrors the production wiring (real ``AsyncSession.get`` is awaitable)
+    by using ``AsyncMock`` on ``.get`` rather than the bare ``MagicMock``
+    used by the broader ``client`` fixture. Other repo calls in the
+    handler are independently patched per-test.
+    """
+    mock_tenant = MagicMock(spec=Tenant)
+    mock_tenant.created_at = TENANT_CREATED_AT
+
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=mock_tenant)
+
+    app.dependency_overrides[get_session] = lambda: mock_session
+    app.dependency_overrides[get_current_tenant] = lambda: STUB_TENANT
+    app.dependency_overrides[get_arq_redis] = lambda: MagicMock()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+class TestCostSummaryFallback:
+    """``/cost/summary`` with optional ``from``/``to`` (KD-A through KD-F)."""
+
+    async def test_omitted_from_uses_tenant_created_at(
+        self,
+        client_with_tenant_session: AsyncClient,
+        patched_summary_repo: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(cost_module, "datetime", _FrozenClock)
+        with (
+            patched_summary_repo,
+            patch.object(cost_module, "get_cached", AsyncMock(return_value=None)),
+            patch.object(cost_module, "set_cached", AsyncMock()),
+        ):
+            response = await client_with_tenant_session.get(
+                "/api/v1/cost/summary",
+                params={"to": "2026-04-28"},
+            )
+            # ``patch.multiple`` with pre-supplied AsyncMock kwargs
+            # yields an empty mapping on enter, so capture await args
+            # via the patched class attribute *inside* the ``with``
+            # block (the patch is reverted at exit).
+            get_total = ExternalServiceCallRepository.get_total_for_period
+            kwargs = get_total.await_args.kwargs
+        assert response.status_code == 200
+        # Resolved ``from`` must reach the repo as ``2026-01-01``
+        # (TENANT_CREATED_AT.date()), not as None.
+        assert kwargs["from_date"] == TENANT_CREATED_AT.date()
+        assert str(kwargs["to_date"]) == "2026-04-28"
+
+    async def test_omitted_to_uses_now_utc_date(
+        self,
+        client_with_tenant_session: AsyncClient,
+        patched_summary_repo: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(cost_module, "datetime", _FrozenClock)
+        with (
+            patched_summary_repo,
+            patch.object(cost_module, "get_cached", AsyncMock(return_value=None)),
+            patch.object(cost_module, "set_cached", AsyncMock()),
+        ):
+            response = await client_with_tenant_session.get(
+                "/api/v1/cost/summary",
+                params={"from": "2026-02-01"},
+            )
+            get_total = ExternalServiceCallRepository.get_total_for_period
+            kwargs = get_total.await_args.kwargs
+        assert response.status_code == 200
+        assert str(kwargs["from_date"]) == "2026-02-01"
+        # Resolved ``to`` is the frozen UTC date, not local ``today``.
+        assert kwargs["to_date"] == FROZEN_NOW.date()
+
+    async def test_both_omitted_uses_full_fallback(
+        self,
+        client_with_tenant_session: AsyncClient,
+        patched_summary_repo: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(cost_module, "datetime", _FrozenClock)
+        with (
+            patched_summary_repo,
+            patch.object(cost_module, "get_cached", AsyncMock(return_value=None)),
+            patch.object(cost_module, "set_cached", AsyncMock()),
+        ):
+            response = await client_with_tenant_session.get("/api/v1/cost/summary")
+            get_total = ExternalServiceCallRepository.get_total_for_period
+            kwargs = get_total.await_args.kwargs
+        assert response.status_code == 200
+        data = response.json()
+        # Response body echoes the resolved bounds (Pydantic alias).
+        assert data["from"] == str(TENANT_CREATED_AT.date())
+        assert data["to"] == str(FROZEN_NOW.date())
+        assert kwargs["from_date"] == TENANT_CREATED_AT.date()
+        assert kwargs["to_date"] == FROZEN_NOW.date()
+
+    async def test_cache_key_invariant_no_params_equals_explicit_resolved(
+        self,
+        client_with_tenant_session: AsyncClient,
+        patched_summary_repo: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """KD-F: cache keys for "no params" and "explicit resolved dates" match.
+
+        Two requests against the same logical period (one omits the
+        bounds, the other passes them explicitly) must produce identical
+        cache keys — otherwise UI clients that sometimes omit params and
+        sometimes pass tenant-relative dates would see ghost cache misses.
+        """
+        monkeypatch.setattr(cost_module, "datetime", _FrozenClock)
+        observed_keys: list[str] = []
+
+        async def _capture(_redis: Any, key: str, _value: str) -> None:
+            observed_keys.append(key)
+
+        with (
+            patched_summary_repo,
+            patch.object(cost_module, "get_cached", AsyncMock(return_value=None)),
+            patch.object(cost_module, "set_cached", AsyncMock(side_effect=_capture)),
+        ):
+            r1 = await client_with_tenant_session.get("/api/v1/cost/summary")
+            r2 = await client_with_tenant_session.get(
+                "/api/v1/cost/summary",
+                params={
+                    "from": str(TENANT_CREATED_AT.date()),
+                    "to": str(FROZEN_NOW.date()),
+                },
+            )
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert len(observed_keys) == 2
+        first, second = observed_keys
+        assert first == second, f"Cache-key invariant violated: {first!r} != {second!r}"
+
+
+class TestCostCourseFallback:
+    """``/cost/course/{id}`` with optional ``from``/``to`` (KD-A through KD-F)."""
+
+    async def test_omitted_from_uses_tenant_created_at(
+        self,
+        client_with_tenant_session: AsyncClient,
+        patched_course_repo: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(cost_module, "datetime", _FrozenClock)
+        node_get, descendants, repo_methods_ctx = patched_course_repo
+        with (
+            node_get,
+            descendants,
+            repo_methods_ctx,
+            patch.object(cost_module, "get_cached", AsyncMock(return_value=None)),
+            patch.object(cost_module, "set_cached", AsyncMock()),
+        ):
+            response = await client_with_tenant_session.get(
+                f"/api/v1/cost/course/{COURSE_ID}",
+                params={"to": "2026-04-28"},
+            )
+            get_total = ExternalServiceCallRepository.get_total_for_subtree
+            kwargs = get_total.await_args.kwargs
+        assert response.status_code == 200
+        assert kwargs["from_date"] == TENANT_CREATED_AT.date()
+        assert str(kwargs["to_date"]) == "2026-04-28"
+
+    async def test_omitted_to_uses_now_utc_date(
+        self,
+        client_with_tenant_session: AsyncClient,
+        patched_course_repo: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(cost_module, "datetime", _FrozenClock)
+        node_get, descendants, repo_methods_ctx = patched_course_repo
+        with (
+            node_get,
+            descendants,
+            repo_methods_ctx,
+            patch.object(cost_module, "get_cached", AsyncMock(return_value=None)),
+            patch.object(cost_module, "set_cached", AsyncMock()),
+        ):
+            response = await client_with_tenant_session.get(
+                f"/api/v1/cost/course/{COURSE_ID}",
+                params={"from": "2026-02-01"},
+            )
+            get_total = ExternalServiceCallRepository.get_total_for_subtree
+            kwargs = get_total.await_args.kwargs
+        assert response.status_code == 200
+        assert str(kwargs["from_date"]) == "2026-02-01"
+        assert kwargs["to_date"] == FROZEN_NOW.date()
+
+    async def test_both_omitted_uses_full_fallback(
+        self,
+        client_with_tenant_session: AsyncClient,
+        patched_course_repo: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(cost_module, "datetime", _FrozenClock)
+        node_get, descendants, repo_methods_ctx = patched_course_repo
+        with (
+            node_get,
+            descendants,
+            repo_methods_ctx,
+            patch.object(cost_module, "get_cached", AsyncMock(return_value=None)),
+            patch.object(cost_module, "set_cached", AsyncMock()),
+        ):
+            response = await client_with_tenant_session.get(
+                f"/api/v1/cost/course/{COURSE_ID}",
+            )
+            get_total = ExternalServiceCallRepository.get_total_for_subtree
+            kwargs = get_total.await_args.kwargs
+        assert response.status_code == 200
+        data = response.json()
+        assert data["from"] == str(TENANT_CREATED_AT.date())
+        assert data["to"] == str(FROZEN_NOW.date())
+        assert kwargs["from_date"] == TENANT_CREATED_AT.date()
+        assert kwargs["to_date"] == FROZEN_NOW.date()


### PR DESCRIPTION
## Summary

  Both `/api/v1/cost/summary` and `/api/v1/cost/course/{course_node_id}` now accept omitted `from`/`to` query parameters. Lower bound resolves to
  `Tenant.created_at` via an in-handler session lookup (KD-B: not via `TenantContext` extension); upper bound resolves to `datetime.now(UTC).date()` per
  project-wide convention. Cache keys carry resolved values so a "no-params" request collides with the explicit-dates request producing the same bounds (KD-F
  invariant locked by inline unit test).

  ## Changes

  - **`src/course_supporter/api/routes/cost.py`** — both endpoint signatures switch `from_`/`to_` to `date | None = None`; new private `_resolve_date_range` helper
   shared by both endpoints; module docstring documents the optional contract.
  - **`tests/unit/test_api/test_cost_routes.py`** — drop the two missing-param 422 cases per endpoint; add `TestCostSummaryFallback` (4 tests incl. cache-key
  invariant) and `TestCostCourseFallback` (3 tests); `_FrozenClock` + `client_with_tenant_session` fixture.
  - **`tests/integration/test_cost_endpoints_db.py`** — pin `Tenant.created_at` in `cost_seed` so the omitted-`from` fallback covers seeded ESCs; add
  `TestCostEndpointsFallbackE2E` (2 tests, one per endpoint).

  ## Quality gates

  - 38/38 cost tests pass (27 unit + 11 integration).
  - `mypy --strict` clean across 171 source files.
  - `ruff check` + `ruff format` clean.
  - All pre-commit hooks pass.

  ## Test plan

  - [x] Unit: `uv run pytest tests/unit/test_api/test_cost_routes.py`
  - [x] Integration: `uv run pytest tests/integration/test_cost_endpoints_db.py --run-db --run-redis`
  - [x] Type-check: `uv run mypy src/ tests/unit/security/`
  - [x] Lint/format: `uv run ruff check src/course_supporter/api/routes/cost.py tests/unit/test_api/test_cost_routes.py
  tests/integration/test_cost_endpoints_db.py`