### PR TITLE
task(2.4.2): ingestion + STT — fill video pipeline Krok 1-2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ asyncio_mode = "auto"
 markers = [
     "requires_db: test needs a running PostgreSQL instance",
     "requires_redis: test needs a running Redis instance",
+    "requires_ffmpeg: test needs ffmpeg/ffprobe on PATH (auto-skipped if absent)",
     "audio_smoke: real-API audio pipeline smoke test (requires RUN_SMOKE=1)",
     "presentation_smoke: real-API presentation pipeline smoke test (requires RUN_SMOKE=1)",
     "authored_safety_smoke: real-API authored Stage 2 safety smoke test (requires RUN_SMOKE=1)",

--- a/src/course_supporter/ingestion/factory.py
+++ b/src/course_supporter/ingestion/factory.py
@@ -130,35 +130,22 @@ def create_processors(
     Args:
         heavy: Bundle of heavy step callables.
         vd_pipeline: Optional VDPipeline (legacy ``vd/`` visual analysis).
-            Unused since Phase 2.4 task 2.4.1 — the new skeleton
-            VideoProcessor takes no deps; retained for the real Pass 1
-            vision wiring (task 2.4.4).
-        stt_router: Optional STTRouter for audio transcription (and, from
-            task 2.4.2, video STT). AudioProcessor uses it today; the
-            VIDEO skeleton does not yet consume it.
-        redis: Optional ArqRedis client for the audio word-cache
-            (KD-2.2-D). AudioProcessor is registered only when both
-            ``stt_router`` and ``redis`` are non-None — both dependencies
-            are required for the three-stage pipeline (STT in stage 1 +
-            cache hand-off across stages).
+            Unused by the new video_pipeline namespace; retained for the
+            real Pass 1 vision wiring (task 2.4.4). Passing it into the
+            VIDEO processor would couple the new namespace to legacy
+            ``vd/`` types (isolation per 2.4.1 acceptance #3).
+        stt_router: Optional STTRouter for VIDEO + AUDIO transcription.
+        redis: Optional ArqRedis client for the STT inter-stage carriers
+            (video ``video_stt_result``; audio word-cache KD-2.2-D).
 
     Returns:
         Mapping from SourceType to fully-wired processor instances.
-        ``SourceType.AUDIO`` is absent from the result when the combined
-        guard above is unsatisfied; factory dispatch in ``api/tasks.py``
-        raises ``KeyError`` for unwired source types.
+        ``SourceType.VIDEO`` and ``SourceType.AUDIO`` are absent when the
+        combined guard below is unsatisfied (both need STT + Redis);
+        factory dispatch in ``api/tasks.py`` raises ``KeyError`` for
+        unwired source types.
     """
-    # Phase 2.4 task 2.4.1 — VIDEO routes to the new skeleton
-    # VideoProcessor (``ingestion.video_pipeline``). Its 7-step pipeline is
-    # stubbed (zero external calls); real edges land in tasks 2.4.2-2.4.7
-    # and the legacy ``ingestion.video`` processors are removed in 2.4.9.
-    # The skeleton takes no constructor deps — ``stt_router`` (real STT,
-    # task 2.4.2) and ``vd_pipeline`` (real Pass 1 vision, task 2.4.4) are
-    # retained on the factory for that future wiring; passing them into
-    # the skeleton would couple the new namespace to legacy ``vd/`` types
-    # (isolation per 2.4.1 acceptance #3).
     result: dict[SourceType, MaterialProcessor] = {
-        SourceType.VIDEO: VideoProcessor(),
         SourceType.PRESENTATION: PresentationProcessor(),
         SourceType.TEXT: TextProcessor(),
         SourceType.WEB: WebProcessor(
@@ -166,7 +153,15 @@ def create_processors(
         ),
     }
 
+    # VIDEO + AUDIO share the same two deps: STT in stage 1 + a Redis
+    # inter-stage carrier across stages. Phase 2.4 task 2.4.2 wired the
+    # real VideoProcessor (``ingestion.video_pipeline``); the legacy
+    # ``ingestion.video`` processors are removed in 2.4.9.
     if stt_router is not None and redis is not None:
+        result[SourceType.VIDEO] = VideoProcessor(
+            stt_router=stt_router,
+            redis=redis,
+        )
         result[SourceType.AUDIO] = AudioProcessor(
             stt_router=stt_router,
             redis=redis,

--- a/src/course_supporter/ingestion/video_pipeline/media.py
+++ b/src/course_supporter/ingestion/video_pipeline/media.py
@@ -1,0 +1,237 @@
+"""Subprocess wrappers for the video media toolchain (Phase 2.4 task 2.4.2).
+
+Thin, pipeline-agnostic adapters over the external binaries the video
+ingestion edges (Krok 1-2) need: yt-dlp (URL video-stream download),
+ffprobe (container metadata), ffmpeg (audio-track extraction). Each
+function shells out and maps failure onto the task 2.4.2 taxonomy (D3):
+
+* :class:`~course_supporter.ingestion.base.UnsupportedFormatError` —
+  *constraint* failures (size/duration cap, corrupt/unsupported
+  container).
+* :class:`~course_supporter.ingestion.base.ProcessingError` —
+  *operational* failures (download fail, ffmpeg extract fail, missing
+  binary, timeout).
+
+No ``SourceDocument`` / ORM / Redis knowledge lives here — pure value
+in, value out. The pure parsing helper :func:`_parse_probe` is
+unit-tested directly; the subprocess orchestration runs for real only
+in the ``requires_ffmpeg`` integration test. Isolated from the legacy
+``course_supporter.vd`` module (task 2.4.1 acceptance #3).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from course_supporter.ingestion.base import ProcessingError, UnsupportedFormatError
+from course_supporter.ingestion.video_pipeline.schemas import VideoFileMetadata
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = structlog.get_logger()
+
+# 5 GB — mirrors ``AUTHORED_POLICY.max_video_size_bytes``. Enforced
+# worker-side for the URL path because the HTTP ``file.size`` guard does
+# not reach yt-dlp downloads (D2: ``--max-filesize`` + this post-download
+# check are the two layers).
+_MAX_VIDEO_SIZE_BYTES = 5 * 1024 * 1024 * 1024
+
+_DOWNLOAD_TIMEOUT_SEC = 600.0
+_PROBE_TIMEOUT_SEC = 30.0
+_EXTRACT_TIMEOUT_SEC = 600.0
+
+_ERR_TAIL = 500  # bytes of stderr surfaced in error messages
+
+
+async def _run(cmd: list[str], *, timeout_sec: float) -> tuple[int, bytes, bytes]:
+    """Run ``cmd`` to completion, returning ``(returncode, stdout, stderr)``.
+
+    Raises :class:`ProcessingError` when the binary is missing or the
+    command exceeds ``timeout_sec`` (the process is killed first).
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise ProcessingError(f"Required binary not found: {cmd[0]} ({exc}).") from exc
+
+    try:
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout_sec)
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise ProcessingError(
+            f"Command timed out after {timeout_sec:.0f}s: {cmd[0]}."
+        ) from None
+
+    returncode = proc.returncode if proc.returncode is not None else 1
+    return returncode, out, err
+
+
+async def download_video(url: str, dest_dir: Path) -> Path:
+    """Download a video *stream* from ``url`` via yt-dlp (Krok 1, URL path).
+
+    Downloads best video+audio merged into an mp4 container (NOT
+    audio-only — the legacy ``WhisperVideoProcessor`` audio-only download
+    is explicitly not the model, R0.2). Host allowlist is best-effort
+    (D2): an unsupported/private host surfaces as a yt-dlp non-zero exit
+    → ``ProcessingError``. The 5 GB cap is enforced both via
+    ``--max-filesize`` and a post-download size check.
+    """
+    out_template = str(dest_dir / "source.%(ext)s")
+    cmd = [
+        sys.executable,
+        "-m",
+        "yt_dlp",
+        "-f",
+        "bv*+ba/b",
+        "--merge-output-format",
+        "mp4",
+        "--max-filesize",
+        "5G",
+        "--no-playlist",
+        "--quiet",
+        "--no-warnings",
+        "-o",
+        out_template,
+        url,
+    ]
+    rc, _out, err = await _run(cmd, timeout_sec=_DOWNLOAD_TIMEOUT_SEC)
+    if rc != 0:
+        raise ProcessingError(
+            f"yt-dlp download failed (code {rc}) for {url}: "
+            f"{err.decode(errors='replace')[:_ERR_TAIL]}"
+        )
+    # Filesystem inspection off the event loop (ASYNC240).
+    return await asyncio.to_thread(_resolve_download, dest_dir, url)
+
+
+def _resolve_download(dest_dir: Path, url: str) -> Path:
+    """Locate the merged yt-dlp output and enforce the 5 GB cap (sync)."""
+    candidates = [p for p in dest_dir.glob("source.*") if p.is_file()]
+    if not candidates:
+        raise ProcessingError(f"yt-dlp produced no output file for {url}.")
+    video_path = max(candidates, key=lambda p: p.stat().st_size)
+
+    size = video_path.stat().st_size
+    if size > _MAX_VIDEO_SIZE_BYTES:
+        raise UnsupportedFormatError(
+            f"Downloaded video ({size / 1024**3:.2f} GB) exceeds maximum "
+            f"{_MAX_VIDEO_SIZE_BYTES // 1024**3} GB."
+        )
+    return video_path
+
+
+async def probe_metadata(path: Path) -> VideoFileMetadata:
+    """Probe container metadata via ffprobe (Krok 1, §1 ``file_metadata``).
+
+    Returns duration_ms / codec / resolution. A corrupt or non-video
+    container surfaces as ``UnsupportedFormatError`` (constraint, D3).
+    """
+    rc, out, err = await _run(
+        [
+            "ffprobe",
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
+            "-show_format",
+            "-show_streams",
+            str(path),
+        ],
+        timeout_sec=_PROBE_TIMEOUT_SEC,
+    )
+    if rc != 0:
+        raise UnsupportedFormatError(
+            f"ffprobe failed (code {rc}) on {path.name}: "
+            f"{err.decode(errors='replace')[:_ERR_TAIL]}"
+        )
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError as exc:
+        raise UnsupportedFormatError(
+            f"ffprobe returned invalid JSON for {path.name}: {exc}."
+        ) from exc
+    return _parse_probe(data, source_name=path.name)
+
+
+def _parse_probe(data: dict[str, Any], *, source_name: str) -> VideoFileMetadata:
+    """Map ffprobe ``-show_format -show_streams`` JSON to ``VideoFileMetadata``.
+
+    Pure (no I/O) so it can be unit-tested with recorded ffprobe output.
+    Raises ``UnsupportedFormatError`` when there is no video stream or
+    no derivable duration (corrupt / unsupported container).
+    """
+    streams = data.get("streams") or []
+    video_streams = [s for s in streams if s.get("codec_type") == "video"]
+    if not video_streams:
+        raise UnsupportedFormatError(
+            f"No video stream found in {source_name} "
+            f"(unsupported or corrupt container)."
+        )
+    vs = video_streams[0]
+    fmt = data.get("format") or {}
+
+    duration_s = fmt.get("duration") or vs.get("duration")
+    if duration_s is None:
+        raise UnsupportedFormatError(
+            f"Could not determine duration for {source_name} "
+            f"(corrupt or unsupported container)."
+        )
+    duration_ms = round(float(duration_s) * 1000)
+
+    codec = str(vs.get("codec_name") or "unknown")
+    width, height = vs.get("width"), vs.get("height")
+    resolution = f"{width}x{height}" if width and height else "unknown"
+
+    return VideoFileMetadata(
+        duration_ms=duration_ms,
+        codec=codec,
+        resolution=resolution,
+    )
+
+
+async def extract_audio(video_path: Path, dest_dir: Path) -> Path:
+    """Extract the audio track to mono 16 kHz mp3 via ffmpeg (Krok 2).
+
+    Output format aligns with the ElevenLabs Scribe core: the provider
+    derives its multipart content-type from the file extension
+    (``guess_content_type`` → ``.mp3`` = ``audio/mpeg``); mono/16 kHz is
+    a free, Scribe-compatible STT canonical (the core imposes no
+    sample-rate constraint). Failure → ``ProcessingError`` (operational).
+    """
+    audio_path = dest_dir / "audio.mp3"
+    rc, _out, err = await _run(
+        [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(video_path),
+            "-vn",
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            "-f",
+            "mp3",
+            str(audio_path),
+        ],
+        timeout_sec=_EXTRACT_TIMEOUT_SEC,
+    )
+    if rc != 0:
+        raise ProcessingError(
+            f"ffmpeg audio extraction failed (code {rc}) on "
+            f"{video_path.name}: {err.decode(errors='replace')[:_ERR_TAIL]}"
+        )
+    if not await asyncio.to_thread(audio_path.exists):
+        raise ProcessingError(f"ffmpeg produced no audio output for {video_path.name}.")
+    return audio_path

--- a/src/course_supporter/ingestion/video_pipeline/media.py
+++ b/src/course_supporter/ingestion/video_pipeline/media.py
@@ -30,17 +30,24 @@ import structlog
 
 from course_supporter.ingestion.base import ProcessingError, UnsupportedFormatError
 from course_supporter.ingestion.video_pipeline.schemas import VideoFileMetadata
+from course_supporter.security.policies import AUTHORED_POLICY
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 logger = structlog.get_logger()
 
-# 5 GB — mirrors ``AUTHORED_POLICY.max_video_size_bytes``. Enforced
-# worker-side for the URL path because the HTTP ``file.size`` guard does
-# not reach yt-dlp downloads (D2: ``--max-filesize`` + this post-download
-# check are the two layers).
-_MAX_VIDEO_SIZE_BYTES = 5 * 1024 * 1024 * 1024
+# Single source of truth: the authored upload policy's video size cap
+# (5 GB). Enforced worker-side for the URL path because the HTTP
+# ``file.size`` guard does not reach yt-dlp downloads (D2). Both layers —
+# yt-dlp ``--max-filesize`` and the post-download check — derive from this
+# byte value (passing bytes to yt-dlp also avoids the ``5G`` unit
+# ambiguity). ``max_video_size_bytes`` is Optional on ``ContextPolicy``;
+# the authored policy always sets it, and the fallback keeps the type
+# ``int`` with a safe default.
+_MAX_VIDEO_SIZE_BYTES: int = (
+    AUTHORED_POLICY.max_video_size_bytes or 5 * 1024 * 1024 * 1024
+)
 
 _DOWNLOAD_TIMEOUT_SEC = 600.0
 _PROBE_TIMEOUT_SEC = 30.0
@@ -97,7 +104,7 @@ async def download_video(url: str, dest_dir: Path) -> Path:
         "--merge-output-format",
         "mp4",
         "--max-filesize",
-        "5G",
+        str(_MAX_VIDEO_SIZE_BYTES),
         "--no-playlist",
         "--quiet",
         "--no-warnings",

--- a/src/course_supporter/ingestion/video_pipeline/media.py
+++ b/src/course_supporter/ingestion/video_pipeline/media.py
@@ -53,7 +53,9 @@ _DOWNLOAD_TIMEOUT_SEC = 600.0
 _PROBE_TIMEOUT_SEC = 30.0
 _EXTRACT_TIMEOUT_SEC = 600.0
 
-_ERR_TAIL = 500  # bytes of stderr surfaced in error messages
+# Bytes of stderr surfaced in error messages — the *tail*, since ffmpeg /
+# yt-dlp print version/config banners first and the actual error last.
+_ERR_TAIL = 1024
 
 
 async def _run(cmd: list[str], *, timeout_sec: float) -> tuple[int, bytes, bytes]:
@@ -116,7 +118,7 @@ async def download_video(url: str, dest_dir: Path) -> Path:
     if rc != 0:
         raise ProcessingError(
             f"yt-dlp download failed (code {rc}) for {url}: "
-            f"{err.decode(errors='replace')[:_ERR_TAIL]}"
+            f"{err.decode(errors='replace')[-_ERR_TAIL:]}"
         )
     # Filesystem inspection off the event loop (ASYNC240).
     return await asyncio.to_thread(_resolve_download, dest_dir, url)
@@ -160,7 +162,7 @@ async def probe_metadata(path: Path) -> VideoFileMetadata:
     if rc != 0:
         raise UnsupportedFormatError(
             f"ffprobe failed (code {rc}) on {path.name}: "
-            f"{err.decode(errors='replace')[:_ERR_TAIL]}"
+            f"{err.decode(errors='replace')[-_ERR_TAIL:]}"
         )
     try:
         data = json.loads(out)
@@ -237,7 +239,7 @@ async def extract_audio(video_path: Path, dest_dir: Path) -> Path:
     if rc != 0:
         raise ProcessingError(
             f"ffmpeg audio extraction failed (code {rc}) on "
-            f"{video_path.name}: {err.decode(errors='replace')[:_ERR_TAIL]}"
+            f"{video_path.name}: {err.decode(errors='replace')[-_ERR_TAIL:]}"
         )
     if not await asyncio.to_thread(audio_path.exists):
         raise ProcessingError(f"ffmpeg produced no audio output for {video_path.name}.")

--- a/src/course_supporter/ingestion/video_pipeline/processor.py
+++ b/src/course_supporter/ingestion/video_pipeline/processor.py
@@ -1,10 +1,9 @@
-"""VideoProcessor skeleton — 7-step video pipeline on stubs (Phase 2.4).
+"""VideoProcessor — 7-step video pipeline (Phase 2.4).
 
-Task 2.4.1: a thin, end-to-end topology kistyak. The canonical 7-step
-flow (``PHASE-2-4.md`` §1) maps onto the existing 3-method
-:class:`~course_supporter.ingestion.base.MaterialProcessor` contract
-without extending it (symmetric with the audio precedent, which folds
-Pass 2c into ``process_detail``):
+The canonical 7-step flow (``PHASE-2-4.md`` §1) maps onto the existing
+3-method :class:`~course_supporter.ingestion.base.MaterialProcessor`
+contract without extending it (symmetric with the audio precedent, which
+folds Pass 2c into ``process_detail``):
 
 * :meth:`process_raw`    — Krok 1-4 (ingest → STT → detection → Pass 1)
                            → ``SourceDocument``.
@@ -12,23 +11,31 @@ Pass 2c into ``process_detail``):
 * :meth:`process_detail` — Krok 6-7 (Pass 2b slice + Pass 2c cleanup)
                            → ``list[DocumentSegmentDraft]``.
 
-Each gnízdo lives in :mod:`course_supporter.ingestion.video_pipeline.steps`
-as an offline stub; data flows in-memory between them. No external calls
-(S3, ffmpeg, ElevenLabs, LLM) and no ``Job.stage_progress`` / Redis are
-touched in the skeleton — real edges + the inter-stage transport land in
-tasks 2.4.2-2.4.7. The new namespace has zero imports from the legacy
-``course_supporter.vd`` module (isolation per task 2.4.1 acceptance #3).
+Each gnízdo lives in :mod:`course_supporter.ingestion.video_pipeline.steps`.
+Krok 1-2 are real as of task 2.4.2 (ingestion + STT); Krok 3-7 remain
+stubs (tasks 2.4.3-2.4.7). Data flows in-memory between steps; the STT
+carrier is *additionally* written to Redis (``video_stt_result:{job_id}``,
+TTL 3600 s) as the producer side of the inter-stage transport for the
+future Pass 2a consumer (Krok 5, task 2.4.5) — mirroring the audio
+word-cache, NOT the deadlocking ``jobs`` row (rule #12). The namespace
+has zero imports from the legacy ``course_supporter.vd`` module (isolation
+per task 2.4.1 acceptance #3).
 
 Factory dispatch invariant: ``create_processors`` routes by
 ``source_type`` so this processor only receives ``SourceType.VIDEO``
 inputs; no entry guard is needed (matches AudioProcessor / Phase 2.2).
+``stt_router`` + ``redis`` are required constructor deps (STT in Krok 2 +
+the Redis carrier) — the factory registers VIDEO only when both are
+present, symmetric with AUDIO.
 """
 
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-from course_supporter.ingestion.base import MaterialProcessor
+from course_supporter.ingestion.base import MaterialProcessor, ProcessingError
 from course_supporter.ingestion.video_pipeline import steps
 from course_supporter.models.source import (
     ChunkType,
@@ -36,8 +43,13 @@ from course_supporter.models.source import (
     SourceDocument,
     SourceType,
 )
+from course_supporter.service_logging import get_current_job_id
 
 if TYPE_CHECKING:
+    import uuid
+
+    from arq.connections import ArqRedis
+
     from course_supporter.ingestion.schemas import (
         DocumentSegmentDraft,
         DocumentSummaryDraft,
@@ -49,16 +61,29 @@ if TYPE_CHECKING:
     from course_supporter.llm.router import ModelRouter
     from course_supporter.llm.stage_router import StageRouter
     from course_supporter.storage.orm import AuthoredDocument
+    from course_supporter.stt.router import STTRouter
+
+_STT_RESULT_TTL_SEC = 3600
+_STT_RESULT_KEY_TMPL = "video_stt_result:{job_id}"
 
 
 class VideoProcessor(MaterialProcessor):
-    """Video source-type processor — skeleton over 7 stub gnízda.
+    """Video source-type processor — three-stage ingestion over 7 gnízda.
 
-    See module docstring for the 7-step → 3-method mapping. Takes no
-    constructor dependencies: the skeleton makes zero external calls, so
-    STT / vision / LLM clients are wired only when their real gnízda land
-    (tasks 2.4.2/2.4.4/2.4.5/2.4.7).
+    See module docstring for the 7-step → 3-method mapping and the Redis
+    inter-stage carrier. Requires ``stt_router`` (Krok 2 transcription)
+    and ``redis`` (STT-carrier write) — mirrors ``AudioProcessor``.
     """
+
+    def __init__(
+        self,
+        *,
+        stt_router: STTRouter,
+        redis: ArqRedis,
+    ) -> None:
+        super().__init__()
+        self._stt_router = stt_router
+        self._redis = redis
 
     async def process_raw(
         self,
@@ -68,15 +93,49 @@ class VideoProcessor(MaterialProcessor):
     ) -> SourceDocument:
         """Krok 1-4 → ``SourceDocument``.
 
-        The ``router`` parameter is accepted for ABC symmetry but unused
-        in the skeleton (the real Pass 1 vision call wires its own ladder
-        in task 2.4.4).
+        Reads ``job_id`` from the ContextVar (set at ARQ task entry) for
+        the Redis carrier key. All transient files (yt-dlp download +
+        extracted audio) live in a processor-owned tempdir cleaned on
+        exit. The ``router`` parameter is accepted for ABC symmetry but
+        unused (the real Pass 1 vision call wires its own ladder in task
+        2.4.4).
         """
-        file_metadata = await steps.step_1_ingest(source)
-        stt = await steps.step_2_stt(source, file_metadata)
-        scenes = await steps.step_3_detection(stt)
-        frame_descriptions = await steps.step_4_pass1_vision(scenes)
-        return self._assemble_source_document(source, stt, frame_descriptions)
+        job_id = get_current_job_id()
+        if job_id is None:
+            raise ProcessingError(
+                "VideoProcessor.process_raw requires ContextVar job_id; "
+                "the ARQ task entry must set it before invocation."
+            )
+
+        with tempfile.TemporaryDirectory(prefix="video_ingest_") as tmp_dir:
+            tmp = Path(tmp_dir)
+            video_path, file_metadata = await steps.step_1_ingest(source, tmp=tmp)
+            stt = await steps.step_2_stt(
+                video_path,
+                file_metadata,
+                stt_router=self._stt_router,
+                tmp=tmp,
+            )
+            await self._store_stt_result(job_id, stt)
+            scenes = await steps.step_3_detection(stt)
+            frame_descriptions = await steps.step_4_pass1_vision(scenes)
+            doc = self._assemble_source_document(source, stt, frame_descriptions)
+
+        if stt.detected_language:
+            doc.metadata["detected_language"] = stt.detected_language
+        return doc
+
+    async def _store_stt_result(self, job_id: uuid.UUID, stt: SttResult) -> None:
+        """Write the STT carrier to Redis for the future Pass 2a consumer.
+
+        Producer side of the inter-stage transport (task 2.4.2); the
+        consumer (Krok 5, Pass 2a) lands in task 2.4.5. Key
+        ``video_stt_result:{job_id}``, TTL 3600 s, payload
+        ``SttResult.model_dump_json()`` — the audio word-cache pattern,
+        NOT the ``jobs`` row (rule #12 deadlock).
+        """
+        key = _STT_RESULT_KEY_TMPL.format(job_id=job_id)
+        await self._redis.set(key, stt.model_dump_json(), ex=_STT_RESULT_TTL_SEC)
 
     @staticmethod
     def _assemble_source_document(

--- a/src/course_supporter/ingestion/video_pipeline/schemas.py
+++ b/src/course_supporter/ingestion/video_pipeline/schemas.py
@@ -1,12 +1,12 @@
-"""Mock data-structure shapes for the video pipeline skeleton (Phase 2.4).
+"""Data-structure shapes for the video pipeline (Phase 2.4 §1, Krok 1-4).
 
-These carriers mirror the *forms* of the per-step structures described in
-``PHASE-2-4.md`` §1 (Krok 1-4 intermediate state). The skeleton (task
-2.4.1) threads them in-memory between gnízda — no DB / Redis / external
-calls. Tasks 2.4.2-2.4.7 replace the stub bodies in :mod:`steps` with
-real logic; the shapes here are deliberately minimal and may be widened
-(or moved to the proper inter-stage transport — Redis per the audio
-precedent — when a real, large transient payload motivates it).
+These carriers mirror the per-step structures described in
+``PHASE-2-4.md`` §1. Krok 1-2 (``VideoFileMetadata`` / ``SttResult``) are
+real as of task 2.4.2: ``SttResult`` is the **inter-stage carrier**
+serialised to Redis (``video_stt_result:{job_id}``) for the future Pass
+2a consumer (Krok 5, task 2.4.5). Krok 3-4 carriers (``Scene`` /
+``FrameDescription``) are still produced by stubs; tasks 2.4.3-2.4.4
+fill them.
 
 Pass 2a/2b/2c (Krok 5-7) reuse the existing pipeline carriers
 ``DocumentSummaryDraft`` / ``DocumentSegmentDraft`` rather than redefining
@@ -48,16 +48,26 @@ class SttPause(BaseModel):
 
 
 class SttResult(BaseModel):
-    """Krok 2 — STT output (ElevenLabs Scribe in the real pipeline, §1).
+    """Krok 2 — STT output (ElevenLabs Scribe via the audio core, §1).
 
     ``words`` is a word-level stream (not a flat string) so downstream
-    Pass 2a/2b can align segment boundaries to ``pauses``.
+    Pass 2a/2b can align segment boundaries to ``pauses``. ``duration_ms``
+    comes from ffprobe (Krok 1), not STT word-end derivation.
+    Serialised to Redis as the inter-stage carrier for Pass 2a.
     """
 
     language: str
     duration_ms: int
     words: list[SttWord] = Field(default_factory=list)
     pauses: list[SttPause] = Field(default_factory=list)
+    detected_language: str | None = Field(
+        default=None,
+        description=(
+            "ISO 639-1 code reported by the provider on auto-detection; "
+            "surfaced to the orchestrator's language-cache (None when the "
+            "caller pinned the language)."
+        ),
+    )
 
 
 class ChangeClass(StrEnum):

--- a/src/course_supporter/ingestion/video_pipeline/steps.py
+++ b/src/course_supporter/ingestion/video_pipeline/steps.py
@@ -1,18 +1,22 @@
-"""Seven pipeline gnízda (steps) as offline stubs (Phase 2.4 task 2.4.1).
+"""Seven pipeline gnízda (steps) of the canonical 7-step video flow.
 
-Each function is one gnízdo of the canonical 7-step video flow
-(``PHASE-2-4.md`` §1). In the skeleton every step is a deterministic
-stub: zero network / disk / LLM, returns a mock structure of the §1
-shape. Data flows in-memory between steps (return values / arguments);
-no ``Job.stage_progress`` or Redis is written in the skeleton.
+Each function is one gnízdo of ``PHASE-2-4.md`` §1. Krok 1-2 are real
+as of task 2.4.2 (ingestion via S3/yt-dlp + ffprobe; STT via ffmpeg
+audio extraction → ElevenLabs Scribe core); Krok 3-7 remain offline
+stubs returning mock §1 structures (tasks 2.4.3-2.4.7 fill them).
 
-Filling order (per ``PHASE-2-4.md`` §3): each later task (2.4.2-2.4.7)
-replaces the body of exactly one step here with real logic, without
-touching its neighbours. Real implementations raise
-:class:`~course_supporter.ingestion.base.ProcessingError` per their
-own error taxonomy (drafted per-task); the skeleton's failure-injection
-point is to patch any one of these step functions to raise (see
-``tests/integration/test_video_skeleton.py``).
+Data flows in-memory between steps (return values / arguments). The
+real STT carrier is *additionally* written to Redis by the processor
+(``video_stt_result:{job_id}``) for the future Pass 2a consumer — that
+producer write lives in ``processor.py``, not here.
+
+Filling order (per ``PHASE-2-4.md`` §3): each task replaces one or two
+step bodies, leaving neighbours and the ``VideoProcessor`` orchestration
+untouched. Real steps raise
+:class:`~course_supporter.ingestion.base.UnsupportedFormatError`
+(constraint) or :class:`~course_supporter.ingestion.base.ProcessingError`
+(operational) per the per-task taxonomy (D3); the failure-injection seam
+is to patch any step (or ``media.*``) to raise (see the tests).
 
 Steps 1-4 are invoked from ``VideoProcessor.process_raw``; step 5 from
 ``process_macro``; steps 6-7 from ``process_detail``.
@@ -20,12 +24,16 @@ Steps 1-4 are invoked from ``VideoProcessor.process_raw``; step 5 from
 
 from __future__ import annotations
 
+import itertools
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+from course_supporter.ingestion.base import UnsupportedFormatError
 from course_supporter.ingestion.schemas import (
     DocumentSegmentDraft,
     DocumentSummaryDraft,
 )
+from course_supporter.ingestion.video_pipeline import media
 from course_supporter.ingestion.video_pipeline.schemas import (
     ChangeClass,
     FrameDescription,
@@ -41,45 +49,116 @@ from course_supporter.ingestion.video_pipeline.schemas import (
 if TYPE_CHECKING:
     from course_supporter.models.source import SourceDocument
     from course_supporter.storage.orm import AuthoredDocument
+    from course_supporter.stt.router import STTRouter
+
+# 150 min — mirrors AudioProcessor.MAX_DURATION_SEC (Phase 2.2 vision §5).
+# Enforced worker-side after ffprobe, BEFORE STT, so an over-long video
+# never reaches the (billable) Scribe call.
+_MAX_DURATION_MS = 150 * 60 * 1000
+
+# Minimum inter-word silence (ms) treated as a Pass 2a boundary candidate.
+# rationale: starting default; calibrated in 2.4.5 (the real consumer of
+# pauses — Pass 2a segment boundaries, KD2c).
+_PAUSE_THRESHOLD_MS = 700
 
 
 # ── Krok 1-4 — invoked from process_raw ────────────────────────────
 
 
-async def step_1_ingest(source: AuthoredDocument) -> VideoFileMetadata:
-    """Krok 1 — resolve container metadata (§1).
+async def step_1_ingest(
+    source: AuthoredDocument,
+    *,
+    tmp: Path,
+) -> tuple[Path, VideoFileMetadata]:
+    """Krok 1 — resolve the local video + probe container metadata (§1).
 
-    Skeleton: no S3 download / ffprobe (task 2.4.2). Reads
-    ``source_url`` only to mirror the real signature; never opens the
-    file. Returns a fixed mock metadata shape.
+    Two source paths (the S3 download already happened in the
+    orchestrator's ``_resolve_s3_url``, so an ``s3://`` upload arrives as
+    a local temp path here):
+
+    * ``http(s)://`` → yt-dlp video-stream download into ``tmp``;
+    * anything else → treated as an already-local file path.
+
+    Then ffprobe fills ``file_metadata`` and the 150-min duration cap is
+    enforced (constraint → ``UnsupportedFormatError``, R1 ``state=ERROR``)
+    before any STT cost is incurred. Returns the resolved local path
+    (consumed by Krok 2) alongside the metadata.
     """
-    _ = source.source_url
-    return VideoFileMetadata(
-        duration_ms=600_000,
-        codec="h264",
-        resolution="1920x1080",
-    )
+    url = source.source_url
+    if url.startswith(("http://", "https://")):
+        video_path = await media.download_video(url, tmp)
+    else:
+        video_path = Path(url)
+
+    file_metadata = await media.probe_metadata(video_path)
+
+    if file_metadata.duration_ms > _MAX_DURATION_MS:
+        raise UnsupportedFormatError(
+            f"Video duration ({file_metadata.duration_ms / 60_000:.1f} min) "
+            f"exceeds maximum {_MAX_DURATION_MS // 60_000} min."
+        )
+
+    return video_path, file_metadata
 
 
 async def step_2_stt(
-    source: AuthoredDocument,
+    video_path: Path,
     file_metadata: VideoFileMetadata,
+    *,
+    stt_router: STTRouter,
+    tmp: Path,
 ) -> SttResult:
-    """Krok 2 — speech-to-text (§1).
+    """Krok 2 — extract the audio track and transcribe it (§1).
 
-    Skeleton: no audio extraction / ElevenLabs call (task 2.4.2).
-    Returns a tiny deterministic word stream plus one pause candidate.
+    ffmpeg extracts a Scribe-friendly mono 16 kHz mp3 into ``tmp`` (the
+    processor-owned tempdir, so it is cleaned with the rest — the S3
+    source path lives outside ``tmp`` and must not collect siblings).
+    The file path is handed to the reused audio ElevenLabs Scribe core
+    via ``STTRouter.transcribe`` (one external call). The STT-domain
+    result (seconds) is converted to the §1 ms-based ``SttResult``;
+    ``pauses`` are derived from inter-word silence (no provider field
+    surfaces them). ``duration_ms`` comes from ffprobe (Krok 1), not STT
+    word-ends.
     """
-    _ = source.source_url
-    return SttResult(
-        language="en",
-        duration_ms=file_metadata.duration_ms,
-        words=[
-            SttWord(text="Hello", start_ms=0, end_ms=500),
-            SttWord(text="world", start_ms=500, end_ms=1000),
-        ],
-        pauses=[SttPause(start_ms=1000, end_ms=1500)],
+    audio_path = await media.extract_audio(video_path, tmp)
+
+    # language=None mirrors AudioProcessor: always auto-detect; the
+    # orchestrator caches the detected language back onto the entry.
+    result = await stt_router.transcribe(
+        "transcribe",
+        str(audio_path),
+        language=None,
     )
+
+    words = [
+        SttWord(
+            text=w.text,
+            start_ms=round(w.start_sec * 1000),
+            end_ms=round(w.end_sec * 1000),
+        )
+        for w in result.words
+    ]
+
+    return SttResult(
+        language=result.language or "und",
+        duration_ms=file_metadata.duration_ms,
+        words=words,
+        pauses=_derive_pauses(words),
+        detected_language=result.detected_language,
+    )
+
+
+def _derive_pauses(words: list[SttWord]) -> list[SttPause]:
+    """Derive Pass 2a boundary candidates from inter-word silence (KD2c).
+
+    Scribe surfaces no explicit pause field, so a pause is any gap
+    ``>= _PAUSE_THRESHOLD_MS`` between consecutive words.
+    """
+    pauses: list[SttPause] = []
+    for prev, nxt in itertools.pairwise(words):
+        if nxt.start_ms - prev.end_ms >= _PAUSE_THRESHOLD_MS:
+            pauses.append(SttPause(start_ms=prev.end_ms, end_ms=nxt.start_ms))
+    return pauses
 
 
 async def step_3_detection(stt: SttResult) -> list[Scene]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """Shared pytest fixtures."""
 
+import shutil
+
 import pytest
 
 
@@ -31,7 +33,14 @@ def pytest_collection_modifyitems(
         for marker_name, (option_flag, reason_msg) in markers_to_check.items()
     }
 
+    # ffmpeg is orthogonal to the DB/Redis flags: gate on binary
+    # presence (auto-skip if absent), not a CLI flag, so the skip reason
+    # names its own dependency cleanly.
+    ffmpeg_missing = shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None
+
     for item in items:
         for marker_name, (should_skip, reason_msg) in skip_conditions.items():
             if should_skip and marker_name in item.keywords:
                 item.add_marker(pytest.mark.skip(reason=reason_msg))
+        if ffmpeg_missing and "requires_ffmpeg" in item.keywords:
+            item.add_marker(pytest.mark.skip(reason="needs ffmpeg/ffprobe on PATH"))

--- a/tests/integration/test_video_skeleton.py
+++ b/tests/integration/test_video_skeleton.py
@@ -1,16 +1,21 @@
-"""End-to-end skeleton topology test for the video_pipeline (Phase 2.4 task 2.4.1).
+"""End-to-end topology tests for the video_pipeline (Phase 2.4).
 
 Drives the real ``arq_ingest_material`` orchestrator against a live DB
-with the new skeleton ``VideoProcessor`` injected via ``create_processors``.
-All 7 gnízda are offline stubs (zero external calls); Stage 2 safety and
-ARQ work-window are patched. The test verifies pipeline topology:
+with the ``VideoProcessor`` injected via ``create_processors``. Krok 1-2
+are real (task 2.4.2); the external toolchain (ffmpeg/ffprobe) and the
+ElevenLabs Scribe core are mocked in the ``requires_db`` tests so they
+stay independent of ffmpeg, and exercised for real in the separate
+``requires_ffmpeg`` test on an ffmpeg-generated fixture (no binary in
+VCS). Stage 2 safety + the ARQ work-window are patched.
 
 * happy path — ``source_type=video`` traverses all 7 gnízda → ``state=ready``
   with a persisted ``DocumentSummary`` + ``DocumentSegment[]`` (cascade
   content_hash to root);
-* R1 failure path — a gnízdo raising ``ProcessingError`` → ``state=ERROR``
-  with non-empty ``error_message``, the row **retained** (NOT soft-deleted,
-  per KD-2.1-P + task 2.4.8 retry), and nothing persisted.
+* R1 failure path — a gnízdo raising → ``state=ERROR`` with non-empty
+  ``error_message``, the row **retained** (NOT soft-deleted, KD-2.1-P +
+  task 2.4.8 retry), and nothing persisted;
+* real-ffmpeg path — a 1 s ``tiny.mp4`` generated at runtime runs through
+  real ffprobe + ffmpeg (mock STT) → ``state=ready``.
 
 Requires ``docker compose up -d`` (PostgreSQL).
 Run with: ``uv run pytest tests/integration/test_video_skeleton.py --run-db -v``
@@ -18,7 +23,10 @@ Run with: ``uv run pytest tests/integration/test_video_skeleton.py --run-db -v``
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 import uuid
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -29,6 +37,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from course_supporter.api.tasks import arq_ingest_material
 from course_supporter.ingestion.base import ProcessingError
 from course_supporter.ingestion.video_pipeline import VideoProcessor
+from course_supporter.ingestion.video_pipeline.schemas import VideoFileMetadata
 from course_supporter.models.source import SourceType
 from course_supporter.storage.authored_document_repository import (
     AuthoredDocumentRepository,
@@ -40,6 +49,7 @@ from course_supporter.storage.orm import (
     DocumentSegment,
     DocumentSummary,
 )
+from course_supporter.stt.schemas import STTResult, STTWord
 
 pytestmark = pytest.mark.requires_db
 
@@ -47,9 +57,69 @@ _FACTORY = "course_supporter.api.tasks.create_processors"
 _HEAVY = "course_supporter.api.tasks.create_heavy_steps"
 _WORK_WINDOW = "course_supporter.job_priority.check_work_window"
 _STAGE2 = "course_supporter.security.stage2.run_stage2_safety_check"
-_STEP4 = "course_supporter.ingestion.video_pipeline.steps.step_4_pass1_vision"
+_PKG = "course_supporter.ingestion.video_pipeline"
+_PROBE = f"{_PKG}.media.probe_metadata"
+_EXTRACT = f"{_PKG}.media.extract_audio"
 
 _SOURCE_URL = "s3://bucket/lecture.mp4"
+_MOCK_META = VideoFileMetadata(duration_ms=60_000, codec="h264", resolution="1280x720")
+
+
+@pytest.fixture
+def tiny_video(tmp_path: Path) -> Path:
+    """A 1 s 320x240 h264+aac mp4 generated via ffmpeg (requires_ffmpeg only).
+
+    Avoids a committed binary (``*.mp4`` is gitignored): the fixture only
+    materialises for the ``requires_ffmpeg`` test, which is skipped when
+    ffmpeg is absent — so ``shutil.which`` always resolves here.
+    """
+    out = tmp_path / "tiny.mp4"
+    ffmpeg = shutil.which("ffmpeg")
+    assert ffmpeg is not None
+    subprocess.run(  # noqa: S603
+        [
+            ffmpeg,
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=blue:s=320x240:d=1",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=1",
+            "-c:v",
+            "libx264",
+            "-c:a",
+            "aac",
+            "-pix_fmt",
+            "yuv420p",
+            "-shortest",
+            str(out),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return out
+
+
+def _stt_router_with_words() -> AsyncMock:
+    """STTRouter mock returning a two-word transcript (no ElevenLabs call)."""
+    router = AsyncMock()
+    router.transcribe = AsyncMock(
+        return_value=STTResult(
+            text="hello world",
+            words=[
+                STTWord(start_sec=0.0, end_sec=0.5, text="hello"),
+                STTWord(start_sec=0.6, end_sec=1.0, text="world"),
+            ],
+            language="en",
+            detected_language="en",
+            provider="elevenlabs",
+            model_id="scribe_v2",
+        )
+    )
+    return router
 
 
 def _build_ctx(
@@ -60,26 +130,35 @@ def _build_ctx(
         "session_factory": session_factory,
         "model_router": MagicMock(),
         "stage_router": MagicMock(),
-        "redis": MagicMock(),
+        "redis": AsyncMock(),
         "s3_client": None,
     }
 
 
-def _video_processors() -> dict[SourceType, VideoProcessor]:
-    """Inject the real skeleton VideoProcessor at the VIDEO dispatch key."""
-    return {SourceType.VIDEO: VideoProcessor()}
+def _video_processors(
+    stt_router: AsyncMock | None = None,
+) -> dict[SourceType, VideoProcessor]:
+    """Inject the real VideoProcessor at the VIDEO dispatch key."""
+    return {
+        SourceType.VIDEO: VideoProcessor(
+            stt_router=stt_router or _stt_router_with_words(),
+            redis=AsyncMock(),
+        )
+    }
 
 
 async def _seed_video_job(
     session_factory: async_sessionmaker[AsyncSession],
     committed_seeds: dict[str, uuid.UUID],
+    *,
+    source_url: str = _SOURCE_URL,
 ) -> uuid.UUID:
-    """Flip the seeded document to source_type=video and create its Job."""
+    """Flip the seeded document to source_type=video + source_url and add a Job."""
     async with session_factory() as session:
         await session.execute(
             update(AuthoredDocument)
             .where(AuthoredDocument.id == committed_seeds["material_id"])
-            .values(source_type="video")
+            .values(source_type="video", source_url=source_url)
         )
         job = await JobRepository(session).create(
             tenant_id=committed_seeds["tenant_id"],
@@ -90,119 +169,112 @@ async def _seed_video_job(
         return job.id
 
 
-class TestVideoSkeletonTopology:
-    """Acceptance #1-#2 — full orchestrator topology over the skeleton."""
+def _safe_verdict() -> Any:
+    from course_supporter.security.schemas import SafetyResult
 
-    async def test_skeleton_reaches_ready_with_persisted_cascade(
-        self,
-        session_factory: async_sessionmaker[AsyncSession],
-        committed_seeds: dict[str, uuid.UUID],
-    ) -> None:
-        """Mock video matter traverses 7 gnízda → state=ready + Summary + Segments."""
-        mid = committed_seeds["material_id"]
-        job_id = await _seed_video_job(session_factory, committed_seeds)
-        ctx = _build_ctx(session_factory)
+    return SafetyResult(
+        is_safe=True,
+        violations=[],
+        confidence=0.95,
+        reasoning="benign",
+    )
 
-        from course_supporter.security.schemas import SafetyResult
 
-        safe_verdict = SafetyResult(
-            is_safe=True,
-            violations=[],
-            confidence=0.95,
-            reasoning="benign",
-        )
+async def _assert_ready_with_cascade(
+    session_factory: async_sessionmaker[AsyncSession],
+    mid: uuid.UUID,
+    job_id: uuid.UUID,
+) -> None:
+    """Shared assertions: state=ready + Summary + Segments + cascade hash."""
+    async with session_factory() as session:
+        final_job = await JobRepository(session).get_by_id(job_id)
+        final_mat = await AuthoredDocumentRepository(session).get_by_id(mid)
+    assert final_job is not None
+    assert final_job.status == "complete"
+    assert final_mat is not None
+    assert final_mat.state == "ready"
+    assert final_mat.error_message is None
 
-        with (
-            patch(_WORK_WINDOW),
-            patch(_HEAVY),
-            patch(_FACTORY, return_value=_video_processors()),
-            patch(_STAGE2, new=AsyncMock(return_value=safe_verdict)),
-        ):
-            await arq_ingest_material(
-                ctx,
-                str(job_id),
-                str(mid),
-                "video",
-                _SOURCE_URL,
+    async with session_factory() as session:
+        summary = (
+            await session.execute(
+                select(DocumentSummary).where(
+                    DocumentSummary.authored_document_id == mid
+                )
             )
+        ).scalar_one_or_none()
+    assert summary is not None, "Pass 2a did not persist a summary"
 
-        # Final lifecycle state.
-        async with session_factory() as session:
-            final_job = await JobRepository(session).get_by_id(job_id)
-            final_mat = await AuthoredDocumentRepository(session).get_by_id(mid)
-        assert final_job is not None
-        assert final_job.status == "complete"
-        assert final_mat is not None
-        assert final_mat.state == "ready"
-        assert final_mat.error_message is None
-
-        # Pass 2a — DocumentSummary persisted.
-        async with session_factory() as session:
-            summary = (
+    async with session_factory() as session:
+        segments = list(
+            (
                 await session.execute(
-                    select(DocumentSummary).where(
-                        DocumentSummary.authored_document_id == mid
-                    )
+                    select(DocumentSegment)
+                    .where(DocumentSegment.document_summary_id == summary.id)
+                    .order_by(DocumentSegment.order)
                 )
-            ).scalar_one_or_none()
-        assert summary is not None, "skeleton Pass 2a did not persist a summary"
-
-        # Pass 2b/2c — DocumentSegment rows persisted with content.
-        async with session_factory() as session:
-            segments = list(
-                (
-                    await session.execute(
-                        select(DocumentSegment)
-                        .where(DocumentSegment.document_summary_id == summary.id)
-                        .order_by(DocumentSegment.order)
-                    )
-                )
-                .scalars()
-                .all()
             )
-        assert len(segments) >= 1, "skeleton did not persist segment rows"
-        assert all(seg.content for seg in segments)
+            .scalars()
+            .all()
+        )
+    assert len(segments) >= 1, "no segment rows persisted"
+    assert all(seg.content for seg in segments)
 
-        # KD9 / KD-2.1-F — cascade content_hash reaches the root CourseNode.
-        async with session_factory() as session:
-            mat_repo = AuthoredDocumentRepository(session)
-            node_repo = CourseNodeRepository(session)
-            entry = await mat_repo.get_by_id(mid)
-            assert entry is not None
-            root = await node_repo.get_root_for(entry.course_node_id)
-        assert summary.content_hash is not None
-        assert entry.content_hash is not None
-        assert root is not None
-        assert root.content_hash is not None
+    async with session_factory() as session:
+        node_repo = CourseNodeRepository(session)
+        entry = await AuthoredDocumentRepository(session).get_by_id(mid)
+        assert entry is not None
+        root = await node_repo.get_root_for(entry.course_node_id)
+    assert summary.content_hash is not None
+    assert entry.content_hash is not None
+    assert root is not None
+    assert root.content_hash is not None
 
-    async def test_skeleton_failure_path_marks_error_without_soft_delete(
+
+class TestVideoTopology:
+    """Acceptance #1-#6 — full orchestrator topology over real Krok 1-2."""
+
+    async def test_reaches_ready_with_persisted_cascade(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         committed_seeds: dict[str, uuid.UUID],
     ) -> None:
-        """R1 — gnízdo ProcessingError → state=ERROR, row retained, no persist."""
+        """Krok 1-2 (mocked toolchain) + stub 3-7 → state=ready + persist."""
         mid = committed_seeds["material_id"]
         job_id = await _seed_video_job(session_factory, committed_seeds)
         ctx = _build_ctx(session_factory)
-
-        error_msg = "injected vision failure"
 
         with (
             patch(_WORK_WINDOW),
             patch(_HEAVY),
             patch(_FACTORY, return_value=_video_processors()),
-            patch(
-                _STEP4,
-                new=AsyncMock(side_effect=ProcessingError(error_msg)),
-            ),
+            patch(_STAGE2, new=AsyncMock(return_value=_safe_verdict())),
+            patch(_PROBE, new=AsyncMock(return_value=_MOCK_META)),
+            patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))),
         ):
-            await arq_ingest_material(
-                ctx,
-                str(job_id),
-                str(mid),
-                "video",
-                _SOURCE_URL,
-            )
+            await arq_ingest_material(ctx, str(job_id), str(mid), "video", _SOURCE_URL)
+
+        await _assert_ready_with_cascade(session_factory, mid, job_id)
+
+    async def test_failure_path_marks_error_without_soft_delete(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        committed_seeds: dict[str, uuid.UUID],
+    ) -> None:
+        """R1 — Krok 1 ProcessingError → state=ERROR, row retained, no persist."""
+        mid = committed_seeds["material_id"]
+        job_id = await _seed_video_job(session_factory, committed_seeds)
+        ctx = _build_ctx(session_factory)
+
+        error_msg = "ffprobe failed: corrupt container"
+
+        with (
+            patch(_WORK_WINDOW),
+            patch(_HEAVY),
+            patch(_FACTORY, return_value=_video_processors()),
+            patch(_PROBE, new=AsyncMock(side_effect=ProcessingError(error_msg))),
+        ):
+            await arq_ingest_material(ctx, str(job_id), str(mid), "video", _SOURCE_URL)
 
         async with session_factory() as session:
             final_job = await JobRepository(session).get_by_id(job_id)
@@ -212,15 +284,11 @@ class TestVideoSkeletonTopology:
         assert final_job.status == "failed"
         assert error_msg in (final_job.error_message or "")
 
-        # R1 — fail_processing only: state=ERROR, error_message set, and the
-        # row is RETAINED (not soft-deleted) so it stays retryable per
-        # KD-2.1-P + task 2.4.8.
         assert final_mat is not None
         assert final_mat.state == "error"
         assert error_msg in (final_mat.error_message or "")
         assert final_mat.deleted_at is None
 
-        # Failure injected in process_raw (before Pass 2a commit) → nothing persisted.
         async with session_factory() as session:
             summary = (
                 await session.execute(
@@ -230,3 +298,33 @@ class TestVideoSkeletonTopology:
                 )
             ).scalar_one_or_none()
         assert summary is None, "no DocumentSummary should persist on failure"
+
+
+@pytest.mark.requires_ffmpeg
+class TestVideoRealFfmpeg:
+    """Acceptance #1/#3 — real ffprobe + ffmpeg over the committed fixture."""
+
+    async def test_real_toolchain_reaches_ready(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        committed_seeds: dict[str, uuid.UUID],
+        tiny_video: Path,
+    ) -> None:
+        """tiny.mp4 → real ffprobe metadata + real audio extract (mock STT)."""
+        mid = committed_seeds["material_id"]
+        job_id = await _seed_video_job(
+            session_factory, committed_seeds, source_url=str(tiny_video)
+        )
+        ctx = _build_ctx(session_factory)
+
+        with (
+            patch(_WORK_WINDOW),
+            patch(_HEAVY),
+            patch(_FACTORY, return_value=_video_processors()),
+            patch(_STAGE2, new=AsyncMock(return_value=_safe_verdict())),
+        ):
+            await arq_ingest_material(
+                ctx, str(job_id), str(mid), "video", str(tiny_video)
+            )
+
+        await _assert_ready_with_cascade(session_factory, mid, job_id)

--- a/tests/integration/test_video_skeleton.py
+++ b/tests/integration/test_video_skeleton.py
@@ -49,6 +49,7 @@ from course_supporter.storage.orm import (
     DocumentSegment,
     DocumentSummary,
 )
+from course_supporter.stt.router import STTRouter
 from course_supporter.stt.schemas import STTResult, STTWord
 
 pytestmark = pytest.mark.requires_db
@@ -105,7 +106,7 @@ def tiny_video(tmp_path: Path) -> Path:
 
 def _stt_router_with_words() -> AsyncMock:
     """STTRouter mock returning a two-word transcript (no ElevenLabs call)."""
-    router = AsyncMock()
+    router = AsyncMock(spec=STTRouter)
     router.transcribe = AsyncMock(
         return_value=STTResult(
             text="hello world",

--- a/tests/unit/test_ingestion/test_factory.py
+++ b/tests/unit/test_ingestion/test_factory.py
@@ -63,34 +63,40 @@ class TestCreateHeavySteps:
 
 class TestCreateProcessors:
     def test_returns_all_source_types(self) -> None:
-        """Dict contains all four SourceType keys."""
+        """With STT + Redis present the dict contains all five SourceType keys."""
         heavy = create_heavy_steps()
         mock_router = AsyncMock(spec=STTRouter)
-        processors = create_processors(heavy, stt_router=mock_router)
+        mock_redis = AsyncMock()
+        processors = create_processors(heavy, stt_router=mock_router, redis=mock_redis)
 
         assert set(processors.keys()) == {
             SourceType.VIDEO,
             SourceType.PRESENTATION,
             SourceType.TEXT,
             SourceType.WEB,
+            SourceType.AUDIO,
         }
 
-    def test_video_maps_to_skeleton_processor(self) -> None:
-        """VIDEO maps to the new video_pipeline skeleton VideoProcessor.
+    def test_video_maps_to_video_pipeline_processor(self) -> None:
+        """VIDEO maps to the ``ingestion.video_pipeline`` VideoProcessor.
 
-        Phase 2.4 task 2.4.1 rewired VIDEO from the legacy
-        ``ingestion.video`` processors (VideoProcessor / WhisperVideoProcessor)
-        to the ``ingestion.video_pipeline`` skeleton, which takes no
-        constructor deps and is independent of ``stt_router`` presence.
+        Phase 2.4 task 2.4.2 wired the real VideoProcessor with the
+        ``stt_router`` + ``redis`` deps (STT in Krok 2 + the Redis STT
+        carrier), so VIDEO now follows the AUDIO combined-guard: present
+        only when both deps are supplied, absent otherwise.
         """
         heavy = create_heavy_steps()
         mock_router = AsyncMock(spec=STTRouter)
+        mock_redis = AsyncMock()
 
-        with_router = create_processors(heavy, stt_router=mock_router)
-        without_router = create_processors(heavy)
+        with_deps = create_processors(heavy, stt_router=mock_router, redis=mock_redis)
+        assert isinstance(with_deps[SourceType.VIDEO], VideoProcessor)
 
-        assert isinstance(with_router[SourceType.VIDEO], VideoProcessor)
-        assert isinstance(without_router[SourceType.VIDEO], VideoProcessor)
+        without_redis = create_processors(heavy, stt_router=mock_router)
+        assert SourceType.VIDEO not in without_redis
+
+        without_deps = create_processors(heavy)
+        assert SourceType.VIDEO not in without_deps
 
     def test_presentation_processor_type(self) -> None:
         """PRESENTATION maps to PresentationProcessor."""

--- a/tests/unit/test_ingestion/test_factory.py
+++ b/tests/unit/test_ingestion/test_factory.py
@@ -90,7 +90,11 @@ class TestCreateProcessors:
         mock_redis = AsyncMock()
 
         with_deps = create_processors(heavy, stt_router=mock_router, redis=mock_redis)
-        assert isinstance(with_deps[SourceType.VIDEO], VideoProcessor)
+        video = with_deps[SourceType.VIDEO]
+        assert isinstance(video, VideoProcessor)
+        # Deps are actually wired in (symmetric with the AUDIO assertions).
+        assert video._stt_router is mock_router
+        assert video._redis is mock_redis
 
         without_redis = create_processors(heavy, stt_router=mock_router)
         assert SourceType.VIDEO not in without_redis

--- a/tests/unit/test_ingestion/test_video_media.py
+++ b/tests/unit/test_ingestion/test_video_media.py
@@ -1,0 +1,71 @@
+"""Unit tests for the video media toolchain parsing (Phase 2.4 task 2.4.2).
+
+Covers the pure ffprobe-JSON → ``VideoFileMetadata`` mapping
+(``_parse_probe``) — no subprocess, no ffmpeg. The real subprocess
+orchestration (download / probe / extract) runs in the
+``requires_ffmpeg`` integration test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from course_supporter.ingestion.base import UnsupportedFormatError
+from course_supporter.ingestion.video_pipeline.media import _parse_probe
+
+_PROBE_OK = {
+    "format": {"duration": "61.5"},
+    "streams": [
+        {"codec_type": "audio", "codec_name": "aac"},
+        {"codec_type": "video", "codec_name": "h264", "width": 1920, "height": 1080},
+    ],
+}
+
+
+class TestParseProbe:
+    def test_maps_duration_codec_resolution(self) -> None:
+        meta = _parse_probe(_PROBE_OK, source_name="lecture.mp4")
+
+        assert meta.duration_ms == 61_500
+        assert meta.codec == "h264"
+        assert meta.resolution == "1920x1080"
+
+    def test_duration_falls_back_to_stream(self) -> None:
+        data = {
+            "format": {},
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "vp9",
+                    "width": 640,
+                    "height": 480,
+                    "duration": "12.0",
+                }
+            ],
+        }
+        meta = _parse_probe(data, source_name="x.webm")
+
+        assert meta.duration_ms == 12_000
+        assert meta.codec == "vp9"
+
+    def test_no_video_stream_raises(self) -> None:
+        data = {"format": {"duration": "10"}, "streams": [{"codec_type": "audio"}]}
+        with pytest.raises(UnsupportedFormatError, match="No video stream"):
+            _parse_probe(data, source_name="audio_only.mkv")
+
+    def test_missing_duration_raises(self) -> None:
+        data = {
+            "format": {},
+            "streams": [{"codec_type": "video", "codec_name": "h264"}],
+        }
+        with pytest.raises(UnsupportedFormatError, match="determine duration"):
+            _parse_probe(data, source_name="corrupt.mp4")
+
+    def test_unknown_resolution_when_dimensions_missing(self) -> None:
+        data = {
+            "format": {"duration": "5"},
+            "streams": [{"codec_type": "video", "codec_name": "h264"}],
+        }
+        meta = _parse_probe(data, source_name="nores.mp4")
+
+        assert meta.resolution == "unknown"

--- a/tests/unit/test_ingestion/test_video_pipeline_skeleton.py
+++ b/tests/unit/test_ingestion/test_video_pipeline_skeleton.py
@@ -1,142 +1,331 @@
-"""Unit tests for the video_pipeline skeleton VideoProcessor (Phase 2.4 task 2.4.1).
+"""Unit tests for the video_pipeline VideoProcessor (Phase 2.4).
 
-Drives the three base methods directly (no DB / orchestrator) on a mock
-AuthoredDocument, exercising all 7 stub gnízda + their mock shapes, plus
-the namespace-isolation gate (acceptance #3) and the per-step
-failure-injection seam. The full orchestrator topology (state=ready,
-persist cascade, R1 failure path) lives in the requires_db integration
-test ``tests/integration/test_video_skeleton.py``.
+Krok 1-2 are real as of task 2.4.2 (ingestion + STT); the external
+toolchain (``media.download_video`` / ``probe_metadata`` /
+``extract_audio``) and the ``stt_router`` are mocked here so the unit
+layer needs neither ffmpeg nor a network. Krok 3-7 remain stubs. The
+real ffmpeg/ffprobe edge runs in the ``requires_ffmpeg`` integration
+test; the full orchestrator topology in ``tests/integration``.
 """
 
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from course_supporter.ingestion.base import ProcessingError
+from course_supporter.ingestion.base import ProcessingError, UnsupportedFormatError
 from course_supporter.ingestion.schemas import (
     DocumentSegmentDraft,
     DocumentSummaryDraft,
 )
-from course_supporter.ingestion.video_pipeline import VideoProcessor
+from course_supporter.ingestion.video_pipeline import VideoProcessor, steps
+from course_supporter.ingestion.video_pipeline.schemas import (
+    SttResult,
+    VideoFileMetadata,
+)
 from course_supporter.models.source import ChunkType, SourceDocument, SourceType
 from course_supporter.storage.orm import AuthoredDocument
+from course_supporter.stt.schemas import STTResult, STTWord
 
-_STEP4 = "course_supporter.ingestion.video_pipeline.steps.step_4_pass1_vision"
+_PKG = "course_supporter.ingestion.video_pipeline"
+_DOWNLOAD = f"{_PKG}.media.download_video"
+_PROBE = f"{_PKG}.media.probe_metadata"
+_EXTRACT = f"{_PKG}.media.extract_audio"
+_STEP4 = f"{_PKG}.steps.step_4_pass1_vision"
+_GET_JOB_ID = f"{_PKG}.processor.get_current_job_id"
+
+_JOB_ID = uuid.UUID("00000000-0000-0000-0000-0000000000aa")
 
 
-def _mock_authored_document() -> Mock:
+def _meta(duration_ms: int = 60_000) -> VideoFileMetadata:
+    return VideoFileMetadata(
+        duration_ms=duration_ms, codec="h264", resolution="1280x720"
+    )
+
+
+def _mock_authored_document(source_url: str = "/local/lecture.mp4") -> Mock:
     """AuthoredDocument stand-in (spec_set for attribute-access safety)."""
     doc = Mock(spec_set=AuthoredDocument)
-    doc.source_url = "s3://bucket/lecture.mp4"
+    doc.source_url = source_url
     doc.source_type = SourceType.VIDEO
     doc.filename = "lecture.mp4"
     return doc
 
 
+def _stt_router(words_sec: list[tuple[str, float, float]]) -> AsyncMock:
+    """STTRouter whose ``transcribe`` returns the given word stream."""
+    router = AsyncMock()
+    router.transcribe = AsyncMock(
+        return_value=STTResult(
+            text=" ".join(t for t, _, _ in words_sec),
+            words=[STTWord(start_sec=s, end_sec=e, text=t) for t, s, e in words_sec],
+            language="en",
+            detected_language="en",
+            provider="elevenlabs",
+            model_id="scribe_v2",
+        )
+    )
+    return router
+
+
+def _make_processor(
+    *,
+    stt_router: AsyncMock | None = None,
+    redis: AsyncMock | None = None,
+) -> VideoProcessor:
+    return VideoProcessor(
+        stt_router=stt_router or _stt_router([("Hello", 0.0, 0.5)]),
+        redis=redis or AsyncMock(),
+    )
+
+
 class TestVideoProcessorConstruction:
-    def test_takes_no_constructor_args(self) -> None:
-        """Skeleton VideoProcessor wires with no dependencies."""
-        assert isinstance(VideoProcessor(), VideoProcessor)
+    def test_requires_stt_router_and_redis(self) -> None:
+        """VideoProcessor wires with the two real-edge deps (mirror audio)."""
+        proc = VideoProcessor(stt_router=Mock(), redis=Mock())
+        assert isinstance(proc, VideoProcessor)
 
 
-class TestVideoProcessorPipeline:
-    """Happy-path coverage of the 7 stub gnízda over the 3 base methods."""
+class TestStep1Ingest:
+    """Krok 1 — resolve local video + ffprobe + duration cap."""
 
-    async def test_process_raw_builds_video_source_document(self) -> None:
-        """Krok 1-4 → SourceDocument(VIDEO) with transcript + visual chunks."""
-        proc = VideoProcessor()
+    async def test_local_path_skips_download(self) -> None:
+        """An already-local (S3-resolved) path goes straight to ffprobe."""
+        meta = _meta()
+        source = _mock_authored_document("/tmp/seed/lecture.mp4")
 
-        doc = await proc.process_raw(_mock_authored_document())
+        with (
+            patch(_DOWNLOAD) as dl,
+            patch(_PROBE, new=AsyncMock(return_value=meta)),
+        ):
+            video_path, out_meta = await steps.step_1_ingest(source, tmp=Path("/tmp/x"))
+
+        dl.assert_not_called()
+        assert video_path == Path("/tmp/seed/lecture.mp4")
+        assert out_meta is meta
+
+    async def test_url_path_downloads_video_stream(self) -> None:
+        """An http(s) URL is downloaded via yt-dlp before ffprobe."""
+        meta = _meta()
+        downloaded = Path("/tmp/x/source.mp4")
+        source = _mock_authored_document("https://youtube.com/watch?v=abc")
+
+        with (
+            patch(_DOWNLOAD, new=AsyncMock(return_value=downloaded)) as dl,
+            patch(_PROBE, new=AsyncMock(return_value=meta)),
+        ):
+            video_path, _ = await steps.step_1_ingest(source, tmp=Path("/tmp/x"))
+
+        dl.assert_awaited_once_with("https://youtube.com/watch?v=abc", Path("/tmp/x"))
+        assert video_path == downloaded
+
+    async def test_duration_cap_raises_unsupported_format(self) -> None:
+        """Over-150-min video is rejected before any STT cost (constraint)."""
+        over = _meta(151 * 60 * 1000)
+        source = _mock_authored_document()
+
+        with (
+            patch(_DOWNLOAD),
+            patch(_PROBE, new=AsyncMock(return_value=over)),
+            pytest.raises(UnsupportedFormatError, match="exceeds maximum"),
+        ):
+            await steps.step_1_ingest(source, tmp=Path("/tmp/x"))
+
+
+class TestStep2Stt:
+    """Krok 2 — audio extraction + Scribe + sec→ms + pause derivation."""
+
+    async def test_converts_seconds_to_ms_and_derives_pauses(self) -> None:
+        """STT seconds → §1 ms words; a >=700ms gap becomes a pause."""
+        meta = _meta(9_000)
+        # gap word1.end=0.5s -> word2.start=1.4s == 900ms >= threshold.
+        router = _stt_router([("Hello", 0.0, 0.5), ("world", 1.4, 2.0)])
+
+        with patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))):
+            result = await steps.step_2_stt(
+                Path("/tmp/x/source.mp4"), meta, stt_router=router, tmp=Path("/tmp/x")
+            )
+
+        assert [w.text for w in result.words] == ["Hello", "world"]
+        assert (result.words[0].start_ms, result.words[0].end_ms) == (0, 500)
+        assert (result.words[1].start_ms, result.words[1].end_ms) == (1400, 2000)
+        assert result.duration_ms == 9_000  # from ffprobe, not STT
+        assert len(result.pauses) == 1
+        assert (result.pauses[0].start_ms, result.pauses[0].end_ms) == (500, 1400)
+        assert result.detected_language == "en"
+
+    async def test_short_gap_yields_no_pause(self) -> None:
+        """A sub-threshold inter-word gap is not a boundary candidate."""
+        meta = _meta(2_000)
+        router = _stt_router([("Hello", 0.0, 0.5), ("world", 0.6, 1.0)])  # 100ms gap
+
+        with patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))):
+            result = await steps.step_2_stt(
+                Path("/tmp/x/source.mp4"), meta, stt_router=router, tmp=Path("/tmp/x")
+            )
+
+        assert result.pauses == []
+
+
+class TestProcessRawPipeline:
+    """process_raw chains Krok 1-4 + writes the Redis STT carrier."""
+
+    async def test_builds_video_source_document(self) -> None:
+        meta = _meta()
+        proc = _make_processor(stt_router=_stt_router([("Hello", 0.0, 0.5)]))
+
+        with (
+            patch(_GET_JOB_ID, return_value=_JOB_ID),
+            patch(_PROBE, new=AsyncMock(return_value=meta)),
+            patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))),
+        ):
+            doc = await proc.process_raw(_mock_authored_document())
 
         assert isinstance(doc, SourceDocument)
         assert doc.source_type == SourceType.VIDEO
-        assert doc.source_url == "s3://bucket/lecture.mp4"
-        assert doc.title == "lecture.mp4"
-        chunk_types = {chunk.chunk_type for chunk in doc.chunks}
+        chunk_types = {c.chunk_type for c in doc.chunks}
         assert ChunkType.TRANSCRIPT in chunk_types
         assert ChunkType.VISUAL_SCENE in chunk_types
-        assert doc.assemble_text()  # non-empty reference text
+        assert doc.metadata["detected_language"] == "en"
 
-    async def test_process_macro_returns_contiguous_segment_cover(self) -> None:
-        """Krok 5 → DocumentSummaryDraft; segments start at 0 + contiguous."""
-        proc = VideoProcessor()
-        doc = await proc.process_raw(_mock_authored_document())
-
-        summary = await proc.process_macro(doc, Mock())
-
-        assert isinstance(summary, DocumentSummaryDraft)
-        assert summary.segments  # mock reference text is comfortably long
-        assert summary.segments[0].start_pos == 0
-        prev_end = 0
-        for seg in summary.segments:
-            assert seg.start_pos == prev_end
-            assert seg.end_pos > seg.start_pos
-            prev_end = seg.end_pos
-        assert prev_end == len(doc.assemble_text())
-        # Last segment flagged noisy → drives the Pass 2c stub branch.
-        assert summary.segments[-1].noisy is True
-
-    async def test_process_detail_fills_content_and_cleans_noisy(self) -> None:
-        """Krok 6-7 → every segment has content; noisy segments are cleaned."""
-        proc = VideoProcessor()
-        doc = await proc.process_raw(_mock_authored_document())
-        reference = doc.assemble_text()
-        summary = await proc.process_macro(doc, Mock())
-
-        detail = await proc.process_detail(doc, summary)
-
-        assert len(detail) == len(summary.segments)
-        assert all(isinstance(seg, DocumentSegmentDraft) for seg in detail)
-        assert all(seg.content for seg in detail)
-        for seg in detail:
-            if seg.noisy:
-                assert seg.content is not None
-                assert seg.content.startswith("[cleaned] ")
-            else:
-                assert seg.content == reference[seg.start_pos : seg.end_pos]
-
-    async def test_full_pipeline_offline(self) -> None:
-        """All 3 base methods chain end-to-end without external calls."""
-        proc = VideoProcessor()
-        source = _mock_authored_document()
-
-        doc = await proc.process_raw(source)
-        summary = await proc.process_macro(doc, Mock())
-        detail = await proc.process_detail(doc, summary)
-
-        assert detail
-        assert all(seg.content for seg in detail)
-
-
-class TestVideoProcessorFailureInjection:
-    """Any gnízdo can raise ProcessingError (failure-injection seam)."""
-
-    async def test_step_failure_propagates_processing_error(self) -> None:
-        """Patching a gnízdo to raise surfaces ProcessingError to the caller."""
-        proc = VideoProcessor()
+    async def test_writes_stt_carrier_to_redis_in_readable_form(self) -> None:
+        """Acceptance #4 — Redis payload round-trips via SttResult."""
+        meta = _meta()
+        redis = AsyncMock()
+        proc = _make_processor(
+            stt_router=_stt_router([("Hello", 0.0, 0.5), ("world", 0.6, 1.0)]),
+            redis=redis,
+        )
 
         with (
-            patch(
-                _STEP4,
-                new=AsyncMock(side_effect=ProcessingError("injected vision failure")),
-            ),
-            pytest.raises(ProcessingError, match="injected vision failure"),
+            patch(_GET_JOB_ID, return_value=_JOB_ID),
+            patch(_PROBE, new=AsyncMock(return_value=meta)),
+            patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))),
+        ):
+            await proc.process_raw(_mock_authored_document())
+
+        redis.set.assert_awaited_once()
+        call = redis.set.await_args
+        assert call.args[0] == f"video_stt_result:{_JOB_ID}"
+        assert call.kwargs["ex"] == 3600
+        carrier = SttResult.model_validate_json(call.args[1])
+        assert [w.text for w in carrier.words] == ["Hello", "world"]
+        assert carrier.duration_ms == 60_000
+
+    async def test_missing_job_id_raises(self) -> None:
+        proc = _make_processor()
+        with (
+            patch(_GET_JOB_ID, return_value=None),
+            pytest.raises(ProcessingError, match="ContextVar job_id"),
         ):
             await proc.process_raw(_mock_authored_document())
 
 
+class TestErrorTaxonomy:
+    """Acceptance #5 — distinct exception classes per failure category."""
+
+    async def test_download_failure_is_processing_error(self) -> None:
+        """Operational: yt-dlp failure surfaces as ProcessingError."""
+        proc = _make_processor()
+        source = _mock_authored_document("https://youtube.com/watch?v=abc")
+        with (
+            patch(_GET_JOB_ID, return_value=_JOB_ID),
+            patch(_DOWNLOAD, new=AsyncMock(side_effect=ProcessingError("yt-dlp boom"))),
+            pytest.raises(ProcessingError, match="yt-dlp boom"),
+        ):
+            await proc.process_raw(source)
+
+    async def test_cap_is_unsupported_format_error(self) -> None:
+        """Constraint: over-cap duration surfaces as UnsupportedFormatError."""
+        over = _meta(200 * 60 * 1000)
+        proc = _make_processor()
+        with (
+            patch(_GET_JOB_ID, return_value=_JOB_ID),
+            patch(_PROBE, new=AsyncMock(return_value=over)),
+            pytest.raises(UnsupportedFormatError),
+        ):
+            await proc.process_raw(_mock_authored_document())
+
+    async def test_stt_failure_propagates(self) -> None:
+        """Operational: STT provider failure propagates out of process_raw."""
+        meta = _meta()
+        router = AsyncMock()
+        router.transcribe = AsyncMock(side_effect=ProcessingError("scribe down"))
+        proc = _make_processor(stt_router=router)
+        with (
+            patch(_GET_JOB_ID, return_value=_JOB_ID),
+            patch(_PROBE, new=AsyncMock(return_value=meta)),
+            patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))),
+            pytest.raises(ProcessingError, match="scribe down"),
+        ):
+            await proc.process_raw(_mock_authored_document())
+
+
+class TestFailureInjectionSeam:
+    """A downstream stub gnízdo can still be patched to raise (R1 seam)."""
+
+    async def test_step4_failure_propagates(self) -> None:
+        meta = _meta()
+        proc = _make_processor()
+        with (
+            patch(_GET_JOB_ID, return_value=_JOB_ID),
+            patch(_PROBE, new=AsyncMock(return_value=meta)),
+            patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))),
+            patch(_STEP4, new=AsyncMock(side_effect=ProcessingError("vision boom"))),
+            pytest.raises(ProcessingError, match="vision boom"),
+        ):
+            await proc.process_raw(_mock_authored_document())
+
+
+def _doc_with_text(text: str) -> SourceDocument:
+    from course_supporter.models.source import ContentChunk
+
+    return SourceDocument(
+        source_type=SourceType.VIDEO,
+        source_url="s3://bucket/lecture.mp4",
+        title="lecture.mp4",
+        chunks=[ContentChunk(chunk_type=ChunkType.TRANSCRIPT, text=text, index=0)],
+    )
+
+
+class TestMacroAndDetailStubs:
+    """Krok 5-7 stubs still produce a valid contiguous cover (unchanged)."""
+
+    async def test_macro_returns_contiguous_cover(self) -> None:
+        proc = _make_processor()
+        doc = _doc_with_text("some reasonably long mock transcript text here")
+
+        summary = await proc.process_macro(doc, Mock())
+
+        assert isinstance(summary, DocumentSummaryDraft)
+        assert summary.segments[0].start_pos == 0
+        assert summary.segments[-1].end_pos == len(doc.assemble_text())
+        assert summary.segments[-1].noisy is True
+
+    async def test_detail_fills_and_cleans(self) -> None:
+        proc = _make_processor()
+        doc = _doc_with_text("some reasonably long mock transcript text here")
+        summary = await proc.process_macro(doc, Mock())
+
+        detail = await proc.process_detail(doc, summary)
+
+        assert all(isinstance(s, DocumentSegmentDraft) for s in detail)
+        assert all(s.content for s in detail)
+        assert any(
+            (s.content or "").startswith("[cleaned] ") for s in detail if s.noisy
+        )
+
+
 class TestVideoPipelineIsolation:
-    """Acceptance #3 — new namespace has zero ``course_supporter.vd`` imports."""
+    """Acceptance #3/#8 — namespace has zero ``course_supporter.vd`` imports."""
 
     def test_no_vd_imports_in_namespace(self) -> None:
         import course_supporter.ingestion.video_pipeline as pkg
 
         package_dir = Path(pkg.__file__).parent
-        # Mirror acceptance #3 (``rg "from course_supporter.vd"``): match the
-        # import statement forms, not bare docstring mentions of the module.
         import_forms = ("from course_supporter.vd", "import course_supporter.vd")
         offenders = [
             py.name

--- a/tests/unit/test_ingestion/test_video_pipeline_skeleton.py
+++ b/tests/unit/test_ingestion/test_video_pipeline_skeleton.py
@@ -28,6 +28,7 @@ from course_supporter.ingestion.video_pipeline.schemas import (
 )
 from course_supporter.models.source import ChunkType, SourceDocument, SourceType
 from course_supporter.storage.orm import AuthoredDocument
+from course_supporter.stt.router import STTRouter
 from course_supporter.stt.schemas import STTResult, STTWord
 
 _PKG = "course_supporter.ingestion.video_pipeline"
@@ -57,7 +58,7 @@ def _mock_authored_document(source_url: str = "/local/lecture.mp4") -> Mock:
 
 def _stt_router(words_sec: list[tuple[str, float, float]]) -> AsyncMock:
     """STTRouter whose ``transcribe`` returns the given word stream."""
-    router = AsyncMock()
+    router = AsyncMock(spec=STTRouter)
     router.transcribe = AsyncMock(
         return_value=STTResult(
             text=" ".join(t for t, _, _ in words_sec),
@@ -252,7 +253,7 @@ class TestErrorTaxonomy:
     async def test_stt_failure_propagates(self) -> None:
         """Operational: STT provider failure propagates out of process_raw."""
         meta = _meta()
-        router = AsyncMock()
+        router = AsyncMock(spec=STTRouter)
         router.transcribe = AsyncMock(side_effect=ProcessingError("scribe down"))
         proc = _make_processor(stt_router=router)
         with (


### PR DESCRIPTION
Fills the first two `video_pipeline` gnízda (Krok 1 ingestion, Krok 2 STT) with real logic. Krok 3-7 stay stubs, so the pipeline still reaches `state=ready` on mock data. Builds on the task 2.4.1 skeleton (PR #430).

## What changed
- **`media.py` (new)** — pipeline-agnostic subprocess wrappers, isolated from legacy `vd/`:
  - `download_video` — yt-dlp **video stream** (not audio-only) + `--max-filesize 5G` + post-download size check.
  - `probe_metadata` — ffprobe → `VideoFileMetadata` (duration_ms/codec/resolution); pure `_parse_probe` unit-tested.
  - `extract_audio` — ffmpeg mono/16 kHz `.mp3` (Scribe-aligned: content-type derives from extension).
- **`step_1_ingest`** — resolve local (S3 already resolved by orchestrator) vs `http(s)` (yt-dlp) → ffprobe + **150-min cap post-ffprobe / pre-STT**.
- **`step_2_stt`** — ffmpeg extract → reused ElevenLabs Scribe core via `STTRouter.transcribe` → `SttResult` (sec→ms) + pauses derived from inter-word silence.
- **`VideoProcessor`** — gains `stt_router` + `redis` deps (mirror `AudioProcessor`); processor-owned tempdir; writes the STT carrier to Redis (`video_stt_result:{job_id}`, TTL 3600 s) as the **producer** for the future Pass 2a consumer (task 2.4.5) — NOT the `jobs` row (rule #12 deadlock).
- **`factory.py`** — VIDEO joins AUDIO under the STT+Redis combined guard.
- **`requires_ffmpeg`** pytest marker (skip-if-absent, binary detection — orthogonal to `--run-db`).

## Ratified pre-flight decisions
- **D1** — `file_metadata`/`raw_hash` stay **in-memory** (no `file_metadata` column exists, no processor→entry write-back channel without touching the orchestrator). No migration this task; persist deferred to a consumer task.
- **D2** — host allowlist **best-effort** (yt-dlp fail → `ProcessingError`) + double 5 GB guard.
- **D3** — taxonomy via existing classes: `UnsupportedFormatError` (constraint: cap, corrupt container) vs `ProcessingError` (operational: download/ffmpeg/STT). No new enum/column; structured UI mapping → task 2.4.8.

## Active-debt
- ffmpeg/ffprobe already in both `Dockerfile` + `Dockerfile.worker` → **DD-2.3-AI not triggered** (no Docker change).

## Tests
- Unit (36): mocked toolchain + STT, pure ffprobe-JSON parse, sec→ms + pause derivation, Redis carrier round-trip, error taxonomy, vd-isolation.
- Integration (`--run-db`, 3): topology → `state=ready` + persist cascade; R1 failure → `state=ERROR` retained; `requires_ffmpeg` real ffprobe+ffmpeg on a runtime-generated `tiny.mp4` (not committed — `*.mp4` is gitignored).
- Non-db regression: **2092 passed, 0 failed**. ruff + `mypy src/` strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)