### PR TITLE
phase(2.3.backend.hotfix): Pass 2a presentation prompt fix + RUN_SMOKE test

### DIFF
--- a/prompts/presentation_pass_2a_mapping/v1.md
+++ b/prompts/presentation_pass_2a_mapping/v1.md
@@ -21,6 +21,8 @@ Respond with **only** a JSON object exactly matching this shape:
 
 ```
 {
+  "title": "<doc-level title summarising the presentation theme, up to 128 chars; or null if the deck has no discernible theme>",
+  "description": "<doc-level description of the presentation subject, 1-3 sentences, up to 512 chars>",
   "segments": [
     {
       "start_slide": <integer, 1-indexed inclusive>,
@@ -39,6 +41,11 @@ Respond with **only** a JSON object exactly matching this shape:
   raw JSON.
 - **No** preamble, no trailing commentary, no explanations outside
   the JSON.
+- The **top-level** `description` is **required**: a 1-3 sentence summary
+  of the whole presentation's subject (≤512 chars), distinct from the
+  per-segment descriptions. The **top-level** `title` summarises the deck's
+  theme (≤128 chars); emit `null` only when the deck has no discernible
+  theme.
 - Slide numbers are **1-indexed inclusive** on both ends.
   `start_slide=3, end_slide=5` covers slides 3, 4, and 5 (three
   slides).
@@ -104,6 +111,8 @@ Expected output:
 
 ```
 {
+  "title": "Intro to Python: Variables and Operators",
+  "description": "Introduces Python variables (definition, reassignment, naming rules) and arithmetic operators, then applies them through two target-value practice exercises.",
   "segments": [
     {
       "start_slide": 1,

--- a/tests/integration/test_presentation_pipeline_smoke.py
+++ b/tests/integration/test_presentation_pipeline_smoke.py
@@ -1,0 +1,82 @@
+"""Real-API presentation pipeline smoke test (RUN_SMOKE-gated; KD-2.3-G/H/T).
+
+Drives PresentationProcessor (process_raw -> process_macro -> process_detail)
+against a real StageRouter ladder (Pass 1 vision + Pass 2a mapping). Skipped
+by default; opt-in via ``RUN_SMOKE=1``.
+
+Closes the gap that let the Pass 2a prompt/schema contract mismatch reach
+Phase 2.3 backend merge: mock-based unit tests are schema-conformant by
+construction (they hand-craft a response containing the top-level
+``description``), so they never exercise the real prompt against the real
+schema. This test does. Mirrors ``test_audio_pipeline_smoke.py`` (RUN_SMOKE
+convention, Phase 2.2 Decision 3). A content-rich PDF fixture lives in-repo.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+from course_supporter.ingestion.presentation import PresentationProcessor
+from course_supporter.ingestion.schemas import DocumentSummaryDraft
+from course_supporter.models.source import SourceType
+from course_supporter.service_logging import set_job_from_arq
+
+# tests/integration/<file> -> tests -> fixtures/presentations (in-repo).
+_FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "presentations"
+    / "lesson6_functions_1.pdf"
+)
+
+pytestmark = [
+    pytest.mark.presentation_smoke,
+    pytest.mark.skipif(
+        not os.getenv("RUN_SMOKE"),
+        reason=(
+            "Real-API presentation pipeline smoke test gated by RUN_SMOKE env "
+            "variable; opt-in only to avoid accidental real-API consumption."
+        ),
+    ),
+]
+
+
+@pytest.mark.skipif(
+    not _FIXTURE.exists(),
+    reason=f"Presentation fixture absent at {_FIXTURE}.",
+)
+async def test_presentation_smoke_real_llm() -> None:
+    """Full presentation pipeline against the real StageRouter ladder.
+
+    Validates the Pass 2a prompt -> PresentationPass2aResult schema roundtrip
+    with a real model: success proves the prompt instructs the model to emit
+    the required top-level ``description`` whose omission caused the
+    deterministic LadderExhaustedError fixed in the companion commit.
+    """
+    from course_supporter.llm.stage_router import StageRouter
+
+    stage_router = StageRouter.from_config()
+
+    proc = PresentationProcessor()
+    set_job_from_arq(uuid.uuid4())
+
+    class _SmokeSource:
+        source_type = SourceType.PRESENTATION
+        source_url = str(_FIXTURE)
+        filename = _FIXTURE.name
+
+    doc = await proc.process_raw(_SmokeSource())
+    assert doc.source_type == SourceType.PRESENTATION
+
+    summary = await proc.process_macro(doc, stage_router)
+    assert isinstance(summary, DocumentSummaryDraft)
+    # The fix: Pass 2a now emits the required top-level description.
+    assert summary.description
+    assert len(summary.segments) > 0
+
+    detail = await proc.process_detail(doc, summary)
+    assert len(detail) == len(summary.segments)


### PR DESCRIPTION
## Scope

Hotfix для Phase 2.3 backend defect, виявленого через Phase 2.3 UI manual smoke (2026-05-21). Defect: presentations exhaust LLM ladder на stage `presentation_pass_2a_mapping` через prompt ↔ schema contract mismatch — детерміністично для будь-якого fixture.

## Discovery

Phase 2.3 UI smoke runbook execution (gate G4.1 trigger):
- 2 of 2 presentation fixtures exhausted ladder з ідентичною помилкою на обох rungs (mistral-large-2512 + gemini-2.5-pro): `STRUCTURAL Field required (field: description)`.
- UI render mechanism PASSED (G4.3) — це backend defect, не UI defect.

## Root cause (per investigation 2026-05-21)

- Prompt `presentation_pass_2a_mapping/v1.md:22-34` instructed model to return only `{segments: [...]}`.
- Schema `PresentationPass2aResult` (schemas.py:767) requires top-level `description: str` як обов'язкове.
- Structured-output enforcement off (KD-2.3-T Path 3 = prompt-only, no `response_format`) → модель детерміністично пропускала field.
- Smoking gun: generic `pass_2a_mapping/v1.md` (text/web source_types) має top-level title/description і працює коректно.

## Commit chain (2 atomic, базується на main)

- `4fd71cb` — phase(2.3.backend.hotfix): align pass_2a presentation prompt with PresentationPass2aResult schema (Path A — prompt fix; 3 deltas у v1.md: output shape + hard rule + calibration example; mirror generic prompt structure; no version bump).
- `9372768` — test(presentation): add RUN_SMOKE presentation pass_2a e2e regression test (Path D — closes test gap; mock-based tests були schema-conformant by construction; додає RUN_SMOKE test що exercises real prompt vs real schema).

## Validation

- **Real-LLM end-to-end** (Path A): upload `DRF_intro.pptx` через UI → backend processing → `state='ready'`, populated `description` (324 chars), 4 segments (Miller's rule 2-7 satisfied), title populated.
- **Quality gates** (Path A): `pytest -k presentation_prompt` → 8/8 PASS.
- **RUN_SMOKE test collection** (Path D): `pytest` без RUN_SMOKE env → collected + skipped (gate працює); pre-commit hooks (ruff/mypy/etc) — усі pass.
- **PDF native path** validated by inference: Pass 2a — format-agnostic (consumes per-slide description list від Pass 1, незалежно від PDF vs PPTX source). PPTX→PyMuPDF validation covers the same Pass 2a code path. PDF native end-to-end не tested через unrelated Stage 2 security policy issue (fixture `lesson5_lists_dict_tuples_slices.pdf` rejected as promotional content — surfaced окремо для post-merge discussion, orthogonal до prompt fix).

## Discovered orthogonal issue (NOT in scope, deferred discussion)

Stage 2 SecurityLayer надмірно агресивний для authored presentations: реальна навчальна лекція з ITVDN branding/promotional links відхилена як «not a homework submission for the course». Operator estimate: ~30% authored materials під ризиком блокування. Surface для окремого discussion + remediation post-merge. Wording «homework submission» на authored upload вказує на shared classifier з homework-центричним instruction prompt — варто перевірити authored-context calibration.

## Investigation report

`~/Desktop/investigation-pass-2a-2026-05-21.md` (operator-side, не закомічено).

## Workflow

Спрощений hotfix cycle (без sealed scenario) per vision-side decision: pre-flight Rule #2 → ratify → code → staged diff Rule #4 → ratify → commit, для кожного з 2 commits.
