### PR TITLE
Phase 1 x cleanup backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,6 @@ logs:  ## Показати логи сервісів
 
 ps:  ## Статус сервісів
 	docker compose ps
+
+psql:  ## Відкрити psql shell у postgres контейнері
+	docker compose exec postgres psql -U $${POSTGRES_USER:-course_supporter} -d $${POSTGRES_DB:-course_supporter}

--- a/src/course_supporter/api/routes/documents.py
+++ b/src/course_supporter/api/routes/documents.py
@@ -58,7 +58,7 @@ from course_supporter.storage.cascade import CascadeDeleteService, build_cascade
 from course_supporter.storage.content_hash import ContentHashService
 from course_supporter.storage.course_node_repository import CourseNodeRepository
 from course_supporter.storage.orm import AuthoredDocument
-from course_supporter.storage.s3 import S3Client, upload_file_chunks
+from course_supporter.storage.s3 import S3Client, sanitize_s3_key, upload_file_chunks
 
 logger = structlog.get_logger()
 
@@ -206,7 +206,8 @@ async def create_document(
     if file is not None:
         if actual_filename is None:
             actual_filename = file.filename
-        key = f"{node_id}/{uuid.uuid4()}/{actual_filename or 'upload'}"
+        safe_name = sanitize_s3_key(actual_filename or "upload")
+        key = f"{node_id}/{uuid.uuid4()}/{safe_name}"
         content_type = file.content_type or "application/octet-stream"
         actual_url, uploaded_bytes = await s3.upload_smart(
             stream=upload_file_chunks(file),
@@ -294,7 +295,8 @@ async def get_upload_url(
 
     await _require_node_for_tenant(session, tenant.tenant_id, node_id)
 
-    key = f"tenants/{tenant.tenant_id}/nodes/{node_id}/{uuid.uuid4()}/{body.filename}"
+    safe_name = sanitize_s3_key(body.filename)
+    key = f"tenants/{tenant.tenant_id}/nodes/{node_id}/{uuid.uuid4()}/{safe_name}"
 
     upload_url = await s3.generate_presigned_url(
         key, body.content_type, expires_in=PRESIGNED_URL_EXPIRY
@@ -342,7 +344,7 @@ async def confirm_upload(
         )
 
     actual_filename = body.filename or body.key.rsplit("/", 1)[-1]
-    s3_url = f"{s3._endpoint_url}/{s3._bucket}/{body.key}"
+    s3_url = s3.get_object_url(body.key)
 
     document_repo = AuthoredDocumentRepository(session)
     document = await document_repo.create(

--- a/src/course_supporter/api/routes/nodes.py
+++ b/src/course_supporter/api/routes/nodes.py
@@ -38,7 +38,7 @@ from course_supporter.api.schemas import (
     NodeResponse,
     NodeTreeResponse,
     NodeUpdateRequest,
-    NodeWithMaterialsResponse,
+    NodeWithDocumentsResponse,
 )
 from course_supporter.auth.context import TenantContext
 from course_supporter.auth.registry import AuthScope
@@ -231,7 +231,7 @@ async def get_node_detail(
     node_id: uuid.UUID,
     tenant: SharedDep,
     session: SessionDep,
-) -> NodeWithMaterialsResponse:
+) -> NodeWithDocumentsResponse:
     """Get the full subtree with materials attached to each node.
 
     Returns the hierarchical view including materials at each level
@@ -246,7 +246,7 @@ async def get_node_detail(
     tree_roots = await repo.get_subtree_with_active_documents(node_id)
     if not tree_roots:
         raise HTTPException(status_code=404, detail="Node not found")
-    return NodeWithMaterialsResponse.model_validate(tree_roots[0])
+    return NodeWithDocumentsResponse.model_validate(tree_roots[0])
 
 
 # ── Single node operations ──

--- a/src/course_supporter/api/routes/storage.py
+++ b/src/course_supporter/api/routes/storage.py
@@ -137,7 +137,7 @@ async def delete_file(
         raise HTTPException(status_code=403, detail="Key does not belong to tenant.")
 
     # Look up the AuthoredDocument (if any) referencing this S3 URL.
-    s3_url = f"{s3._endpoint_url}/{s3._bucket}/{key}"
+    s3_url = s3.get_object_url(key)
     document_repo = AuthoredDocumentRepository(session)
     document = await document_repo.get_by_source_url(s3_url)
 

--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -252,7 +252,7 @@ class AuthoredDocumentSummaryResponse(BaseModel):
     created_at: datetime = Field(description="When this entry was created.")
 
 
-class NodeWithMaterialsResponse(BaseModel):
+class NodeWithDocumentsResponse(BaseModel):
     """Recursive tree node with attached materials.
 
     Used in tree detail to provide the full hierarchical view
@@ -273,7 +273,7 @@ class NodeWithMaterialsResponse(BaseModel):
         description="Authored documents attached directly to this node.",
         validation_alias="documents",
     )
-    children: list[NodeWithMaterialsResponse] = Field(
+    children: list[NodeWithDocumentsResponse] = Field(
         default_factory=list,
         description="Child nodes, recursively nested.",
     )

--- a/src/course_supporter/storage/s3.py
+++ b/src/course_supporter/storage/s3.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import tempfile
 from collections.abc import AsyncIterator
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from types import TracebackType
 from typing import Any
 from urllib.parse import urlparse
@@ -21,6 +21,20 @@ logger = structlog.get_logger()
 MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024  # 10 MB
 MULTIPART_THRESHOLD = 50 * 1024 * 1024  # 50 MB
 DOWNLOAD_CHUNK_SIZE = 64 * 1024  # 64 KB
+
+
+def sanitize_s3_key(filename: str) -> str:
+    """Strip directory components from a filename for safe S3 key composition.
+
+    Prevents path traversal: inputs like ``../../etc/passwd`` collapse to
+    ``passwd``. Empty or dot-only names (``""``, ``"."``, ``".."``) fall
+    back to ``upload``. POSIX-only semantics — backslash is preserved
+    verbatim (S3 allows it in keys).
+    """
+    name = PurePosixPath(filename).name
+    if not name or name in {".", ".."}:
+        return "upload"
+    return name
 
 
 class S3Client:
@@ -84,6 +98,14 @@ class S3Client:
         """Close the S3 client context."""
         await self.close()
 
+    def get_object_url(self, key: str) -> str:
+        """Return the path-style URL for an S3 object key.
+
+        Encapsulates the ``endpoint/bucket/key`` composition so callers
+        do not reach into private attributes of S3Client.
+        """
+        return f"{self._endpoint_url}/{self._bucket}/{key}"
+
     async def upload_file(
         self,
         key: str,
@@ -110,7 +132,7 @@ class S3Client:
             Body=data,
             ContentType=content_type,
         )
-        url = f"{self._endpoint_url}/{self._bucket}/{key}"
+        url = self.get_object_url(key)
         logger.info("s3_upload", key=key, content_type=content_type)
         return url
 
@@ -245,7 +267,7 @@ class S3Client:
 
         # Large or unknown size — streaming multipart
         total = await self.upload_stream(stream, key, content_type)
-        url = f"{self._endpoint_url}/{self._bucket}/{key}"
+        url = self.get_object_url(key)
         return url, total
 
     def extract_key(self, url: str) -> str | None:

--- a/tests/_helpers/kd3_marker.py
+++ b/tests/_helpers/kd3_marker.py
@@ -1,0 +1,53 @@
+"""KD3 cascade soft-delete marker test helpers.
+
+Shared regex + tolerance + assertion helper for the KD3 author-content
+scrub marker contract (vision §3 KD3, Amendment 23 + 24). Consumers:
+
+- ``tests/unit/test_cascade_delete_service.py::TestKD3MarkerFormat`` —
+  unit-level scrub callable contract.
+- ``tests/storage/test_cascade_invalidation.py`` — cascade-engine
+  integration with real DB.
+
+Update this module on contract changes; both consumer suites pick
+up the new format atomically.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+
+MARKER_REGEX = (
+    r"^інформація видалена автором "
+    r"(\d{2})-(\d{2})-(\d{4}) "
+    r"(\d{2}):(\d{2}):(\d{2})$"
+)
+TIMESTAMP_TOLERANCE_SECONDS = 5
+
+
+def parse_marker_timestamp(marker: str) -> datetime:
+    """Parse the embedded timestamp from a KD3 marker string."""
+    match = re.match(MARKER_REGEX, marker)
+    assert match is not None, f"Marker did not match contract: {marker!r}"
+    day, month, year, hour, minute, second = match.groups()
+    return datetime(
+        int(year),
+        int(month),
+        int(day),
+        int(hour),
+        int(minute),
+        int(second),
+        tzinfo=UTC,
+    )
+
+
+def assert_marker_recent(value: str) -> None:
+    """Assert ``value`` matches the KD3 marker contract with a recent
+    timestamp (within ``TIMESTAMP_TOLERANCE_SECONDS`` of now).
+    """
+    parsed = parse_marker_timestamp(value)
+    drift = abs((datetime.now(UTC) - parsed).total_seconds())
+    assert drift <= TIMESTAMP_TOLERANCE_SECONDS, (
+        f"Marker timestamp drift {drift}s exceeds tolerance "
+        f"{TIMESTAMP_TOLERANCE_SECONDS}s"
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -125,9 +125,8 @@ async def committed_seeds(
     Returns dict with ``tenant_id``, ``course_node_id``, ``material_id``.
     The ``course_node_id`` key matches the v0.20 column name on
     ``Job.course_node_id`` (KD13 — renamed from legacy
-    ``course_node_id`` in task 0.3); the underlying row is still a
-    ``CourseNode`` and will be re-typed to ``CourseNode`` only in
-    Phase 1.1. Cleans up after the test via DELETE in reverse FK order.
+    ``materialnode_id`` in task 0.3). Cleans up after the test via
+    DELETE in reverse FK order.
     """
     async with session_factory() as session:
         tenant = Tenant(name=f"test-tenant-{uuid.uuid4().hex[:8]}")
@@ -159,10 +158,8 @@ async def committed_seeds(
 
     yield ids
 
-    # Cleanup: delete in reverse FK order. Note that
-    # ``AuthoredDocument.course_node_id`` and ``CourseNode.id`` are
-    # still legacy column names — they get renamed in Phase 1.1
-    # along with the table-level CourseNode → CourseNode rename.
+    # Cleanup: delete in reverse FK order following the
+    # ``AuthoredDocument.course_node_id → CourseNode.id`` FK chain.
     async with session_factory() as session:
         await session.execute(
             Job.__table__.delete().where(Job.course_node_id == ids["course_node_id"])

--- a/tests/storage/test_cascade_invalidation.py
+++ b/tests/storage/test_cascade_invalidation.py
@@ -33,10 +33,8 @@ rule #13 — atomic commits over artificial bisect-separation.
 
 from __future__ import annotations
 
-import re
 import uuid
 from collections.abc import AsyncGenerator
-from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -63,47 +61,7 @@ from course_supporter.storage.orm import (
     Job,
     Tenant,
 )
-
-# ── KD3 marker contract helpers (duplicated from canonical site) ──
-#
-# Canonical regex + recency assertion live in
-# ``tests/unit/test_cascade_delete_service.py::TestKD3MarkerFormat``
-# (unit-level scrub callable contract). Duplicated here because this
-# file exercises a different concern (cascade-engine integration)
-# and the regex is small enough to keep inline rather than extract
-# a shared test-helper module. Update both sites in lock-step on
-# contract changes (Amendment 23/24 anchor).
-
-_MARKER_REGEX = (
-    r"^інформація видалена автором "
-    r"(\d{2})-(\d{2})-(\d{4}) "
-    r"(\d{2}):(\d{2}):(\d{2})$"
-)
-_TIMESTAMP_TOLERANCE_SECONDS = 5
-
-
-def _assert_marker_recent(value: str) -> None:
-    """Assert ``value`` matches the KD3 marker contract with a recent
-    timestamp (within ``_TIMESTAMP_TOLERANCE_SECONDS`` of now).
-    """
-    match = re.match(_MARKER_REGEX, value)
-    assert match is not None, f"Value did not match marker contract: {value!r}"
-    day, month, year, hour, minute, second = match.groups()
-    parsed = datetime(
-        int(year),
-        int(month),
-        int(day),
-        int(hour),
-        int(minute),
-        int(second),
-        tzinfo=UTC,
-    )
-    drift = abs((datetime.now(UTC) - parsed).total_seconds())
-    assert drift <= _TIMESTAMP_TOLERANCE_SECONDS, (
-        f"Marker timestamp drift {drift}s exceeds tolerance "
-        f"{_TIMESTAMP_TOLERANCE_SECONDS}s"
-    )
-
+from tests._helpers.kd3_marker import assert_marker_recent
 
 # ── Unit-level: scrub_authored_document field semantics ───────────
 
@@ -128,7 +86,7 @@ class TestScrubAuthoredDocument:
         await scrub_authored_document(doc)
 
         assert doc.filename is not None
-        _assert_marker_recent(doc.filename)
+        assert_marker_recent(doc.filename)
 
     async def test_scrub_writes_marker_to_source_url(self) -> None:
         doc = _StubDocument(
@@ -138,7 +96,7 @@ class TestScrubAuthoredDocument:
 
         await scrub_authored_document(doc)
 
-        _assert_marker_recent(doc.source_url)
+        assert_marker_recent(doc.source_url)
 
     async def test_scrub_idempotent_re_stamps_marker(self) -> None:
         """Idempotency under the marker contract means a second scrub
@@ -151,8 +109,8 @@ class TestScrubAuthoredDocument:
         await scrub_authored_document(doc)
 
         assert doc.filename is not None
-        _assert_marker_recent(doc.filename)
-        _assert_marker_recent(doc.source_url)
+        assert_marker_recent(doc.filename)
+        assert_marker_recent(doc.source_url)
 
     async def test_scrub_does_not_touch_unrelated_attributes(self) -> None:
         """Scrub list is exactly ``filename`` + ``source_url`` — other
@@ -185,8 +143,8 @@ class TestScrubAuthoredDocument:
         assert doc.filename != "x.mp4"
         assert doc.source_url != ""
         assert doc.source_url != "https://example.com/x.mp4"
-        _assert_marker_recent(doc.filename)
-        _assert_marker_recent(doc.source_url)
+        assert_marker_recent(doc.filename)
+        assert_marker_recent(doc.source_url)
 
 
 class _StubDocument:
@@ -522,12 +480,12 @@ class TestCascadeScrubCompleteness:
                 assert node.title is not None, (
                     f"CourseNode {node_id} title unexpectedly NULL"
                 )
-                _assert_marker_recent(node.title)
+                assert_marker_recent(node.title)
                 assert node.description is not None, (
                     f"CourseNode {node_id} description unexpectedly NULL "
                     f"(Amendment 24 ruling: nullable column receives marker)"
                 )
-                _assert_marker_recent(node.description)
+                assert_marker_recent(node.description)
 
             # AuthoredDocument descendant scrubbed + soft-deleted.
             persisted_doc = await session.get(AuthoredDocument, doc_id)
@@ -538,8 +496,8 @@ class TestCascadeScrubCompleteness:
                 f"(Amendment 24 ruling: nullable column receives marker): "
                 f"{persisted_doc.filename!r}"
             )
-            _assert_marker_recent(persisted_doc.filename)
-            _assert_marker_recent(persisted_doc.source_url)
+            assert_marker_recent(persisted_doc.filename)
+            assert_marker_recent(persisted_doc.source_url)
 
         await _cleanup_tenant(gap3_session_factory, [tenant_id])
 

--- a/tests/unit/test_api/test_reconciliation_routes.py
+++ b/tests/unit/test_api/test_reconciliation_routes.py
@@ -416,7 +416,6 @@ class TestReconcileApply:
         data = resp.json()
         # NOTE: EditableTreeResponse.course_node_id refers to
         # StructureNodeEditable.course_node_id, not Job.course_node_id.
-        # Renames for that field are Phase 1.1 (CourseNode → CourseNode).
         assert data["course_node_id"] == str(NODE_ID)
 
     async def test_422_no_accepted_issues(self, client: AsyncClient) -> None:

--- a/tests/unit/test_cascade_delete_service.py
+++ b/tests/unit/test_cascade_delete_service.py
@@ -14,6 +14,7 @@ from course_supporter.storage.cascade import (
     SoftDeletableEntity,
     build_cascade_map,
 )
+from tests._helpers.kd3_marker import assert_marker_recent
 
 # ── Fakes: minimal soft-deletable entities (no SQLAlchemy involved) ─
 
@@ -918,42 +919,6 @@ class TestKD3MarkerFormat:
     Amendment 24 (hotfix-4 disposition: marker overrides nullability).
     """
 
-    _MARKER_REGEX: ClassVar[str] = (
-        r"^інформація видалена автором "
-        r"(\d{2})-(\d{2})-(\d{4}) "
-        r"(\d{2}):(\d{2}):(\d{2})$"
-    )
-    _TIMESTAMP_TOLERANCE_SECONDS: ClassVar[int] = 5
-
-    @staticmethod
-    def _parse_marker_timestamp(marker: str) -> datetime:
-        """Parse the embedded timestamp from a marker string."""
-        import re
-
-        match = re.match(TestKD3MarkerFormat._MARKER_REGEX, marker)
-        assert match is not None, f"Marker did not match contract: {marker!r}"
-        day, month, year, hour, minute, second = match.groups()
-        return datetime(
-            int(year),
-            int(month),
-            int(day),
-            int(hour),
-            int(minute),
-            int(second),
-            tzinfo=UTC,
-        )
-
-    def _assert_marker_recent(self, marker: str) -> None:
-        """Assert the marker timestamp is within tolerance of now."""
-        parsed = self._parse_marker_timestamp(marker)
-        now = datetime.now(UTC)
-        drift = abs((now - parsed).total_seconds())
-        assert drift <= self._TIMESTAMP_TOLERANCE_SECONDS, (
-            f"Marker timestamp drift {drift}s exceeds tolerance "
-            f"{self._TIMESTAMP_TOLERANCE_SECONDS}s "
-            f"(parsed={parsed}, now={now})"
-        )
-
     async def test_format_helper_emits_kd3_marker_with_default_now(self) -> None:
         """``_format_deleted_marker()`` with no argument computes its
         own ``datetime.now(UTC)`` and returns the contract format.
@@ -961,7 +926,7 @@ class TestKD3MarkerFormat:
         from course_supporter.storage.cascade import _format_deleted_marker
 
         marker = _format_deleted_marker()
-        self._assert_marker_recent(marker)
+        assert_marker_recent(marker)
 
     async def test_format_helper_honors_provided_now(self) -> None:
         """``_format_deleted_marker(now=...)`` uses the supplied
@@ -981,7 +946,7 @@ class TestKD3MarkerFormat:
         node.title = "Original Course Title"
         node.description = "Original description text"
         await scrub_course_node(node)
-        self._assert_marker_recent(node.title)
+        assert_marker_recent(node.title)
 
     async def test_scrub_course_node_stamps_description_with_marker(self) -> None:
         """``scrub_course_node`` writes the KD3 marker to ``description``
@@ -994,7 +959,7 @@ class TestKD3MarkerFormat:
         node.title = "Original Course Title"
         node.description = "Original description text"
         await scrub_course_node(node)
-        self._assert_marker_recent(node.description)
+        assert_marker_recent(node.description)
 
     async def test_scrub_course_node_columns_share_marker(self) -> None:
         """Single scrub invocation produces ONE marker reused across
@@ -1022,7 +987,7 @@ class TestKD3MarkerFormat:
         doc.filename = "lecture-01.pdf"
         doc.source_url = "https://s3.example.com/bucket/lecture-01.pdf"
         await scrub_authored_document(doc)
-        self._assert_marker_recent(doc.filename)
+        assert_marker_recent(doc.filename)
 
     async def test_scrub_authored_document_stamps_source_url_with_marker(
         self,
@@ -1036,7 +1001,7 @@ class TestKD3MarkerFormat:
         doc.filename = "lecture-01.pdf"
         doc.source_url = "https://s3.example.com/bucket/lecture-01.pdf"
         await scrub_authored_document(doc)
-        self._assert_marker_recent(doc.source_url)
+        assert_marker_recent(doc.source_url)
 
     async def test_scrub_authored_document_columns_share_marker(self) -> None:
         """Single scrub invocation produces ONE marker reused across

--- a/tests/unit/test_s3_client.py
+++ b/tests/unit/test_s3_client.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from course_supporter.storage.s3 import S3Client
+from course_supporter.storage.s3 import S3Client, sanitize_s3_key
 
 
 class TestS3Client:
@@ -341,3 +341,75 @@ class TestS3Config:
         config: BotoConfig = call_kwargs[1]["config"]
         assert config.signature_version == "s3v4"
         assert config.s3["addressing_style"] == "path"
+
+
+class TestGetObjectUrl:
+    """Tests for S3Client.get_object_url() — public encapsulation method."""
+
+    def test_basic_url(self) -> None:
+        """get_object_url() composes path-style URL from endpoint + bucket + key."""
+        client = S3Client(
+            endpoint_url="https://s3.example.com",
+            access_key="key",
+            secret_key="secret",
+            bucket="course-materials",
+        )
+        url = client.get_object_url("tenants/abc/file.pdf")
+        assert url == "https://s3.example.com/course-materials/tenants/abc/file.pdf"
+
+    def test_endpoint_trailing_slash_stripped(self) -> None:
+        """__init__ strips endpoint trailing slash; get_object_url honors it."""
+        client = S3Client(
+            endpoint_url="https://s3.example.com/",
+            access_key="key",
+            secret_key="secret",
+            bucket="bucket",
+        )
+        assert client.get_object_url("k") == "https://s3.example.com/bucket/k"
+
+    def test_special_chars_in_key_preserved(self) -> None:
+        """get_object_url() preserves spaces, unicode, and slashes verbatim."""
+        client = S3Client(
+            endpoint_url="https://s3.local",
+            access_key="key",
+            secret_key="secret",
+            bucket="b",
+        )
+        assert (
+            client.get_object_url("a b/файл.txt") == "https://s3.local/b/a b/файл.txt"
+        )
+
+    def test_empty_key(self) -> None:
+        """get_object_url() returns endpoint/bucket/ for empty key."""
+        client = S3Client(
+            endpoint_url="https://s3.local",
+            access_key="key",
+            secret_key="secret",
+            bucket="b",
+        )
+        assert client.get_object_url("") == "https://s3.local/b/"
+
+
+class TestSanitizeS3Key:
+    """Tests for sanitize_s3_key() — path-traversal defense."""
+
+    @pytest.mark.parametrize(
+        ("filename", "expected"),
+        [
+            ("normal.pdf", "normal.pdf"),
+            ("../../etc/passwd", "passwd"),
+            ("foo/bar/baz.txt", "baz.txt"),
+            ("/absolute/path/file.md", "file.md"),
+            ("", "upload"),
+            (".", "upload"),
+            ("..", "upload"),
+            ("a\\b\\c.pdf", "a\\b\\c.pdf"),
+            ("file with spaces.docx", "file with spaces.docx"),
+            ("документ.txt", "документ.txt"),
+            ("trailing/", "trailing"),
+            ("...hidden", "...hidden"),
+        ],
+    )
+    def test_sanitization(self, filename: str, expected: str) -> None:
+        """sanitize_s3_key() strips dir components and falls back to 'upload'."""
+        assert sanitize_s3_key(filename) == expected


### PR DESCRIPTION
# Phase 1.X — Cleanup bundle (backend)

Phase 1.X cleanup bundle resolving 7 deferred items з Phase 1 POST-MERGE-NOTES §5 та AI ReviewBot Round 1+2 deferred. Single PR з 4 atomic commits, no investigation phase (light cleanup process per CLEANUP-PLAN).

## Items resolved

| Item | Description | Origin |
|---|---|---|
| 5 | S3Client encapsulation — public `get_object_url(key)` method, removed direct access to `_endpoint_url` / `_bucket` from route handlers + DRY internal callers (`upload_file`, `upload_smart`) | AI ReviewBot [2] |
| 8 | Filename sanitization — `sanitize_s3_key(filename)` helper using `PurePosixPath.name` для path traversal prevention; applied у 2 user-derived callsites (`create_document`, `get_upload_url`); skip `confirm_upload` (tenant-prefix-validated body.key) | AI ReviewBot [16] |
| 3 | Amendment 31 — rename `NodeWithMaterialsResponse` → `NodeWithDocumentsResponse` (Pydantic class identifier alignment з KD-ui.3 `authored_documents` JSON contract); 5 callsites across 2 files | Amendment 31 |
| 7 | Doc accuracy fixes у `tests/integration/conftest.py` + `tests/unit/test_api/test_reconciliation_routes.py` — tautology cleanup post-Phase-1 sed pass | AI ReviewBot [10][11][12][13] |
| 9 | DRY refactor — extract `_MARKER_REGEX` + `_assert_marker_recent` до `tests/_helpers/kd3_marker.py` (shared module); replace 14 callsites across 2 test files (5 + 9) | AI ReviewBot [17] |
| 4 | `make psql` target — DB probe convenience using existing `up` target env-fallback convention (`$${POSTGRES_USER:-course_supporter}`) | CHECKPOINT 2 vision-side observation |

## Items dropped

**Item 6 (`router=router` "dead code" у `arq_ingest_material`)** — DROPPED 2026-05-07 as false-positive per own probe.

Receivers verification:
- `create_heavy_steps` (factory.py:74-79) — uses router conditionally.
- `create_vd_pipeline` (factory.py:113-115) — uses router у VDPipeline construction.
- `processor.process_raw` — polymorphic across 5 implementations: `TextProcessor` explicit-ignores per protocol conformance docstring; `VideoProcessor` / `WhisperVideoProcessor` / `LongVideoProcessor` / `PresentationProcessor` / `WebProcessor` all use router для Gemini Vision LLM routing.

Видалення зламало б video + presentation production pipelines. AI ReviewBot [4] = false-positive (limited diff context misclassified polymorphic callsite).

## Items deferred

**Item 3 hotfix-10 (Amendment 35 sub-class 3b — `_collect_ready_documents` runtime-broken block)** — out of scope, separate Phase 1.X candidate per `current-state.md`. Conditional resolution: standalone hotfix if feature activates pre-Phase 5, else deletion alongside `arq_ingest_material` orchestration rewrite у Phase 5.

## Commits

| # | SHA | Subject |
|---|---|---|
| 1 | e3c8f04 | `phase(1.X.backend-1): S3Client encapsulation + filename sanitization` |
| 2 | 93d06a2 | `phase(1.X.backend-2): rename NodeWithMaterialsResponse → NodeWithDocumentsResponse (Amendment 31)` |
| 3 | 6b617ec | `phase(1.X.tests): doc accuracy fixes + DRY refactor _MARKER_REGEX helpers` |
| 4 | 7107059 | `phase(1.X.tooling): add make psql target for DB probe convenience` |

Aggregate: 13 files changed (3 new + 10 modified). 4 commits ahead `origin/dev` 8304870.

## Acceptance evidence

Per-commit quality gates (all green):

- **9 pre-commit hooks** active per commit (varying applicability — Makefile/test commits skip ruff/mypy where no Python touched).
- **mypy --strict** на всіх modified production files: 0 issues. Recursive Pydantic forward-reference у `children: list[NodeWithDocumentsResponse]` resolved cleanly without `model_rebuild()`.
- **ruff format + check**: clean across all touched files.
- **Narrow test sweep** per Amendment 36:
  - backend-1: 59 passed / 0 failed (`tests/unit/test_s3_client.py` + 2 route test files).
  - backend-2: 56 passed / 7 skipped requires_db (`tests/unit/test_api/test_nodes.py` + cascade tests).
  - tests: 58 passed / 0 failed (`tests/unit/test_cascade_delete_service.py` + `tests/storage/test_cascade_invalidation.py`).
  - tooling: manual gate (Makefile change).
- **Verification taxonomy** per Amendment 37: changeset = (a) true fix + new coverage; 0 of (b)/(c)/(d).

## Cross-references

- `phase-1-X/state.md` — full ratification chain + per-sub-area evidence.
- `vision.md` v0.20.2 §3 KD3 (cascade soft-delete) + KD9 (content_hash naming) + Amendment 31 (NodeWithDocumentsResponse rename) + Amendment 35 sub-classifications + Amendment 37 verification taxonomy.
- POST-MERGE-NOTES §5 (Phase 1 deferred debt list) — items 4, 5, 7, 8, 9, 17 closed by this PR; Item 6 closed as false-positive; Item 3/16 (Amendment 31) closed.
- `phase-1-X-CLEANUP-PLAN.md` — bundle scope authoritative reference.

## Process discipline lessons

**Rule #25 candidate (vision-side broad-claim verification) — 5th validation instance:** implementer stale memory anchor про phase ownership ("Phase 5 territory per Amendment 35 sub-class 3a" claim) caught by vision-side STOP-escalate during pre-flight review. Vision.md v0.20.2 explicit Phase 1.1 sub-phase definition — `FingerprintService` collapse IS Phase 1.1, не Phase 5. Fix would have introduced incorrect future-state into previously-correct comments. Rule approaching promotion criteria (validated through Phase 1.X bundle).

**Pattern validated:** "light cleanup PR" template (mini pre-flight ~5 точок per item, atomic commit per Rule #13, push per Rule #6, PR creation HOLD до bundle completion) successful — 4 commits, 0 mid-bundle escalation cycles, 1 vision-side STOP-escalate caught false-positive scope expansion at pre-flight stage (not post-commit).

## OpenAPI impact

Component name shift `NodeWithMaterialsResponse` → `NodeWithDocumentsResponse` у `/openapi.json`. JSON wire shape unchanged (field names + types + `validation_alias="documents"` bridge preserved). UI codebase prepared per KD-ui.8 trail.

## Review request

AI ReviewBot — primary review surface per Phase 1 cadence. Manual review focus areas:
- `S3Client.get_object_url` URL formula correctness (path-style, trailing slash handling).
- `sanitize_s3_key` edge cases (empty / dot-only / Windows-style backslash inputs).
- DRY refactor у `tests/_helpers/kd3_marker.py` — verify zero behavior divergence vs original inline definitions.