### PR TITLE
phase(2.2.audio): wire 150-min hard-reject in process_raw

### DIFF
--- a/src/course_supporter/ingestion/audio.py
+++ b/src/course_supporter/ingestion/audio.py
@@ -92,6 +92,7 @@ from pydantic import ValidationError
 from course_supporter.ingestion.base import (
     MaterialProcessor,
     ProcessingError,
+    UnsupportedFormatError,
 )
 from course_supporter.ingestion.schemas import (
     AudioPass2aResult,
@@ -260,6 +261,13 @@ class AudioProcessor(MaterialProcessor):
                 f"requires word-level alignment per KD-2.2-C. Verify "
                 f"the provider is Scribe v2 or a compatible word-level "
                 f"STT model."
+            )
+
+        duration = result.audio_duration_sec
+        if duration is not None and duration > self.MAX_DURATION_SEC:
+            raise UnsupportedFormatError(
+                f"Audio duration ({duration / 60:.1f} min) exceeds maximum "
+                f"{self.MAX_DURATION_SEC / 60:.0f} min per Phase 2.2 vision §5."
             )
 
         await self._store_words(job_id, result.words)

--- a/tests/unit/test_ingestion/test_audio.py
+++ b/tests/unit/test_ingestion/test_audio.py
@@ -13,7 +13,7 @@ from course_supporter.ingestion.audio import (
     AudioProcessor,
     chars_per_word_cumsum,
 )
