### PR TITLE
task(2.4.1): video pipeline skeleton — 7-step kistyak on stubs

### DIFF
--- a/src/course_supporter/ingestion/factory.py
+++ b/src/course_supporter/ingestion/factory.py
@@ -19,7 +19,7 @@ from course_supporter.ingestion.heavy_steps import (
 )
 from course_supporter.ingestion.presentation import PresentationProcessor
 from course_supporter.ingestion.text import TextProcessor
-from course_supporter.ingestion.video import VideoProcessor, WhisperVideoProcessor
+from course_supporter.ingestion.video_pipeline import VideoProcessor
 from course_supporter.ingestion.web import WebProcessor
 from course_supporter.models.source import SourceType
 
@@ -129,10 +129,13 @@ def create_processors(
 
     Args:
         heavy: Bundle of heavy step callables.
-        vd_pipeline: Optional VDPipeline for video visual analysis.
-        stt_router: Optional STTRouter for video and audio transcription.
-            When provided, VideoProcessor uses STTRouter instead of Whisper.
-            When None, falls back to WhisperVideoProcessor.
+        vd_pipeline: Optional VDPipeline (legacy ``vd/`` visual analysis).
+            Unused since Phase 2.4 task 2.4.1 — the new skeleton
+            VideoProcessor takes no deps; retained for the real Pass 1
+            vision wiring (task 2.4.4).
+        stt_router: Optional STTRouter for audio transcription (and, from
+            task 2.4.2, video STT). AudioProcessor uses it today; the
+            VIDEO skeleton does not yet consume it.
         redis: Optional ArqRedis client for the audio word-cache
             (KD-2.2-D). AudioProcessor is registered only when both
             ``stt_router`` and ``redis`` are non-None — both dependencies
@@ -145,19 +148,17 @@ def create_processors(
         guard above is unsatisfied; factory dispatch in ``api/tasks.py``
         raises ``KeyError`` for unwired source types.
     """
-    video_processor: MaterialProcessor
-    if stt_router is not None:
-        video_processor = VideoProcessor(
-            stt_router=stt_router,
-            vd_pipeline=vd_pipeline,
-        )
-    else:
-        video_processor = WhisperVideoProcessor(
-            transcribe_func=heavy.transcribe,
-        )
-
+    # Phase 2.4 task 2.4.1 — VIDEO routes to the new skeleton
+    # VideoProcessor (``ingestion.video_pipeline``). Its 7-step pipeline is
+    # stubbed (zero external calls); real edges land in tasks 2.4.2-2.4.7
+    # and the legacy ``ingestion.video`` processors are removed in 2.4.9.
+    # The skeleton takes no constructor deps — ``stt_router`` (real STT,
+    # task 2.4.2) and ``vd_pipeline`` (real Pass 1 vision, task 2.4.4) are
+    # retained on the factory for that future wiring; passing them into
+    # the skeleton would couple the new namespace to legacy ``vd/`` types
+    # (isolation per 2.4.1 acceptance #3).
     result: dict[SourceType, MaterialProcessor] = {
-        SourceType.VIDEO: video_processor,
+        SourceType.VIDEO: VideoProcessor(),
         SourceType.PRESENTATION: PresentationProcessor(),
         SourceType.TEXT: TextProcessor(),
         SourceType.WEB: WebProcessor(

--- a/src/course_supporter/ingestion/video_pipeline/__init__.py
+++ b/src/course_supporter/ingestion/video_pipeline/__init__.py
@@ -1,0 +1,12 @@
+"""Video ingestion pipeline (Phase 2.4) — new namespace, isolated from ``vd/``.
+
+Skeleton (task 2.4.1) wires a 7-step video pipeline on offline stubs.
+Real per-step logic lands in tasks 2.4.2-2.4.7; the legacy
+``course_supporter.ingestion.video`` + ``course_supporter.vd`` modules are
+removed in task 2.4.9. This package has zero import dependencies on
+``course_supporter.vd``.
+"""
+
+from course_supporter.ingestion.video_pipeline.processor import VideoProcessor
+
+__all__ = ["VideoProcessor"]

--- a/src/course_supporter/ingestion/video_pipeline/processor.py
+++ b/src/course_supporter/ingestion/video_pipeline/processor.py
@@ -1,0 +1,157 @@
+"""VideoProcessor skeleton — 7-step video pipeline on stubs (Phase 2.4).
+
+Task 2.4.1: a thin, end-to-end topology kistyak. The canonical 7-step
+flow (``PHASE-2-4.md`` §1) maps onto the existing 3-method
+:class:`~course_supporter.ingestion.base.MaterialProcessor` contract
+without extending it (symmetric with the audio precedent, which folds
+Pass 2c into ``process_detail``):
+
+* :meth:`process_raw`    — Krok 1-4 (ingest → STT → detection → Pass 1)
+                           → ``SourceDocument``.
+* :meth:`process_macro`  — Krok 5 (Pass 2a mapping) → ``DocumentSummaryDraft``.
+* :meth:`process_detail` — Krok 6-7 (Pass 2b slice + Pass 2c cleanup)
+                           → ``list[DocumentSegmentDraft]``.
+
+Each gnízdo lives in :mod:`course_supporter.ingestion.video_pipeline.steps`
+as an offline stub; data flows in-memory between them. No external calls
+(S3, ffmpeg, ElevenLabs, LLM) and no ``Job.stage_progress`` / Redis are
+touched in the skeleton — real edges + the inter-stage transport land in
+tasks 2.4.2-2.4.7. The new namespace has zero imports from the legacy
+``course_supporter.vd`` module (isolation per task 2.4.1 acceptance #3).
+
+Factory dispatch invariant: ``create_processors`` routes by
+``source_type`` so this processor only receives ``SourceType.VIDEO``
+inputs; no entry guard is needed (matches AudioProcessor / Phase 2.2).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from course_supporter.ingestion.base import MaterialProcessor
+from course_supporter.ingestion.video_pipeline import steps
+from course_supporter.models.source import (
+    ChunkType,
+    ContentChunk,
+    SourceDocument,
+    SourceType,
+)
+
+if TYPE_CHECKING:
+    from course_supporter.ingestion.schemas import (
+        DocumentSegmentDraft,
+        DocumentSummaryDraft,
+    )
+    from course_supporter.ingestion.video_pipeline.schemas import (
+        FrameDescription,
+        SttResult,
+    )
+    from course_supporter.llm.router import ModelRouter
+    from course_supporter.llm.stage_router import StageRouter
+    from course_supporter.storage.orm import AuthoredDocument
+
+
+class VideoProcessor(MaterialProcessor):
+    """Video source-type processor — skeleton over 7 stub gnízda.
+
+    See module docstring for the 7-step → 3-method mapping. Takes no
+    constructor dependencies: the skeleton makes zero external calls, so
+    STT / vision / LLM clients are wired only when their real gnízda land
+    (tasks 2.4.2/2.4.4/2.4.5/2.4.7).
+    """
+
+    async def process_raw(
+        self,
+        source: AuthoredDocument,
+        *,
+        router: ModelRouter | None = None,
+    ) -> SourceDocument:
+        """Krok 1-4 → ``SourceDocument``.
+
+        The ``router`` parameter is accepted for ABC symmetry but unused
+        in the skeleton (the real Pass 1 vision call wires its own ladder
+        in task 2.4.4).
+        """
+        file_metadata = await steps.step_1_ingest(source)
+        stt = await steps.step_2_stt(source, file_metadata)
+        scenes = await steps.step_3_detection(stt)
+        frame_descriptions = await steps.step_4_pass1_vision(scenes)
+        return self._assemble_source_document(source, stt, frame_descriptions)
+
+    def _assemble_source_document(
+        self,
+        source: AuthoredDocument,
+        stt: SttResult,
+        frame_descriptions: list[FrameDescription],
+    ) -> SourceDocument:
+        """Build the canonical ``SourceDocument`` from Krok 2 + Krok 4 output.
+
+        Transcript words join into a single ``TRANSCRIPT`` chunk; each
+        Pass 1 frame description becomes a ``VISUAL_SCENE`` chunk.
+        ``assemble_text`` keeps the ``"\\n\\n"`` separator for video
+        (``models/source.py`` KD-2.2-E), so transcript and visual blocks
+        stay separable in the reference text that Pass 2a/2b operate on.
+        """
+        chunks: list[ContentChunk] = []
+        index = 0
+
+        transcript_text = " ".join(word.text for word in stt.words)
+        if transcript_text:
+            chunks.append(
+                ContentChunk(
+                    chunk_type=ChunkType.TRANSCRIPT,
+                    text=transcript_text,
+                    index=index,
+                    start_sec=(stt.words[0].start_ms / 1000.0 if stt.words else None),
+                    end_sec=(stt.words[-1].end_ms / 1000.0 if stt.words else None),
+                )
+            )
+            index += 1
+
+        for frame in frame_descriptions:
+            chunks.append(
+                ContentChunk(
+                    chunk_type=ChunkType.VISUAL_SCENE,
+                    text=frame.description,
+                    index=index,
+                    start_sec=frame.frame_position_ms / 1000.0,
+                )
+            )
+            index += 1
+
+        return SourceDocument(
+            source_type=SourceType.VIDEO,
+            source_url=source.source_url,
+            title=source.filename or "",
+            chunks=chunks,
+        )
+
+    async def process_macro(
+        self,
+        doc: SourceDocument,
+        router: StageRouter,
+    ) -> DocumentSummaryDraft:
+        """Krok 5 — Pass 2a mapping (stub).
+
+        The ``router`` parameter is accepted to match the ABC / orchestrator
+        call site but unused in the skeleton (real Pass 2a wires the text
+        ladder in task 2.4.5).
+        """
+        return await steps.step_5_pass2a_mapping(doc)
+
+    async def process_detail(
+        self,
+        doc: SourceDocument,
+        summary_draft: DocumentSummaryDraft,
+        *,
+        router: StageRouter | None = None,
+    ) -> list[DocumentSegmentDraft]:
+        """Krok 6-7 — Pass 2b slice + Pass 2c cleanup (stubs).
+
+        Extends the ABC ``process_detail`` signature with the keyword-only
+        ``router`` (symmetric with AudioProcessor). The orchestrator calls
+        this without a router; the skeleton's Pass 2c stub needs none (real
+        cleanup wires the cheap text ladder in task 2.4.7).
+        """
+        sliced = await steps.step_6_pass2b_slice(doc, summary_draft)
+        return await steps.step_7_pass2c_cleanup(sliced)

--- a/src/course_supporter/ingestion/video_pipeline/processor.py
+++ b/src/course_supporter/ingestion/video_pipeline/processor.py
@@ -78,8 +78,8 @@ class VideoProcessor(MaterialProcessor):
         frame_descriptions = await steps.step_4_pass1_vision(scenes)
         return self._assemble_source_document(source, stt, frame_descriptions)
 
+    @staticmethod
     def _assemble_source_document(
-        self,
         source: AuthoredDocument,
         stt: SttResult,
         frame_descriptions: list[FrameDescription],

--- a/src/course_supporter/ingestion/video_pipeline/schemas.py
+++ b/src/course_supporter/ingestion/video_pipeline/schemas.py
@@ -1,0 +1,112 @@
+"""Mock data-structure shapes for the video pipeline skeleton (Phase 2.4).
+
+These carriers mirror the *forms* of the per-step structures described in
+``PHASE-2-4.md`` §1 (Krok 1-4 intermediate state). The skeleton (task
+2.4.1) threads them in-memory between gnízda — no DB / Redis / external
+calls. Tasks 2.4.2-2.4.7 replace the stub bodies in :mod:`steps` with
+real logic; the shapes here are deliberately minimal and may be widened
+(or moved to the proper inter-stage transport — Redis per the audio
+precedent — when a real, large transient payload motivates it).
+
+Pass 2a/2b/2c (Krok 5-7) reuse the existing pipeline carriers
+``DocumentSummaryDraft`` / ``DocumentSegmentDraft`` rather than redefining
+them here.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class VideoFileMetadata(BaseModel):
+    """Krok 1 — container metadata probed from the uploaded video (§1).
+
+    Real probe (ffprobe) lands in task 2.4.2; the skeleton returns a
+    fixed mock shape without decoding the container.
+    """
+
+    duration_ms: int
+    codec: str
+    resolution: str
+
+
+class SttWord(BaseModel):
+    """Single word-level STT token with millisecond timing (§1 Krok 2)."""
+
+    text: str
+    start_ms: int
+    end_ms: int
+
+
+class SttPause(BaseModel):
+    """Silence boundary candidate used for Pass 2a alignment (KD2c, §1)."""
+
+    start_ms: int
+    end_ms: int
+
+
+class SttResult(BaseModel):
+    """Krok 2 — STT output (ElevenLabs Scribe in the real pipeline, §1).
+
+    ``words`` is a word-level stream (not a flat string) so downstream
+    Pass 2a/2b can align segment boundaries to ``pauses``.
+    """
+
+    language: str
+    duration_ms: int
+    words: list[SttWord] = Field(default_factory=list)
+    pauses: list[SttPause] = Field(default_factory=list)
+
+
+class ChangeClass(StrEnum):
+    """Frame change classification (§1 Krok 3).
+
+    Drives both scene boundaries (``BOUNDARY`` = new scene start) and the
+    Pass 1 anchor/diff decision (``FIRST``/``BOUNDARY`` → anchor).
+    """
+
+    FIRST = "first"
+    BOUNDARY = "boundary"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class SampledFrame(BaseModel):
+    """One kept frame after dedup, tagged with its change class (§1 Krok 3)."""
+
+    frame_position_ms: int
+    change_class: ChangeClass
+
+
+class Scene(BaseModel):
+    """Krok 3 — a detected scene spanning ``[start_ms, end_ms]`` (§1).
+
+    Real detection (ffmpeg + scenedetect, 3-gate) lands in task 2.4.3.
+    """
+
+    scene_id: int
+    start_ms: int
+    end_ms: int
+    frames: list[SampledFrame] = Field(default_factory=list)
+
+
+class FrameKind(StrEnum):
+    """Pass 1 description mode — full anchor vs incremental diff (§1 Krok 4)."""
+
+    ANCHOR = "anchor"
+    DIFF = "diff"
+
+
+class FrameDescription(BaseModel):
+    """Krok 4 — vision-LLM textual description bound to a timestamp (§1).
+
+    Real Pass 1 chain-diff (vision ladder, Qwen3-VL rung 1) lands in
+    task 2.4.4.
+    """
+
+    scene_id: int
+    frame_position_ms: int
+    description: str
+    kind: FrameKind

--- a/src/course_supporter/ingestion/video_pipeline/steps.py
+++ b/src/course_supporter/ingestion/video_pipeline/steps.py
@@ -1,0 +1,232 @@
+"""Seven pipeline gnízda (steps) as offline stubs (Phase 2.4 task 2.4.1).
+
+Each function is one gnízdo of the canonical 7-step video flow
+(``PHASE-2-4.md`` §1). In the skeleton every step is a deterministic
+stub: zero network / disk / LLM, returns a mock structure of the §1
+shape. Data flows in-memory between steps (return values / arguments);
+no ``Job.stage_progress`` or Redis is written in the skeleton.
+
+Filling order (per ``PHASE-2-4.md`` §3): each later task (2.4.2-2.4.7)
+replaces the body of exactly one step here with real logic, without
+touching its neighbours. Real implementations raise
+:class:`~course_supporter.ingestion.base.ProcessingError` per their
+own error taxonomy (drafted per-task); the skeleton's failure-injection
+point is to patch any one of these step functions to raise (see
+``tests/integration/test_video_skeleton.py``).
+
+Steps 1-4 are invoked from ``VideoProcessor.process_raw``; step 5 from
+``process_macro``; steps 6-7 from ``process_detail``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from course_supporter.ingestion.schemas import (
+    DocumentSegmentDraft,
+    DocumentSummaryDraft,
+)
+from course_supporter.ingestion.video_pipeline.schemas import (
+    ChangeClass,
+    FrameDescription,
+    FrameKind,
+    SampledFrame,
+    Scene,
+    SttPause,
+    SttResult,
+    SttWord,
+    VideoFileMetadata,
+)
+
+if TYPE_CHECKING:
+    from course_supporter.models.source import SourceDocument
+    from course_supporter.storage.orm import AuthoredDocument
+
+
+# ── Krok 1-4 — invoked from process_raw ────────────────────────────
+
+
+async def step_1_ingest(source: AuthoredDocument) -> VideoFileMetadata:
+    """Krok 1 — resolve container metadata (§1).
+
+    Skeleton: no S3 download / ffprobe (task 2.4.2). Reads
+    ``source_url`` only to mirror the real signature; never opens the
+    file. Returns a fixed mock metadata shape.
+    """
+    _ = source.source_url
+    return VideoFileMetadata(
+        duration_ms=600_000,
+        codec="h264",
+        resolution="1920x1080",
+    )
+
+
+async def step_2_stt(
+    source: AuthoredDocument,
+    file_metadata: VideoFileMetadata,
+) -> SttResult:
+    """Krok 2 — speech-to-text (§1).
+
+    Skeleton: no audio extraction / ElevenLabs call (task 2.4.2).
+    Returns a tiny deterministic word stream plus one pause candidate.
+    """
+    _ = source.source_url
+    return SttResult(
+        language="en",
+        duration_ms=file_metadata.duration_ms,
+        words=[
+            SttWord(text="Hello", start_ms=0, end_ms=500),
+            SttWord(text="world", start_ms=500, end_ms=1000),
+        ],
+        pauses=[SttPause(start_ms=1000, end_ms=1500)],
+    )
+
+
+async def step_3_detection(stt: SttResult) -> list[Scene]:
+    """Krok 3 — pre-LLM scene detection + frame sampling (§1).
+
+    Skeleton: no ffmpeg / scenedetect (task 2.4.3). Emits one mock
+    scene spanning the full duration with a single anchor frame.
+    """
+    return [
+        Scene(
+            scene_id=0,
+            start_ms=0,
+            end_ms=stt.duration_ms,
+            frames=[
+                SampledFrame(frame_position_ms=0, change_class=ChangeClass.FIRST),
+            ],
+        ),
+    ]
+
+
+async def step_4_pass1_vision(scenes: list[Scene]) -> list[FrameDescription]:
+    """Krok 4 — Pass 1 / «Eyes» vision description (§1).
+
+    Skeleton: no vision LLM / chunking (task 2.4.4). Emits one anchor
+    description per sampled frame.
+    """
+    descriptions: list[FrameDescription] = []
+    for scene in scenes:
+        for frame in scene.frames:
+            descriptions.append(
+                FrameDescription(
+                    scene_id=scene.scene_id,
+                    frame_position_ms=frame.frame_position_ms,
+                    description="Mock slide: title and bullet points.",
+                    kind=FrameKind.ANCHOR,
+                )
+            )
+    return descriptions
+
+
+# ── Krok 5 — invoked from process_macro ────────────────────────────
+
+
+async def step_5_pass2a_mapping(doc: SourceDocument) -> DocumentSummaryDraft:
+    """Krok 5 — Pass 2a semantic mapping (§1).
+
+    Skeleton: no premium text LLM (task 2.4.5). Builds a contiguous
+    segment cover over the assembled reference text so the persist
+    cascade (``DocumentSegmentRepository.create_batch`` bounds-check +
+    ``DocumentSummaryDraft`` contiguity validator) is exercised on real
+    data. The last segment is flagged ``noisy=True`` to drive the Pass
+    2c branch in :func:`step_7_pass2c_cleanup`.
+    """
+    reference = doc.assemble_text()
+    total = len(reference)
+    segments: list[DocumentSegmentDraft] = []
+
+    if total >= 2:
+        split = total // 2
+        segments.append(
+            DocumentSegmentDraft(
+                order=0,
+                start_pos=0,
+                end_pos=split,
+                title="Intro (mock)",
+                description="Mock opening segment.",
+                main_concepts=["mock-concept-a"],
+                secondary_concepts=[],
+                noisy=False,
+            )
+        )
+        segments.append(
+            DocumentSegmentDraft(
+                order=1,
+                start_pos=split,
+                end_pos=total,
+                title="Body (mock, noisy)",
+                description="Mock body segment flagged noisy.",
+                main_concepts=["mock-concept-b"],
+                secondary_concepts=["mock-concept-a"],
+                noisy=True,
+            )
+        )
+    elif total == 1:
+        segments.append(
+            DocumentSegmentDraft(
+                order=0,
+                start_pos=0,
+                end_pos=1,
+                title="Whole (mock)",
+                description="Mock single segment.",
+                main_concepts=["mock-concept-a"],
+                secondary_concepts=[],
+                noisy=True,
+            )
+        )
+    # total == 0 → empty segments (the validator allows an empty cover).
+
+    return DocumentSummaryDraft(
+        title="Mock video summary",
+        description="Skeleton mock summary (Phase 2.4 task 2.4.1).",
+        main_concepts=["mock-concept-a", "mock-concept-b"],
+        secondary_concepts=[],
+        segments=segments,
+    )
+
+
+# ── Krok 6-7 — invoked from process_detail ─────────────────────────
+
+
+async def step_6_pass2b_slice(
+    doc: SourceDocument,
+    summary_draft: DocumentSummaryDraft,
+) -> list[DocumentSegmentDraft]:
+    """Krok 6 — Pass 2b algorithmic slice (§1).
+
+    Zero-LLM by design (task 2.4.6 finalises the transcript/visual merge
+    format). Skeleton mirrors the audio Pass 2b slice: fill ``content``
+    for each draft from ``doc.assemble_text()[start_pos:end_pos]`` when
+    not already populated.
+    """
+    reference = doc.assemble_text()
+    sliced: list[DocumentSegmentDraft] = []
+    for draft in summary_draft.segments:
+        if draft.content is not None:
+            sliced.append(draft)
+            continue
+        raw_content = reference[draft.start_pos : draft.end_pos]
+        sliced.append(draft.model_copy(update={"content": raw_content}))
+    return sliced
+
+
+async def step_7_pass2c_cleanup(
+    segments: list[DocumentSegmentDraft],
+) -> list[DocumentSegmentDraft]:
+    """Krok 7 — Pass 2c cleanup of noisy segments (§1).
+
+    Skeleton: no cheap text LLM (task 2.4.7). Selective on ``noisy``,
+    mirroring the audio Pass 2c routing; the stub prefixes a marker
+    instead of denoising. Non-noisy segments keep their raw slice.
+    """
+    cleaned: list[DocumentSegmentDraft] = []
+    for draft in segments:
+        if draft.noisy and draft.content is not None:
+            cleaned.append(
+                draft.model_copy(update={"content": f"[cleaned] {draft.content}"})
+            )
+        else:
+            cleaned.append(draft)
+    return cleaned

--- a/tests/integration/test_video_skeleton.py
+++ b/tests/integration/test_video_skeleton.py
@@ -1,0 +1,232 @@
+"""End-to-end skeleton topology test for the video_pipeline (Phase 2.4 task 2.4.1).
+
+Drives the real ``arq_ingest_material`` orchestrator against a live DB
+with the new skeleton ``VideoProcessor`` injected via ``create_processors``.
+All 7 gnízda are offline stubs (zero external calls); Stage 2 safety and
+ARQ work-window are patched. The test verifies pipeline topology:
+
+* happy path — ``source_type=video`` traverses all 7 gnízda → ``state=ready``
+  with a persisted ``DocumentSummary`` + ``DocumentSegment[]`` (cascade
+  content_hash to root);
+* R1 failure path — a gnízdo raising ``ProcessingError`` → ``state=ERROR``
+  with non-empty ``error_message``, the row **retained** (NOT soft-deleted,
+  per KD-2.1-P + task 2.4.8 retry), and nothing persisted.
+
+Requires ``docker compose up -d`` (PostgreSQL).
+Run with: ``uv run pytest tests/integration/test_video_skeleton.py --run-db -v``
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from course_supporter.api.tasks import arq_ingest_material
+from course_supporter.ingestion.base import ProcessingError
+from course_supporter.ingestion.video_pipeline import VideoProcessor
+from course_supporter.models.source import SourceType
+from course_supporter.storage.authored_document_repository import (
+    AuthoredDocumentRepository,
+)
+from course_supporter.storage.course_node_repository import CourseNodeRepository
+from course_supporter.storage.job_repository import JobRepository
+from course_supporter.storage.orm import (
+    AuthoredDocument,
+    DocumentSegment,
+    DocumentSummary,
+)
+
+pytestmark = pytest.mark.requires_db
+
+_FACTORY = "course_supporter.api.tasks.create_processors"
+_HEAVY = "course_supporter.api.tasks.create_heavy_steps"
+_WORK_WINDOW = "course_supporter.job_priority.check_work_window"
+_STAGE2 = "course_supporter.security.stage2.run_stage2_safety_check"
+_STEP4 = "course_supporter.ingestion.video_pipeline.steps.step_4_pass1_vision"
+
+_SOURCE_URL = "s3://bucket/lecture.mp4"
+
+
+def _build_ctx(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> dict[str, Any]:
+    """Minimal ARQ worker context for the ingestion task."""
+    return {
+        "session_factory": session_factory,
+        "model_router": MagicMock(),
+        "stage_router": MagicMock(),
+        "redis": MagicMock(),
+        "s3_client": None,
+    }
+
+
+def _video_processors() -> dict[SourceType, VideoProcessor]:
+    """Inject the real skeleton VideoProcessor at the VIDEO dispatch key."""
+    return {SourceType.VIDEO: VideoProcessor()}
+
+
+async def _seed_video_job(
+    session_factory: async_sessionmaker[AsyncSession],
+    committed_seeds: dict[str, uuid.UUID],
+) -> uuid.UUID:
+    """Flip the seeded document to source_type=video and create its Job."""
+    async with session_factory() as session:
+        await session.execute(
+            update(AuthoredDocument)
+            .where(AuthoredDocument.id == committed_seeds["material_id"])
+            .values(source_type="video")
+        )
+        job = await JobRepository(session).create(
+            tenant_id=committed_seeds["tenant_id"],
+            course_node_id=committed_seeds["course_node_id"],
+            job_type="ingest",
+        )
+        await session.commit()
+        return job.id
+
+
+class TestVideoSkeletonTopology:
+    """Acceptance #1-#2 — full orchestrator topology over the skeleton."""
+
+    async def test_skeleton_reaches_ready_with_persisted_cascade(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        committed_seeds: dict[str, uuid.UUID],
+    ) -> None:
+        """Mock video matter traverses 7 gnízda → state=ready + Summary + Segments."""
+        mid = committed_seeds["material_id"]
+        job_id = await _seed_video_job(session_factory, committed_seeds)
+        ctx = _build_ctx(session_factory)
+
+        from course_supporter.security.schemas import SafetyResult
+
+        safe_verdict = SafetyResult(
+            is_safe=True,
+            violations=[],
+            confidence=0.95,
+            reasoning="benign",
+        )
+
+        with (
+            patch(_WORK_WINDOW),
+            patch(_HEAVY),
+            patch(_FACTORY, return_value=_video_processors()),
+            patch(_STAGE2, new=AsyncMock(return_value=safe_verdict)),
+        ):
+            await arq_ingest_material(
+                ctx,
+                str(job_id),
+                str(mid),
+                "video",
+                _SOURCE_URL,
+            )
+
+        # Final lifecycle state.
+        async with session_factory() as session:
+            final_job = await JobRepository(session).get_by_id(job_id)
+            final_mat = await AuthoredDocumentRepository(session).get_by_id(mid)
+        assert final_job is not None
+        assert final_job.status == "complete"
+        assert final_mat is not None
+        assert final_mat.state == "ready"
+        assert final_mat.error_message is None
+
+        # Pass 2a — DocumentSummary persisted.
+        async with session_factory() as session:
+            summary = (
+                await session.execute(
+                    select(DocumentSummary).where(
+                        DocumentSummary.authored_document_id == mid
+                    )
+                )
+            ).scalar_one_or_none()
+        assert summary is not None, "skeleton Pass 2a did not persist a summary"
+
+        # Pass 2b/2c — DocumentSegment rows persisted with content.
+        async with session_factory() as session:
+            segments = list(
+                (
+                    await session.execute(
+                        select(DocumentSegment)
+                        .where(DocumentSegment.document_summary_id == summary.id)
+                        .order_by(DocumentSegment.order)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert len(segments) >= 1, "skeleton did not persist segment rows"
+        assert all(seg.content for seg in segments)
+
+        # KD9 / KD-2.1-F — cascade content_hash reaches the root CourseNode.
+        async with session_factory() as session:
+            mat_repo = AuthoredDocumentRepository(session)
+            node_repo = CourseNodeRepository(session)
+            entry = await mat_repo.get_by_id(mid)
+            assert entry is not None
+            root = await node_repo.get_root_for(entry.course_node_id)
+        assert summary.content_hash is not None
+        assert entry.content_hash is not None
+        assert root is not None
+        assert root.content_hash is not None
+
+    async def test_skeleton_failure_path_marks_error_without_soft_delete(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        committed_seeds: dict[str, uuid.UUID],
+    ) -> None:
+        """R1 — gnízdo ProcessingError → state=ERROR, row retained, no persist."""
+        mid = committed_seeds["material_id"]
+        job_id = await _seed_video_job(session_factory, committed_seeds)
+        ctx = _build_ctx(session_factory)
+
+        error_msg = "injected vision failure"
+
+        with (
+            patch(_WORK_WINDOW),
+            patch(_HEAVY),
+            patch(_FACTORY, return_value=_video_processors()),
+            patch(
+                _STEP4,
+                new=AsyncMock(side_effect=ProcessingError(error_msg)),
+            ),
+        ):
+            await arq_ingest_material(
+                ctx,
+                str(job_id),
+                str(mid),
+                "video",
+                _SOURCE_URL,
+            )
+
+        async with session_factory() as session:
+            final_job = await JobRepository(session).get_by_id(job_id)
+            final_mat = await AuthoredDocumentRepository(session).get_by_id(mid)
+
+        assert final_job is not None
+        assert final_job.status == "failed"
+        assert error_msg in (final_job.error_message or "")
+
+        # R1 — fail_processing only: state=ERROR, error_message set, and the
+        # row is RETAINED (not soft-deleted) so it stays retryable per
+        # KD-2.1-P + task 2.4.8.
+        assert final_mat is not None
+        assert final_mat.state == "error"
+        assert error_msg in (final_mat.error_message or "")
+        assert final_mat.deleted_at is None
+
+        # Failure injected in process_raw (before Pass 2a commit) → nothing persisted.
+        async with session_factory() as session:
+            summary = (
+                await session.execute(
+                    select(DocumentSummary).where(
+                        DocumentSummary.authored_document_id == mid
+                    )
+                )
+            ).scalar_one_or_none()
+        assert summary is None, "no DocumentSummary should persist on failure"

--- a/tests/unit/test_ingestion/test_factory.py
+++ b/tests/unit/test_ingestion/test_factory.py
@@ -14,7 +14,7 @@ from course_supporter.ingestion.factory import (
 )
 from course_supporter.ingestion.presentation import PresentationProcessor
 from course_supporter.ingestion.text import TextProcessor
-from course_supporter.ingestion.video import VideoProcessor, WhisperVideoProcessor
+from course_supporter.ingestion.video_pipeline import VideoProcessor
 from course_supporter.ingestion.web import WebProcessor
 from course_supporter.models.source import SourceType
 from course_supporter.stt.router import STTRouter
@@ -75,24 +75,22 @@ class TestCreateProcessors:
             SourceType.WEB,
         }
 
-    def test_video_processor_with_stt_router(self) -> None:
-        """VIDEO maps to VideoProcessor when stt_router is provided."""
+    def test_video_maps_to_skeleton_processor(self) -> None:
+        """VIDEO maps to the new video_pipeline skeleton VideoProcessor.
+
+        Phase 2.4 task 2.4.1 rewired VIDEO from the legacy
+        ``ingestion.video`` processors (VideoProcessor / WhisperVideoProcessor)
+        to the ``ingestion.video_pipeline`` skeleton, which takes no
+        constructor deps and is independent of ``stt_router`` presence.
+        """
         heavy = create_heavy_steps()
         mock_router = AsyncMock(spec=STTRouter)
-        processors = create_processors(heavy, stt_router=mock_router)
 
-        video = processors[SourceType.VIDEO]
-        assert isinstance(video, VideoProcessor)
-        assert video._stt_router is mock_router
+        with_router = create_processors(heavy, stt_router=mock_router)
+        without_router = create_processors(heavy)
 
-    def test_video_processor_fallback_to_whisper(self) -> None:
-        """VIDEO maps to WhisperVideoProcessor when no stt_router."""
-        heavy = create_heavy_steps()
-        processors = create_processors(heavy)
-
-        video = processors[SourceType.VIDEO]
-        assert isinstance(video, WhisperVideoProcessor)
-        assert video._transcribe_func is heavy.transcribe
+        assert isinstance(with_router[SourceType.VIDEO], VideoProcessor)
+        assert isinstance(without_router[SourceType.VIDEO], VideoProcessor)
 
     def test_presentation_processor_type(self) -> None:
         """PRESENTATION maps to PresentationProcessor."""

--- a/tests/unit/test_ingestion/test_video_pipeline_skeleton.py
+++ b/tests/unit/test_ingestion/test_video_pipeline_skeleton.py
@@ -1,0 +1,149 @@
+"""Unit tests for the video_pipeline skeleton VideoProcessor (Phase 2.4 task 2.4.1).
+
+Drives the three base methods directly (no DB / orchestrator) on a mock
+AuthoredDocument, exercising all 7 stub gnízda + their mock shapes, plus
+the namespace-isolation gate (acceptance #3) and the per-step
+failure-injection seam. The full orchestrator topology (state=ready,
+persist cascade, R1 failure path) lives in the requires_db integration
+test ``tests/integration/test_video_skeleton.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from course_supporter.ingestion.base import ProcessingError
+from course_supporter.ingestion.schemas import (
+    DocumentSegmentDraft,
+    DocumentSummaryDraft,
+)
+from course_supporter.ingestion.video_pipeline import VideoProcessor
+from course_supporter.models.source import ChunkType, SourceDocument, SourceType
+from course_supporter.storage.orm import AuthoredDocument
+
+_STEP4 = "course_supporter.ingestion.video_pipeline.steps.step_4_pass1_vision"
+
+
+def _mock_authored_document() -> Mock:
+    """AuthoredDocument stand-in (spec_set for attribute-access safety)."""
+    doc = Mock(spec_set=AuthoredDocument)
+    doc.source_url = "s3://bucket/lecture.mp4"
+    doc.source_type = SourceType.VIDEO
+    doc.filename = "lecture.mp4"
+    return doc
+
+
+class TestVideoProcessorConstruction:
+    def test_takes_no_constructor_args(self) -> None:
+        """Skeleton VideoProcessor wires with no dependencies."""
+        assert isinstance(VideoProcessor(), VideoProcessor)
+
+
+class TestVideoProcessorPipeline:
+    """Happy-path coverage of the 7 stub gnízda over the 3 base methods."""
+
+    async def test_process_raw_builds_video_source_document(self) -> None:
+        """Krok 1-4 → SourceDocument(VIDEO) with transcript + visual chunks."""
+        proc = VideoProcessor()
+
+        doc = await proc.process_raw(_mock_authored_document())
+
+        assert isinstance(doc, SourceDocument)
+        assert doc.source_type == SourceType.VIDEO
+        assert doc.source_url == "s3://bucket/lecture.mp4"
+        assert doc.title == "lecture.mp4"
+        chunk_types = {chunk.chunk_type for chunk in doc.chunks}
+        assert ChunkType.TRANSCRIPT in chunk_types
+        assert ChunkType.VISUAL_SCENE in chunk_types
+        assert doc.assemble_text()  # non-empty reference text
+
+    async def test_process_macro_returns_contiguous_segment_cover(self) -> None:
+        """Krok 5 → DocumentSummaryDraft; segments start at 0 + contiguous."""
+        proc = VideoProcessor()
+        doc = await proc.process_raw(_mock_authored_document())
+
+        summary = await proc.process_macro(doc, Mock())
+
+        assert isinstance(summary, DocumentSummaryDraft)
+        assert summary.segments  # mock reference text is comfortably long
+        assert summary.segments[0].start_pos == 0
+        prev_end = 0
+        for seg in summary.segments:
+            assert seg.start_pos == prev_end
+            assert seg.end_pos > seg.start_pos
+            prev_end = seg.end_pos
+        assert prev_end == len(doc.assemble_text())
+        # Last segment flagged noisy → drives the Pass 2c stub branch.
+        assert summary.segments[-1].noisy is True
+
+    async def test_process_detail_fills_content_and_cleans_noisy(self) -> None:
+        """Krok 6-7 → every segment has content; noisy segments are cleaned."""
+        proc = VideoProcessor()
+        doc = await proc.process_raw(_mock_authored_document())
+        reference = doc.assemble_text()
+        summary = await proc.process_macro(doc, Mock())
+
+        detail = await proc.process_detail(doc, summary)
+
+        assert len(detail) == len(summary.segments)
+        assert all(isinstance(seg, DocumentSegmentDraft) for seg in detail)
+        assert all(seg.content for seg in detail)
+        for seg in detail:
+            if seg.noisy:
+                assert seg.content is not None
+                assert seg.content.startswith("[cleaned] ")
+            else:
+                assert seg.content == reference[seg.start_pos : seg.end_pos]
+
+    async def test_full_pipeline_offline(self) -> None:
+        """All 3 base methods chain end-to-end without external calls."""
+        proc = VideoProcessor()
+        source = _mock_authored_document()
+
+        doc = await proc.process_raw(source)
+        summary = await proc.process_macro(doc, Mock())
+        detail = await proc.process_detail(doc, summary)
+
+        assert detail
+        assert all(seg.content for seg in detail)
+
+
+class TestVideoProcessorFailureInjection:
+    """Any gnízdo can raise ProcessingError (failure-injection seam)."""
+
+    async def test_step_failure_propagates_processing_error(self) -> None:
+        """Patching a gnízdo to raise surfaces ProcessingError to the caller."""
+        proc = VideoProcessor()
+
+        with (
+            patch(
+                _STEP4,
+                new=AsyncMock(side_effect=ProcessingError("injected vision failure")),
+            ),
+            pytest.raises(ProcessingError, match="injected vision failure"),
+        ):
+            await proc.process_raw(_mock_authored_document())
+
+
+class TestVideoPipelineIsolation:
+    """Acceptance #3 — new namespace has zero ``course_supporter.vd`` imports."""
+
+    def test_no_vd_imports_in_namespace(self) -> None:
+        import course_supporter.ingestion.video_pipeline as pkg
+
+        package_dir = Path(pkg.__file__).parent
+        # Mirror acceptance #3 (``rg "from course_supporter.vd"``): match the
+        # import statement forms, not bare docstring mentions of the module.
+        import_forms = ("from course_supporter.vd", "import course_supporter.vd")
+        offenders = [
+            py.name
+            for py in sorted(package_dir.glob("*.py"))
+            if any(form in py.read_text(encoding="utf-8") for form in import_forms)
+        ]
+        assert offenders == [], (
+            f"video_pipeline modules must not import course_supporter.vd; "
+            f"offenders: {offenders}"
+        )


### PR DESCRIPTION
## Що це

Phase 2.4 **Task 2.4.1** — наскрізний тонкий кістяк video ingestion. Video matter проходить усі 7 кроків pipeline на заглушках і досягає `state=ready` з mock-даними. Нуль зовнішніх викликів (S3 / ffmpeg / ElevenLabs / LLM) — перевіряється **топологія**, не реальна обробка.

Sprint-brief: `refactoring-vision/sprint/phases/phase-2-4/PHASE-2-4.md`; task: `PHASE-2-4-task-1.md`.

## Зміни

- **Новий namespace** `src/course_supporter/ingestion/video_pipeline/` (`__init__`/`schemas`/`steps`/`processor`), ізольований від legacy `vd/`.
- 7-кроковий flow (§1) лягає на існуючий 3-методний `MaterialProcessor` контракт **без розширення base**: `process_raw`=кроки 1-4, `process_macro`=крок 5, `process_detail`=кроки 6-7 (дзеркалить `AudioProcessor` `*, router=None`).
- `steps.py` — 7 offline-stub гнізд; міжкрокові дані течуть **in-memory**; failure-injection seam = patch будь-якого `step_N`.
- **ARQ wiring:** `factory.py` `SourceType.VIDEO` → новий skeleton `VideoProcessor()` (без deps); legacy `ingestion.video` import прибрано (файл лишається до task 2.4.9). `api/tasks.py` **не чіпано**.
- Оновлено `test_factory.py` VIDEO-асерти під rewire.

## Ратифіковані pre-flight рішення

- **B3 (in-memory threading, без `stage_progress` у кістяку).** Літеральний `Job.stage_progress` (Choice B) відкинуто після probe: processor-owned окрема session дедлокиться з row-lock оркестратора на рядку `jobs` у кроках 5-7 (`update_stage` = `flush`, не `commit`). Саме тому audio використовує Redis, не рядок `jobs`. Redis inter-stage transport відкладено до 2.4.2 (STT words) / 2.4.4 (frame_descriptions).
- **R1 error path (precedent-aligned).** `ProcessingError` → `fail_processing` → `state=ERROR` + `error_message`, рядок **retained (НЕ soft-delete)**. Soft-delete зарезервовано для `STAGE2_REJECTED` (KD-2.1-P). Узгоджено з task 2.4.8 retry-on-ERROR.

## Acceptance (5/5)

| # | Критерій | Результат |
|---|---|---|
| 1 | `tests/integration/test_video_skeleton.py` → 7 гнізд → `state=ready` + Summary + Segment[] | ✅ 2/2 (`--run-db`) |
| 2 | Failure-injection (R1) → `state=ERROR` + `error_message`, рядок retained, нічого не persisted | ✅ |
| 3 | `rg "from course_supporter.vd" video_pipeline/` → 0 hits | ✅ |
| 4 | Non-db регрес `pytest -m "not requires_db and not requires_redis and not smoke"` | ✅ 2078 passed, 3 skipped |
| 5 | Scope: лише namespace + factory wiring + тести; `video.py`/`vd/` не торкнуто | ✅ |

Плюс `ruff` clean + `mypy src/` strict (131 files) clean.

## Відкритий пункт (vision-side)

**R1 brief-amendment** до `PHASE-2-4-task-1.md` (acceptance #2 + інваріант) — ратифікація vision-side окремо; код уже припускає R1.

> ⚠️ PR на `main` за рішенням operator (швидше); синхронізація з `dev` — окремо на стороні operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)