-from course_supporter.ingestion.base import ProcessingError
+from course_supporter.ingestion.base import ProcessingError, UnsupportedFormatError
 from course_supporter.ingestion.schemas import (
     AudioPass2aResult,
     AudioSegmentDraft,
@@ -44,7 +44,10 @@ def _word(text: str, start: float, end: float) -> STTWord:
 
 
 def _stt_result(
-    words: list[STTWord], segments: list[STTSegment] | None = None
+    words: list[STTWord],
+    segments: list[STTSegment] | None = None,
+    *,
+    audio_duration_sec: float | None = None,
 ) -> STTResult:
     """Build STTResult mirroring Scribe v2 word-level alignment."""
     if segments is None and words:
@@ -62,6 +65,7 @@ def _stt_result(
         words=words,
         provider="mock-scribe",
         model_id="mock-scribe-v2",
+        audio_duration_sec=audio_duration_sec,
     )
 
 
@@ -294,6 +298,50 @@ class TestProcessRaw:
 
         expected = " ".join(w.text for w in words)
         assert doc.assemble_text() == expected
+
+    async def test_duration_exceeded_raises_unsupported_format(self) -> None:
+        """KD-2.2-D area — audio_duration_sec > MAX raises before cache write."""
+        words = [_word("hi", 0.0, 0.3)]
+        result = _stt_result(words, audio_duration_sec=200 * 60)
+        redis = _mock_redis()
+        proc = AudioProcessor(stt_router=_mock_stt_router(result), redis=redis)
+        set_job_from_arq(uuid.uuid4())
+
+        with pytest.raises(UnsupportedFormatError, match=r"exceeds maximum"):
+            await proc.process_raw(_mock_authored_document())
+
+        # Fail-fast — cache must not be populated on rejected upload.
+        assert redis._store == {}
+
+    async def test_duration_at_exact_boundary_proceeds(self) -> None:
+        """D4 strict `>` — 150 min exactly passes (boundary inclusive)."""
+        words = [_word("hi", 0.0, 0.3)]
+        result = _stt_result(words, audio_duration_sec=150 * 60)
+        proc = AudioProcessor(stt_router=_mock_stt_router(result), redis=_mock_redis())
+        set_job_from_arq(uuid.uuid4())
+
+        doc = await proc.process_raw(_mock_authored_document())
+        assert doc.source_type == SourceType.AUDIO
+
+    async def test_duration_just_over_boundary_raises(self) -> None:
+        """Boundary regression guard — 151 min triggers reject."""
+        words = [_word("hi", 0.0, 0.3)]
+        result = _stt_result(words, audio_duration_sec=151 * 60)
+        proc = AudioProcessor(stt_router=_mock_stt_router(result), redis=_mock_redis())
+        set_job_from_arq(uuid.uuid4())
+
+        with pytest.raises(UnsupportedFormatError, match=r"exceeds maximum"):
+            await proc.process_raw(_mock_authored_document())
+
+    async def test_duration_none_proceeds(self) -> None:
+        """D3 fail-open — None duration skips check (defensive; provider gap)."""
+        words = [_word("hi", 0.0, 0.3)]
+        result = _stt_result(words, audio_duration_sec=None)
+        proc = AudioProcessor(stt_router=_mock_stt_router(result), redis=_mock_redis())
+        set_job_from_arq(uuid.uuid4())
+
+        doc = await proc.process_raw(_mock_authored_document())
+        assert doc.source_type == SourceType.AUDIO
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Closes Phase 2.2 KD-2.2-D constant→check gap: \`MAX_DURATION_SEC = 150 * 60\` was declared у \`audio.py:176\` без enforcement (grep на \`src/\` confirmed unused). Surfaced through Phase 2.2 UI sub-area pre-flight (Pr-5).
- Implements duration check у \`AudioProcessor.process_raw\` per \`refactoring-vision/sprint/phases/phase-2-2/INVESTIGATION.md\` §1.5 P5 step 4: raise \`UnsupportedFormatError\` when \`result.audio_duration_sec > MAX_DURATION_SEC\`, placed after entry guard pass + before cache store (fail-fast; no cache write of rejected upload).
- 4 нових unit tests у \`TestProcessRaw\` covering: exceed (200 min), boundary exact (150 min proceeds), boundary over (151 min raises), None (fail-open per D3 ratify).

## Ratified decisions (vision-side, 2026-05-16)

| ID | Decision |
|---|---|
| D1 | Placement between entry guard pass and cache store. |
| D2 | \`UnsupportedFormatError\` per \`base.py:48\`. |
| D3 | None duration → fail-open (skip check); matches post-Phase-2.2 provider populate guarantee (ElevenLabs + OpenAI STT + Deepgram all populate per sub-area #2 commit \`432f341\`). |
| D4 | Strict \`>\` boundary (150 min exact proceeds; 150.01 min reject). |
| D5 | English message convention per \`text.py\`/\`video.py\` style. |
| D6 | UI scenario v0.1 §2 Flow B wording cleanup — vision-side post-merge responsibility (no code change here). |

## UI surface (post-merge)

\`UnsupportedFormatError\` caught by \`api/tasks.py:353\` generic \`except Exception\` handler → \`callback.on_failure(error_message=str(exc))\` → \`AuthoredDocument.state='error'\` + \`error_message\` populated → UI sees via polling + renders через Phase 2.2 UI sub-area Item #5 (lightweight error_message rendering). **No HTTP 400 response** (async worker; upload returned 201 при POST).

## Test plan

- [x] \`uv run pytest tests/unit/test_ingestion/test_audio.py -v\` — 25 passed (21 baseline + 4 new).
- [x] \`uv run pytest tests/unit/\` — 1926 passed, 5 skipped (baseline 1922 → +4).
- [x] \`uv run mypy src/\` — Success: no issues found in 129 source files.
- [x] \`uv run ruff check src/ tests/\` — All checks passed.
- [x] \`uv run ruff format src/ tests/\` — clean.
- [x] \`uv run pre-commit run\` (на staged 2 files) — clean.
- [ ] Manual integration smoke (operator discretion): upload synthetic 200-min .mp3 via \`ffmpeg -f lavfi -i sine=frequency=440:duration=12000 -ar 44100 lecture.mp3\` → ARQ worker → \`AuthoredDocument.state='error'\` + \`error_message\` visible.

## Notes

- Out-of-scope observation: \`pre-commit run --all-files\` surfaced pre-existing import grouping issue у \`scripts/cost_report.py\`. Reverted that change per commission boundary («only \`audio.py\` + \`test_audio.py\`»). If CI complains, separate cleanup commission.