### PR TITLE
task(2.4.3): pre-LLM detection — fill video pipeline Krok 3

### DIFF
--- a/src/course_supporter/ingestion/video_pipeline/detection.py
+++ b/src/course_supporter/ingestion/video_pipeline/detection.py
@@ -105,6 +105,12 @@ class SamplingParams:
 _DEFAULT_PARAMS = SamplingParams()
 _DECODE_CACHE_SIZE = 8  # bounds memory: ~prev+cur working set, sequential access
 
+# Named constants for vd-ported magic numbers (behaviour unchanged).
+_PIP_MASK_GRAY = 128  # neutral grey written over a PiP region before metrics
+_FLOW_MIN_MAGNITUDE_PX = 1.0  # per-pixel flow magnitude that counts as motion
+_FLOW_MIN_SIGNIFICANT_PX = 100  # min moving pixels for a meaningful flow reading
+_PIP_MIN_ZONE_MOTION = 1.0  # min mean zone motion to treat a zone as a PiP candidate
+
 
 class _Rect(NamedTuple):
     """Pixel rectangle (x1, y1, x2, y2)."""
@@ -149,7 +155,7 @@ class _DecodeCache:
         img = cv2.imread(str(path))
         if img is not None and self._mask is not None:
             m = self._mask
-            img[m.y1 : m.y2, m.x1 : m.x2] = 128
+            img[m.y1 : m.y2, m.x1 : m.x2] = _PIP_MASK_GRAY
         self._bgr[path] = img
         if len(self._bgr) > self._maxsize:
             self._bgr.popitem(last=False)
@@ -227,8 +233,8 @@ def _flow_coherence(gray1: Any, gray2: Any, *, downscale_max: int) -> float:
     no_flow: Any = None  # cv2 stub rejects a bare None literal for `flow`
     flow = cv2.calcOpticalFlowFarneback(g1, g2, no_flow, 0.5, 3, 15, 3, 5, 1.2, 0)
     mag, ang = cv2.cartToPolar(flow[..., 0], flow[..., 1])
-    significant = mag > 1.0
-    if int(np.count_nonzero(significant)) < 100:
+    significant = mag > _FLOW_MIN_MAGNITUDE_PX
+    if int(np.count_nonzero(significant)) < _FLOW_MIN_SIGNIFICANT_PX:
         return 0.0
     sig_angles = ang[significant]
     mean_angle = float(
@@ -335,7 +341,7 @@ def _detect_pip(
     second_motion = ranked[1][1] if len(ranked) > 1 else 0.0
     confidence = (best_motion - second_motion) / (best_motion + 1e-6)
 
-    if confidence < confidence_threshold or best_motion < 1.0:
+    if confidence < confidence_threshold or best_motion < _PIP_MIN_ZONE_MOTION:
         return None
     r = zones[best_name]
     return PiPMask(

--- a/src/course_supporter/ingestion/video_pipeline/detection.py
+++ b/src/course_supporter/ingestion/video_pipeline/detection.py
@@ -203,7 +203,10 @@ def _compute_ssim(gray1: Any, gray2: Any, *, win_size: int = 11) -> float:
     sigma2_sq = cv2.GaussianBlur(g2 * g2, (win_size, win_size), 1.5) - mu2 * mu2
     sigma12 = cv2.GaussianBlur(g1 * g2, (win_size, win_size), 1.5) - mu1 * mu2
     num = (2 * mu1 * mu2 + c1) * (2 * sigma12 + c2)
-    den = (mu1 * mu1 + mu2 * mu2 + c1) * (sigma1_sq + sigma2_sq + c2)
+    # c1/c2 are the SSIM stability constants — they already floor den at
+    # ~c1*c2 (~380), so it is never near zero. The epsilon is purely
+    # belt-and-suspenders against float-variance pathology / NaN.
+    den = (mu1 * mu1 + mu2 * mu2 + c1) * (sigma1_sq + sigma2_sq + c2) + 1e-12
     return float(np.mean(num / den))
 
 

--- a/src/course_supporter/ingestion/video_pipeline/detection.py
+++ b/src/course_supporter/ingestion/video_pipeline/detection.py
@@ -185,10 +185,16 @@ class _FrameMetrics(NamedTuple):
     edge_diff: float
 
 
-def _compute_dhash(bgr: Any, hash_size: int) -> Any:
-    """dHash of an (already PiP-masked) BGR frame via imagehash."""
-    rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
-    return imagehash.dhash(Image.fromarray(rgb), hash_size=hash_size)
+def _compute_dhash(gray: Any, hash_size: int) -> Any:
+    """dHash of an (already PiP-masked) grayscale frame via imagehash.
+
+    Takes grayscale (reused from the decode cache, which derives it for
+    the other metrics) — ``imagehash.dhash`` converts to ``"L"``
+    internally, so feeding gray skips a redundant BGR→RGB conversion.
+    cv2 ``BGR2GRAY`` and PIL ``convert("L")`` share the ITU-R 601 luma, so
+    the coarse 17px gradient hash is unchanged.
+    """
+    return imagehash.dhash(Image.fromarray(gray), hash_size=hash_size)
 
 
 def _compute_ssim(gray1: Any, gray2: Any, *, win_size: int = 11) -> float:
@@ -448,8 +454,10 @@ def _segment_scenes(
 
     for entry in entries:
         if entry.dhash is None:
-            bgr = cache.bgr(entry.path)
-            entry.dhash = _compute_dhash(bgr, p.hash_size) if bgr is not None else None
+            gray = cache.gray(entry.path)
+            entry.dhash = (
+                _compute_dhash(gray, p.hash_size) if gray is not None else None
+            )
 
     classes: list[ChangeClass] = []
     for i, entry in enumerate(entries):
@@ -563,8 +571,8 @@ def _pip_and_dedup(
     cache = _DecodeCache(mask)
     entries: list[_Entry] = []
     for i, path in enumerate(raw_paths):
-        bgr = cache.bgr(path)
-        dhash = _compute_dhash(bgr, p.hash_size) if bgr is not None else None
+        gray = cache.gray(path)
+        dhash = _compute_dhash(gray, p.hash_size) if gray is not None else None
         entries.append(
             _Entry(path=path, timestamp_sec=round(i * interval, 2), dhash=dhash)
         )

--- a/src/course_supporter/ingestion/video_pipeline/detection.py
+++ b/src/course_supporter/ingestion/video_pipeline/detection.py
@@ -1,0 +1,597 @@
+"""Pre-LLM scene detection — frame sampling + dedup + segmentation (Krok 3).
+
+Algorithmic (zero LLM): from a video, extract frames at a fixed fps,
+detect a Picture-in-Picture (talking-head) corner, drop visually
+redundant frames via 5-metric tiered voting, fill long coverage gaps,
+and group the survivors into scenes via a 3-gate boundary test —
+emitting a :class:`DetectionResult` (scenes with nested kept frames +
+the PiP box).
+
+This is a *fresh* implementation of the knowledge in
+``course_supporter.vd.frame_sampler`` (R0.2: that mature cv2/imagehash
+module is the **specification**, not code to import/copy — the new
+namespace stays isolated so ``vd/`` can be deleted wholesale in task
+2.4.9). Thresholds (:class:`SamplingParams`) are the vd-derived defaults,
+empirically calibrated on real video during the vd era; a full
+re-calibration sweep is deferred to DD-2.4-B (trigger: production
+code-slide loss).
+
+Two perf refinements over the reference: optical-flow coherence is
+computed on a downscaled grayscale (scale-tolerant; only at boundary
+candidates), and frame decodes are cached (read-once) rather than
+re-``imread`` per comparison.
+
+PiP responsibility split: this step *detects* the box and returns it;
+the output JPEGs stay **raw** (unmasked). The mask is applied internally
+only to the dedup/boundary *metrics* (so a moving talking-head does not
+fake a scene change). Pass 1 (Krok 4) applies the mask to the frame
+itself when building the vision call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+import cv2
+import imagehash
+import numpy as np
+import structlog
+from PIL import Image
+
+from course_supporter.ingestion.base import ProcessingError
+from course_supporter.ingestion.video_pipeline import media
+from course_supporter.ingestion.video_pipeline.schemas import (
+    ChangeClass,
+    DetectionResult,
+    PiPMask,
+    SampledFrame,
+    Scene,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from course_supporter.ingestion.video_pipeline.schemas import VideoFileMetadata
+
+logger = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class SamplingParams:
+    """Frame-sampling + dedup + scene-boundary thresholds (Krok 3, internal).
+
+    vd-derived defaults — empirically calibrated on real video during the
+    vd era (R0.2 knowledge), ported verbatim. Per KD8/KD-2.3-X these are
+    for the *video* source_type only; a full recalibration sweep is
+    deferred to DD-2.4-B. Kept out of the public schema (encapsulation —
+    the spike tunes thresholds, the ``DetectionResult`` contract is
+    stable).
+    """
+
+    fps: float = 0.5
+    hash_size: int = 16
+    gap_fill_max_sec: float = 15.0
+
+    # Scene boundary 3-gate (ALL three required; protects against
+    # false-positive BOUNDARY from rotation/scroll/gesture).
+    scene_boundary_dhash: float = 0.20
+    scene_boundary_color_hist: float = 0.20
+    scene_boundary_flow_coherence: float = 0.6
+    scene_boundary_time_gap: float = 10.0
+
+    # Tier 1: a single strong signal → unconditional keep.
+    tier1_dhash: float = 0.15
+    tier1_pixel_diff: float = 0.10
+
+    # Tier 2: per-metric vote thresholds; keep if >= min_votes agree.
+    vote_dhash: float = 0.03
+    vote_pixel_diff: float = 0.02
+    vote_color_hist: float = 0.15
+    vote_ssim: float = 0.95  # SSIM *below* this votes "changed".
+    vote_edge_diff: float = 0.05
+    min_votes: int = 2
+
+    pixel_noise_floor: int = 25  # intensity delta below this is noise
+    medium_change_dhash: float = 0.10  # MEDIUM vs LOW change_class split
+
+    # Downscaled optical-flow target (longest side, px) — flow coherence
+    # is scale-tolerant, so this is a free speedup at boundary candidates.
+    flow_downscale_max: int = 480
+
+
+_DEFAULT_PARAMS = SamplingParams()
+_DECODE_CACHE_SIZE = 8  # bounds memory: ~prev+cur working set, sequential access
+
+
+class _Rect(NamedTuple):
+    """Pixel rectangle (x1, y1, x2, y2)."""
+
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+
+
+@dataclass
+class _Entry:
+    """Intermediate per-frame data threaded between sub-steps."""
+
+    path: Path
+    timestamp_sec: float
+    dhash: Any = None  # imagehash.ImageHash; lazily filled for gap-fill frames
+
+
+# ── decode cache (read-once; masked once per run) ──────────────────────
+
+
+class _DecodeCache:
+    """Bounded read-once cache of PiP-masked BGR frames + derived gray.
+
+    The mask is constant per run, so masking is applied once at decode
+    (cheaper than copying per comparison). Bounded LRU keeps memory flat
+    for the sequential prev/cur access pattern.
+    """
+
+    def __init__(self, mask: _Rect | None, maxsize: int = _DECODE_CACHE_SIZE) -> None:
+        self._mask = mask
+        self._maxsize = maxsize
+        self._bgr: OrderedDict[Path, Any] = OrderedDict()
+        self._gray: OrderedDict[Path, Any] = OrderedDict()
+
+    def bgr(self, path: Path) -> Any:
+        cached = self._bgr.get(path)
+        if cached is not None:
+            self._bgr.move_to_end(path)
+            return cached
+        img = cv2.imread(str(path))
+        if img is not None and self._mask is not None:
+            m = self._mask
+            img[m.y1 : m.y2, m.x1 : m.x2] = 128
+        self._bgr[path] = img
+        if len(self._bgr) > self._maxsize:
+            self._bgr.popitem(last=False)
+        return img
+
+    def gray(self, path: Path) -> Any:
+        cached = self._gray.get(path)
+        if cached is not None:
+            self._gray.move_to_end(path)
+            return cached
+        bgr = self.bgr(path)
+        gray = None if bgr is None else cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)
+        self._gray[path] = gray
+        if len(self._gray) > self._maxsize:
+            self._gray.popitem(last=False)
+        return gray
+
+
+# ── per-frame metrics ──────────────────────────────────────────────────
+
+
+class _FrameMetrics(NamedTuple):
+    dhash_dist: float
+    pixel_diff: float
+    color_hist: float
+    ssim: float
+    edge_diff: float
+
+
+def _compute_dhash(bgr: Any, hash_size: int) -> Any:
+    """dHash of an (already PiP-masked) BGR frame via imagehash."""
+    rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+    return imagehash.dhash(Image.fromarray(rgb), hash_size=hash_size)
+
+
+def _compute_ssim(gray1: Any, gray2: Any, *, win_size: int = 11) -> float:
+    """Mean SSIM between two grayscale frames (Gaussian-window, no skimage)."""
+    c1 = (0.01 * 255) ** 2
+    c2 = (0.03 * 255) ** 2
+    g1 = gray1.astype(np.float64)
+    g2 = gray2.astype(np.float64)
+    mu1 = cv2.GaussianBlur(g1, (win_size, win_size), 1.5)
+    mu2 = cv2.GaussianBlur(g2, (win_size, win_size), 1.5)
+    sigma1_sq = cv2.GaussianBlur(g1 * g1, (win_size, win_size), 1.5) - mu1 * mu1
+    sigma2_sq = cv2.GaussianBlur(g2 * g2, (win_size, win_size), 1.5) - mu2 * mu2
+    sigma12 = cv2.GaussianBlur(g1 * g2, (win_size, win_size), 1.5) - mu1 * mu2
+    num = (2 * mu1 * mu2 + c1) * (2 * sigma12 + c2)
+    den = (mu1 * mu1 + mu2 * mu2 + c1) * (sigma1_sq + sigma2_sq + c2)
+    return float(np.mean(num / den))
+
+
+def _color_hist_distance(bgr1: Any, bgr2: Any) -> float:
+    """Bhattacharyya distance between BGR colour histograms."""
+    if bgr1 is None or bgr2 is None:
+        return 1.0
+    bins = [8, 8, 8]
+    rng = [0, 256, 0, 256, 0, 256]
+    h1 = cv2.calcHist([bgr1], [0, 1, 2], None, bins, rng)
+    h2 = cv2.calcHist([bgr2], [0, 1, 2], None, bins, rng)
+    cv2.normalize(h1, h1)
+    cv2.normalize(h2, h2)
+    return float(cv2.compareHist(h1, h2, cv2.HISTCMP_BHATTACHARYYA))
+
+
+def _flow_coherence(gray1: Any, gray2: Any, *, downscale_max: int) -> float:
+    """Optical-flow coherence in [0, 1] (1 = coherent motion, 0 = chaotic).
+
+    Computed on a downscaled grayscale — flow coherence (a cosine
+    similarity of motion angles) is scale-tolerant, so this is a free
+    speedup vs full-res Farneback (DD-2.4-B behavioural-equivalence note).
+    """
+    if gray1 is None or gray2 is None:
+        return 0.0
+    g1, g2 = _downscale(gray1, downscale_max), _downscale(gray2, downscale_max)
+    no_flow: Any = None  # cv2 stub rejects a bare None literal for `flow`
+    flow = cv2.calcOpticalFlowFarneback(g1, g2, no_flow, 0.5, 3, 15, 3, 5, 1.2, 0)
+    mag, ang = cv2.cartToPolar(flow[..., 0], flow[..., 1])
+    significant = mag > 1.0
+    if int(np.count_nonzero(significant)) < 100:
+        return 0.0
+    sig_angles = ang[significant]
+    mean_angle = float(
+        np.arctan2(np.mean(np.sin(sig_angles)), np.mean(np.cos(sig_angles)))
+    )
+    return max(float(np.mean(np.cos(sig_angles - mean_angle))), 0.0)
+
+
+def _downscale(gray: Any, max_side: int) -> Any:
+    """Downscale a grayscale frame so its longest side <= ``max_side``."""
+    h, w = gray.shape[:2]
+    longest = max(h, w)
+    if longest <= max_side:
+        return gray
+    scale = max_side / longest
+    return cv2.resize(gray, (round(w * scale), round(h * scale)))
+
+
+def _compare_frames(
+    cache: _DecodeCache,
+    prev: _Entry,
+    cur: _Entry,
+    p: SamplingParams,
+) -> _FrameMetrics:
+    """All 5 dedup metrics between two frames (PiP-masked, cached decode)."""
+    max_bits = p.hash_size * p.hash_size
+    if prev.dhash is None or cur.dhash is None:
+        dhash_dist = 1.0  # undecodable frame → treat as changed (keep, safe)
+    else:
+        dhash_dist = float((prev.dhash - cur.dhash) / max_bits)
+
+    bgr1, bgr2 = cache.bgr(prev.path), cache.bgr(cur.path)
+    if bgr1 is None or bgr2 is None:
+        return _FrameMetrics(dhash_dist, 1.0, 1.0, 0.0, 1.0)
+    gray1, gray2 = cache.gray(prev.path), cache.gray(cur.path)
+
+    abs_diff = cv2.absdiff(gray1, gray2)
+    changed = int(np.count_nonzero(abs_diff > p.pixel_noise_floor))
+    pixel_diff = changed / (gray1.shape[0] * gray1.shape[1])
+
+    color_hist = _color_hist_distance(bgr1, bgr2)
+    ssim = _compute_ssim(gray1, gray2)
+
+    edges1, edges2 = cv2.Canny(gray1, 50, 150), cv2.Canny(gray2, 50, 150)
+    edge_changed = int(np.count_nonzero(cv2.absdiff(edges1, edges2)))
+    max_edges = max(int(np.count_nonzero(edges1)), int(np.count_nonzero(edges2)), 1)
+    edge_diff = edge_changed / max_edges
+
+    return _FrameMetrics(dhash_dist, pixel_diff, color_hist, ssim, edge_diff)
+
+
+# ── PiP detection ──────────────────────────────────────────────────────
+
+
+def _build_zones(width: int, height: int) -> dict[str, _Rect]:
+    """Eight candidate zones: 4 corners + 4 edge centres."""
+    zw, zh = width // 4, height // 3
+    return {
+        "top_left": _Rect(0, 0, zw, zh),
+        "top_right": _Rect(width - zw, 0, width, zh),
+        "bottom_left": _Rect(0, height - zh, zw, height),
+        "bottom_right": _Rect(width - zw, height - zh, width, height),
+        "top_center": _Rect(width // 4, 0, 3 * width // 4, zh),
+        "bottom_center": _Rect(width // 4, height - zh, 3 * width // 4, height),
+        "left_center": _Rect(0, height // 3, zw, 2 * height // 3),
+        "right_center": _Rect(width - zw, height // 3, width, 2 * height // 3),
+    }
+
+
+def _detect_pip(
+    frame_paths: list[Path],
+    width: int,
+    height: int,
+    *,
+    max_pairs: int = 30,
+    confidence_threshold: float = 0.3,
+) -> PiPMask | None:
+    """Detect a PiP overlay via temporal motion per zone (highest-motion wins)."""
+    zones = _build_zones(width, height)
+    zone_totals: dict[str, float] = dict.fromkeys(zones, 0.0)
+    pairs = 0
+
+    step = max(1, len(frame_paths) // (max_pairs * 2))
+    indices = list(range(0, len(frame_paths) - 1, step))[:max_pairs]
+    for i in indices:
+        img1, img2 = (
+            cv2.imread(str(frame_paths[i])),
+            cv2.imread(str(frame_paths[i + 1])),
+        )
+        if img1 is None or img2 is None:
+            continue
+        gray = cv2.cvtColor(cv2.absdiff(img1, img2), cv2.COLOR_BGR2GRAY)
+        for name, rect in zones.items():
+            zone_totals[name] += float(
+                np.mean(gray[rect.y1 : rect.y2, rect.x1 : rect.x2])
+            )
+        pairs += 1
+
+    if pairs == 0:
+        return None
+    zone_avg = {z: v / pairs for z, v in zone_totals.items()}
+    ranked = sorted(zone_avg.items(), key=lambda x: x[1], reverse=True)
+    best_name, best_motion = ranked[0]
+    second_motion = ranked[1][1] if len(ranked) > 1 else 0.0
+    confidence = (best_motion - second_motion) / (best_motion + 1e-6)
+
+    if confidence < confidence_threshold or best_motion < 1.0:
+        return None
+    r = zones[best_name]
+    return PiPMask(
+        x=r.x1,
+        y=r.y1,
+        width=r.x2 - r.x1,
+        height=r.y2 - r.y1,
+        confidence=round(confidence, 4),
+    )
+
+
+# ── dedup voting ───────────────────────────────────────────────────────
+
+
+def _dedup_voting(
+    entries: list[_Entry],
+    p: SamplingParams,
+    mask: _Rect | None,
+) -> list[_Entry]:
+    """Drop redundant frames vs the last *kept* frame (tiered voting).
+
+    Tier 1: a single strong signal (dHash or pixel_diff) → keep. Tier 2:
+    >= ``min_votes`` of the 5 metrics vote "changed" → keep (catches
+    subtle code-slide changes a single metric misses).
+    """
+    if not entries:
+        return []
+    cache = _DecodeCache(mask)
+    kept = [entries[0]]
+    for cur in entries[1:]:
+        m = _compare_frames(cache, kept[-1], cur, p)
+        if m.dhash_dist > p.tier1_dhash or m.pixel_diff > p.tier1_pixel_diff:
+            kept.append(cur)
+            continue
+        votes = (
+            (m.dhash_dist > p.vote_dhash)
+            + (m.pixel_diff > p.vote_pixel_diff)
+            + (m.color_hist > p.vote_color_hist)
+            + (m.ssim < p.vote_ssim)
+            + (m.edge_diff > p.vote_edge_diff)
+        )
+        if votes >= p.min_votes:
+            kept.append(cur)
+    return kept
+
+
+# ── gap fill (async — ffmpeg single-frame) ─────────────────────────────
+
+
+async def _fill_gaps(
+    entries: list[_Entry],
+    video_path: Path,
+    gap_dir: Path,
+    p: SamplingParams,
+) -> list[_Entry]:
+    """Re-extract frames where a post-dedup gap exceeds ``gap_fill_max_sec``."""
+    if len(entries) < 2:
+        return list(entries)
+    result: list[_Entry] = []
+    fill_idx = 0
+    for i, entry in enumerate(entries):
+        result.append(entry)
+        if i + 1 >= len(entries):
+            break
+        gap = entries[i + 1].timestamp_sec - entry.timestamp_sec
+        if gap <= p.gap_fill_max_sec:
+            continue
+        n_fill = max(1, round(gap / p.gap_fill_max_sec) - 1)
+        sub = gap / (n_fill + 1)
+        for j in range(1, n_fill + 1):
+            ts = entry.timestamp_sec + sub * j
+            fpath = gap_dir / f"fill_{fill_idx:03d}_{round(ts)}s.jpg"
+            if await media.extract_single_frame(video_path, ts, fpath):
+                result.append(_Entry(path=fpath, timestamp_sec=round(ts, 1)))
+                fill_idx += 1
+            else:
+                logger.warning("video_gap_fill_failed", timestamp=ts)
+    result.sort(key=lambda e: e.timestamp_sec)
+    return result
+
+
+# ── scene segmentation (3-gate boundary + change_class) ────────────────
+
+
+def _segment_scenes(
+    entries: list[_Entry],
+    p: SamplingParams,
+    mask: _Rect | None,
+) -> list[Scene]:
+    """Assign ``change_class`` (3-gate boundary) and group into scenes.
+
+    Boundary requires ALL of: dHash > threshold AND colour histogram
+    changed AND optical-flow incoherent — plus a time gap forces one.
+    The 3 gates suppress false BOUNDARYs (rotation/scroll/gesture →
+    fake scene + costly Pass 1 anchor).
+    """
+    if not entries:
+        return []
+    cache = _DecodeCache(mask)
+    max_bits = p.hash_size * p.hash_size
+
+    for entry in entries:
+        if entry.dhash is None:
+            bgr = cache.bgr(entry.path)
+            entry.dhash = _compute_dhash(bgr, p.hash_size) if bgr is not None else None
+
+    classes: list[ChangeClass] = []
+    for i, entry in enumerate(entries):
+        if i == 0:
+            classes.append(ChangeClass.FIRST)
+            continue
+        prev = entries[i - 1]
+        time_gap = entry.timestamp_sec - prev.timestamp_sec
+        dist = (
+            float((prev.dhash - entry.dhash) / max_bits)
+            if prev.dhash is not None and entry.dhash is not None
+            else 1.0
+        )
+        classes.append(_classify(prev, entry, dist, time_gap, p, cache))
+
+    return _group_scenes(entries, classes)
+
+
+def _classify(
+    prev: _Entry,
+    cur: _Entry,
+    dist: float,
+    time_gap: float,
+    p: SamplingParams,
+    cache: _DecodeCache,
+) -> ChangeClass:
+    """3-gate boundary decision for a single consecutive pair."""
+    if time_gap > p.scene_boundary_time_gap:
+        return ChangeClass.BOUNDARY
+    if dist <= p.scene_boundary_dhash:
+        return ChangeClass.MEDIUM if dist > p.medium_change_dhash else ChangeClass.LOW
+    # Gate 1 (dHash) passed → gate 2 (colour).
+    if _color_hist_distance(cache.bgr(prev.path), cache.bgr(cur.path)) <= (
+        p.scene_boundary_color_hist
+    ):
+        return ChangeClass.MEDIUM  # colours same → motion, not a new scene
+    # Gate 3 (flow): coherent motion (rotation/scroll) → same scene.
+    coherence = _flow_coherence(
+        cache.gray(prev.path),
+        cache.gray(cur.path),
+        downscale_max=p.flow_downscale_max,
+    )
+    if coherence > p.scene_boundary_flow_coherence:
+        return ChangeClass.MEDIUM
+    return ChangeClass.BOUNDARY  # all three gates passed
+
+
+def _group_scenes(entries: list[_Entry], classes: list[ChangeClass]) -> list[Scene]:
+    """Split frames into scenes at each BOUNDARY; nest frames per scene."""
+    starts = [0] + [
+        i for i in range(1, len(entries)) if classes[i] == ChangeClass.BOUNDARY
+    ]
+    scenes: list[Scene] = []
+    for s_idx, start in enumerate(starts):
+        end = starts[s_idx + 1] - 1 if s_idx + 1 < len(starts) else len(entries) - 1
+        frames = [
+            SampledFrame(
+                frame_position_ms=round(entries[k].timestamp_sec * 1000),
+                change_class=classes[k],
+                frame_path=entries[k].path,
+            )
+            for k in range(start, end + 1)
+        ]
+        scenes.append(
+            Scene(
+                scene_id=s_idx,
+                start_ms=round(entries[start].timestamp_sec * 1000),
+                end_ms=round(entries[end].timestamp_sec * 1000),
+                frames=frames,
+            )
+        )
+    return scenes
+
+
+# ── orchestration ──────────────────────────────────────────────────────
+
+
+def _mask_rect(pip_mask: PiPMask | None) -> _Rect | None:
+    if pip_mask is None:
+        return None
+    return _Rect(
+        pip_mask.x,
+        pip_mask.y,
+        pip_mask.x + pip_mask.width,
+        pip_mask.y + pip_mask.height,
+    )
+
+
+def _resolution(file_metadata: VideoFileMetadata, first_frame: Path) -> tuple[int, int]:
+    """Resolution from ffprobe metadata (Krok 1), falling back to a frame."""
+    parts = file_metadata.resolution.split("x")
+    if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
+        return int(parts[0]), int(parts[1])
+    img = cv2.imread(str(first_frame))
+    if img is None:
+        raise ProcessingError(f"Cannot read extracted frame {first_frame.name}.")
+    h, w = img.shape[:2]
+    return int(w), int(h)
+
+
+def _pip_and_dedup(
+    raw_paths: list[Path],
+    p: SamplingParams,
+    width: int,
+    height: int,
+    interval: float,
+) -> tuple[PiPMask | None, list[_Entry]]:
+    """Sync block: PiP detect + dHash + dedup voting (run off the loop)."""
+    pip_mask = _detect_pip(raw_paths, width, height)
+    mask = _mask_rect(pip_mask)
+    cache = _DecodeCache(mask)
+    entries: list[_Entry] = []
+    for i, path in enumerate(raw_paths):
+        bgr = cache.bgr(path)
+        dhash = _compute_dhash(bgr, p.hash_size) if bgr is not None else None
+        entries.append(
+            _Entry(path=path, timestamp_sec=round(i * interval, 2), dhash=dhash)
+        )
+    deduped = _dedup_voting(entries, p, mask)
+    return pip_mask, deduped
+
+
+async def detect(
+    video_path: Path,
+    file_metadata: VideoFileMetadata,
+    frames_dir: Path,
+    *,
+    params: SamplingParams | None = None,
+) -> DetectionResult:
+    """Krok 3 — extract → PiP detect → dedup → gap fill → scene segment.
+
+    JPEGs land in ``frames_dir`` (processor-owned tempdir, cleaned with
+    the rest). Heavy cv2 work runs off the event loop via
+    ``asyncio.to_thread``; gap fill is async (ffmpeg single-frame).
+    """
+    p = params or _DEFAULT_PARAMS
+    raw_paths = await media.extract_frames_fps(video_path, p.fps, frames_dir / "frames")
+    width, height = _resolution(file_metadata, raw_paths[0])
+    interval = 1.0 / p.fps
+
+    pip_mask, deduped = await asyncio.to_thread(
+        _pip_and_dedup, raw_paths, p, width, height, interval
+    )
+    filled = await _fill_gaps(deduped, video_path, frames_dir / "gap_fill", p)
+    scenes = await asyncio.to_thread(_segment_scenes, filled, p, _mask_rect(pip_mask))
+
+    logger.info(
+        "video_detection_done",
+        raw_frames=len(raw_paths),
+        kept_frames=sum(len(s.frames) for s in scenes),
+        scenes=len(scenes),
+        pip=pip_mask is not None,
+    )
+    return DetectionResult(scenes=scenes, pip_mask=pip_mask)

--- a/src/course_supporter/ingestion/video_pipeline/media.py
+++ b/src/course_supporter/ingestion/video_pipeline/media.py
@@ -52,6 +52,8 @@ _MAX_VIDEO_SIZE_BYTES: int = (
 _DOWNLOAD_TIMEOUT_SEC = 600.0
 _PROBE_TIMEOUT_SEC = 30.0
 _EXTRACT_TIMEOUT_SEC = 600.0
+_FRAME_EXTRACT_TIMEOUT_SEC = 900.0
+_SINGLE_FRAME_TIMEOUT_SEC = 30.0
 
 # Bytes of stderr surfaced in error messages — the *tail*, since ffmpeg /
 # yt-dlp print version/config banners first and the actual error last.
@@ -244,3 +246,83 @@ async def extract_audio(video_path: Path, dest_dir: Path) -> Path:
     if not await asyncio.to_thread(audio_path.exists):
         raise ProcessingError(f"ffmpeg produced no audio output for {video_path.name}.")
     return audio_path
+
+
+async def extract_frames_fps(
+    video_path: Path,
+    fps: float,
+    dest_dir: Path,
+) -> list[Path]:
+    """Extract frames at a fixed ``fps`` into ``dest_dir`` as JPEGs (Krok 3).
+
+    Returns the sorted JPEG paths. ffmpeg failure or zero frames →
+    ``ProcessingError`` (operational; an undecodable stream yields no
+    frames). Filesystem inspection runs off the event loop (ASYNC240).
+    """
+    await asyncio.to_thread(dest_dir.mkdir, parents=True, exist_ok=True)
+    pattern = str(dest_dir / "frame_%06d.jpg")
+    rc, _out, err = await _run(
+        [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(video_path),
+            "-vf",
+            f"fps={fps}",
+            "-q:v",
+            "2",
+            pattern,
+        ],
+        timeout_sec=_FRAME_EXTRACT_TIMEOUT_SEC,
+    )
+    if rc != 0:
+        raise ProcessingError(
+            f"ffmpeg frame extraction failed (code {rc}) on "
+            f"{video_path.name}: {err.decode(errors='replace')[-_ERR_TAIL:]}"
+        )
+    frames = await asyncio.to_thread(_sorted_glob, dest_dir, "frame_*.jpg")
+    if not frames:
+        raise ProcessingError(
+            f"ffmpeg extracted no frames from {video_path.name} "
+            f"(empty or undecodable stream)."
+        )
+    return frames
+
+
+async def extract_single_frame(
+    video_path: Path,
+    timestamp_sec: float,
+    out_path: Path,
+) -> bool:
+    """Extract one frame at ``timestamp_sec`` (Krok 3 gap fill).
+
+    Best-effort: returns ``False`` (rather than raising) on ffmpeg
+    failure or timeout, so a single missed gap-fill frame does not abort
+    the whole pipeline (mirrors the reference behaviour).
+    """
+    await asyncio.to_thread(out_path.parent.mkdir, parents=True, exist_ok=True)
+    try:
+        rc, _out, _err = await _run(
+            [
+                "ffmpeg",
+                "-y",
+                "-ss",
+                f"{timestamp_sec:.2f}",
+                "-i",
+                str(video_path),
+                "-frames:v",
+                "1",
+                "-q:v",
+                "2",
+                str(out_path),
+            ],
+            timeout_sec=_SINGLE_FRAME_TIMEOUT_SEC,
+        )
+    except ProcessingError:
+        return False
+    return rc == 0 and await asyncio.to_thread(out_path.exists)
+
+
+def _sorted_glob(directory: Path, pattern: str) -> list[Path]:
+    """Sorted glob (sync helper run off the event loop)."""
+    return sorted(p for p in directory.glob(pattern) if p.is_file())

--- a/src/course_supporter/ingestion/video_pipeline/processor.py
+++ b/src/course_supporter/ingestion/video_pipeline/processor.py
@@ -117,8 +117,12 @@ class VideoProcessor(MaterialProcessor):
                 tmp=tmp,
             )
             await self._store_stt_result(job_id, stt)
-            scenes = await steps.step_3_detection(stt)
-            frame_descriptions = await steps.step_4_pass1_vision(scenes)
+            detection_result = await steps.step_3_detection(
+                video_path, file_metadata, tmp=tmp
+            )
+            frame_descriptions = await steps.step_4_pass1_vision(
+                detection_result.scenes
+            )
             doc = self._assemble_source_document(source, stt, frame_descriptions)
 
         if stt.detected_language:

--- a/src/course_supporter/ingestion/video_pipeline/schemas.py
+++ b/src/course_supporter/ingestion/video_pipeline/schemas.py
@@ -16,6 +16,7 @@ them here.
 from __future__ import annotations
 
 from enum import StrEnum
+from pathlib import Path
 
 from pydantic import BaseModel, Field
 
@@ -84,22 +85,55 @@ class ChangeClass(StrEnum):
 
 
 class SampledFrame(BaseModel):
-    """One kept frame after dedup, tagged with its change class (§1 Krok 3)."""
+    """One kept frame after dedup, tagged with its change class (§1 Krok 3).
+
+    ``frame_path`` points to the raw (unmasked) JPEG in the processor-owned
+    tempdir — valid only while Krok 4 (Pass 1) runs in the same
+    ``process_raw`` scope, then cleaned. Pass 1 reads it to send the frame
+    to the vision LLM (applying ``DetectionResult.pip_mask`` itself).
+    """
+
+    model_config = {"arbitrary_types_allowed": True}
 
     frame_position_ms: int
     change_class: ChangeClass
+    frame_path: Path
 
 
 class Scene(BaseModel):
-    """Krok 3 — a detected scene spanning ``[start_ms, end_ms]`` (§1).
-
-    Real detection (ffmpeg + scenedetect, 3-gate) lands in task 2.4.3.
-    """
+    """Krok 3 — a detected scene spanning ``[start_ms, end_ms]`` (§1)."""
 
     scene_id: int
     start_ms: int
     end_ms: int
     frames: list[SampledFrame] = Field(default_factory=list)
+
+
+class PiPMask(BaseModel):
+    """Picture-in-Picture overlay box (talking-head corner), §1 Krok 3.
+
+    Krok 3 *detects* the box via temporal-diff motion analysis; it does
+    NOT mask the output JPEGs (those stay raw). Pass 1 applies the mask
+    when building the vision call. Mirrors the ``vd/`` knowledge shape.
+    """
+
+    x: int = Field(ge=0)
+    y: int = Field(ge=0)
+    width: int = Field(gt=0)
+    height: int = Field(gt=0)
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+class DetectionResult(BaseModel):
+    """Krok 3 output — scenes (with nested kept frames) + optional PiP mask.
+
+    Consumed in-memory by Krok 4 (Pass 1): ``scenes`` carry the frame
+    files + change classes (anchor/diff decision), ``pip_mask`` lets Pass
+    1 mask the talking-head corner.
+    """
+
+    scenes: list[Scene] = Field(default_factory=list)
+    pip_mask: PiPMask | None = None
 
 
 class FrameKind(StrEnum):

--- a/src/course_supporter/ingestion/video_pipeline/steps.py
+++ b/src/course_supporter/ingestion/video_pipeline/steps.py
@@ -33,12 +33,11 @@ from course_supporter.ingestion.schemas import (
     DocumentSegmentDraft,
     DocumentSummaryDraft,
 )
-from course_supporter.ingestion.video_pipeline import media
+from course_supporter.ingestion.video_pipeline import detection, media
 from course_supporter.ingestion.video_pipeline.schemas import (
-    ChangeClass,
+    DetectionResult,
     FrameDescription,
     FrameKind,
-    SampledFrame,
     Scene,
     SttPause,
     SttResult,
@@ -161,22 +160,22 @@ def _derive_pauses(words: list[SttWord]) -> list[SttPause]:
     return pauses
 
 
-async def step_3_detection(stt: SttResult) -> list[Scene]:
-    """Krok 3 — pre-LLM scene detection + frame sampling (§1).
+async def step_3_detection(
+    video_path: Path,
+    file_metadata: VideoFileMetadata,
+    *,
+    tmp: Path,
+) -> DetectionResult:
+    """Krok 3 — pre-LLM scene detection + frame sampling + dedup (§1).
 
-    Skeleton: no ffmpeg / scenedetect (task 2.4.3). Emits one mock
-    scene spanning the full duration with a single anchor frame.
+    Delegates to :func:`detection.detect` (ffmpeg fps extraction → PiP
+    detection → 5-metric tiered dedup → gap fill → 3-gate scene boundary).
+    Zero LLM, deterministic. JPEG frames live in ``tmp`` (processor-owned;
+    cleaned with the rest) and are referenced by ``SampledFrame.frame_path``
+    for Pass 1. ffmpeg/cv2 failure → ``ProcessingError`` (raised by
+    ``detection``/``media``); zero frames → ``ProcessingError`` (R1).
     """
-    return [
-        Scene(
-            scene_id=0,
-            start_ms=0,
-            end_ms=stt.duration_ms,
-            frames=[
-                SampledFrame(frame_position_ms=0, change_class=ChangeClass.FIRST),
-            ],
-        ),
-    ]
+    return await detection.detect(video_path, file_metadata, tmp)
 
 
 async def step_4_pass1_vision(scenes: list[Scene]) -> list[FrameDescription]:

--- a/tests/integration/test_video_skeleton.py
+++ b/tests/integration/test_video_skeleton.py
@@ -37,7 +37,13 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from course_supporter.api.tasks import arq_ingest_material
 from course_supporter.ingestion.base import ProcessingError
 from course_supporter.ingestion.video_pipeline import VideoProcessor
-from course_supporter.ingestion.video_pipeline.schemas import VideoFileMetadata
+from course_supporter.ingestion.video_pipeline.schemas import (
+    ChangeClass,
+    DetectionResult,
+    SampledFrame,
+    Scene,
+    VideoFileMetadata,
+)
 from course_supporter.models.source import SourceType
 from course_supporter.storage.authored_document_repository import (
     AuthoredDocumentRepository,
@@ -61,6 +67,7 @@ _STAGE2 = "course_supporter.security.stage2.run_stage2_safety_check"
 _PKG = "course_supporter.ingestion.video_pipeline"
 _PROBE = f"{_PKG}.media.probe_metadata"
 _EXTRACT = f"{_PKG}.media.extract_audio"
+_STEP3 = f"{_PKG}.steps.step_3_detection"
 
 _SOURCE_URL = "s3://bucket/lecture.mp4"
 _MOCK_META = VideoFileMetadata(duration_ms=60_000, codec="h264", resolution="1280x720")
@@ -68,11 +75,12 @@ _MOCK_META = VideoFileMetadata(duration_ms=60_000, codec="h264", resolution="128
 
 @pytest.fixture
 def tiny_video(tmp_path: Path) -> Path:
-    """A 1 s 320x240 h264+aac mp4 generated via ffmpeg (requires_ffmpeg only).
+    """A 4 s 320x240 h264+aac mp4 generated via ffmpeg (requires_ffmpeg only).
 
     Avoids a committed binary (``*.mp4`` is gitignored): the fixture only
     materialises for the ``requires_ffmpeg`` test, which is skipped when
-    ffmpeg is absent — so ``shutil.which`` always resolves here.
+    ffmpeg is absent — so ``shutil.which`` always resolves here. 4 s so
+    Krok 3 (fps=0.5) extracts more than one frame.
     """
     out = tmp_path / "tiny.mp4"
     ffmpeg = shutil.which("ffmpeg")
@@ -84,11 +92,11 @@ def tiny_video(tmp_path: Path) -> Path:
             "-f",
             "lavfi",
             "-i",
-            "color=c=blue:s=320x240:d=1",
+            "color=c=blue:s=320x240:d=4",
             "-f",
             "lavfi",
             "-i",
-            "sine=frequency=440:duration=1",
+            "sine=frequency=440:duration=4",
             "-c:v",
             "libx264",
             "-c:a",
@@ -146,6 +154,27 @@ def _video_processors(
             redis=AsyncMock(),
         )
     }
+
+
+def _detection_result() -> DetectionResult:
+    """One-scene detection stand-in (keeps the ffmpeg-free topology test off cv2)."""
+    return DetectionResult(
+        scenes=[
+            Scene(
+                scene_id=0,
+                start_ms=0,
+                end_ms=1000,
+                frames=[
+                    SampledFrame(
+                        frame_position_ms=0,
+                        change_class=ChangeClass.FIRST,
+                        frame_path=Path("/tmp/x/frames/frame_000001.jpg"),
+                    )
+                ],
+            )
+        ],
+        pip_mask=None,
+    )
 
 
 async def _seed_video_job(
@@ -240,7 +269,7 @@ class TestVideoTopology:
         session_factory: async_sessionmaker[AsyncSession],
         committed_seeds: dict[str, uuid.UUID],
     ) -> None:
-        """Krok 1-2 (mocked toolchain) + stub 3-7 → state=ready + persist."""
+        """Krok 1-3 (mocked toolchain/cv2) + stub 4-7 → state=ready + persist."""
         mid = committed_seeds["material_id"]
         job_id = await _seed_video_job(session_factory, committed_seeds)
         ctx = _build_ctx(session_factory)
@@ -252,6 +281,7 @@ class TestVideoTopology:
             patch(_STAGE2, new=AsyncMock(return_value=_safe_verdict())),
             patch(_PROBE, new=AsyncMock(return_value=_MOCK_META)),
             patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))),
+            patch(_STEP3, new=AsyncMock(return_value=_detection_result())),
         ):
             await arq_ingest_material(ctx, str(job_id), str(mid), "video", _SOURCE_URL)
 

--- a/tests/unit/test_ingestion/test_video_detection.py
+++ b/tests/unit/test_ingestion/test_video_detection.py
@@ -1,0 +1,195 @@
+"""Tests for Krok 3 detection (Phase 2.4 task 2.4.3).
+
+The cv2 algorithm (dedup voting, scene segmentation, PiP, metrics) is
+exercised deterministically on synthetic JPEGs written with cv2 — no
+ffmpeg, no network. One ``requires_ffmpeg`` test runs the full async
+``detect`` over a runtime-generated synthetic multi-scene video,
+validating the ffmpeg→detect chain + the spike preservation gate (a
+high-edge "code-like" frame survives dedup).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from course_supporter.ingestion.video_pipeline import detection
+from course_supporter.ingestion.video_pipeline.schemas import (
+    ChangeClass,
+    DetectionResult,
+    VideoFileMetadata,
+)
+
+_PARAMS = detection.SamplingParams()
+
+
+def _write_solid(path: Path, bgr: tuple[int, int, int]) -> Path:
+    cv2.imwrite(str(path), np.full((240, 320, 3), bgr, dtype=np.uint8))
+    return path
+
+
+def _write_noise(path: Path, seed: int) -> Path:
+    rng = np.random.default_rng(seed)
+    cv2.imwrite(str(path), rng.integers(0, 256, (240, 320, 3), dtype=np.uint8))
+    return path
+
+
+def _entry(path: Path, ts: float) -> detection._Entry:
+    bgr = cv2.imread(str(path))
+    return detection._Entry(
+        path=path,
+        timestamp_sec=ts,
+        dhash=detection._compute_dhash(bgr, _PARAMS.hash_size),
+    )
+
+
+class TestDedupVoting:
+    def test_drops_identical_frame(self, tmp_path: Path) -> None:
+        """An identical consecutive frame is deduplicated away."""
+        a = _write_solid(tmp_path / "a.jpg", (200, 120, 40))
+        b = _write_solid(tmp_path / "b.jpg", (200, 120, 40))  # same colour
+        kept = detection._dedup_voting([_entry(a, 0.0), _entry(b, 2.0)], _PARAMS, None)
+        assert len(kept) == 1
+
+    def test_keeps_distinct_frame(self, tmp_path: Path) -> None:
+        """A visually distinct frame is kept (Tier 1 pixel_diff)."""
+        a = _write_solid(tmp_path / "a.jpg", (255, 0, 0))  # blue
+        b = _write_solid(tmp_path / "b.jpg", (0, 0, 255))  # red
+        kept = detection._dedup_voting([_entry(a, 0.0), _entry(b, 2.0)], _PARAMS, None)
+        assert len(kept) == 2
+
+    def test_first_frame_always_kept(self, tmp_path: Path) -> None:
+        a = _write_solid(tmp_path / "a.jpg", (10, 10, 10))
+        kept = detection._dedup_voting([_entry(a, 0.0)], _PARAMS, None)
+        assert len(kept) == 1
+
+
+class TestSceneSegmentation:
+    def test_time_gap_forces_boundary(self, tmp_path: Path) -> None:
+        """A gap > scene_boundary_time_gap splits scenes even if identical."""
+        a = _write_solid(tmp_path / "a.jpg", (40, 40, 40))
+        b = _write_solid(tmp_path / "b.jpg", (40, 40, 40))
+        scenes = detection._segment_scenes(
+            [_entry(a, 0.0), _entry(b, 20.0)], _PARAMS, None
+        )
+        assert len(scenes) == 2
+        assert scenes[0].frames[0].change_class == ChangeClass.FIRST
+        assert scenes[1].frames[0].change_class == ChangeClass.BOUNDARY
+
+    def test_similar_frames_single_scene(self, tmp_path: Path) -> None:
+        """Near-identical frames close in time stay in one scene."""
+        a = _write_solid(tmp_path / "a.jpg", (40, 40, 40))
+        b = _write_solid(tmp_path / "b.jpg", (40, 40, 40))
+        scenes = detection._segment_scenes(
+            [_entry(a, 0.0), _entry(b, 2.0)], _PARAMS, None
+        )
+        assert len(scenes) == 1
+        assert len(scenes[0].frames) == 2
+
+    def test_frame_path_populated(self, tmp_path: Path) -> None:
+        a = _write_solid(tmp_path / "a.jpg", (40, 40, 40))
+        scenes = detection._segment_scenes([_entry(a, 0.0)], _PARAMS, None)
+        assert scenes[0].frames[0].frame_path == a
+
+
+class TestMetricsAndPip:
+    def test_compare_identical_low_change(self, tmp_path: Path) -> None:
+        a = _write_noise(tmp_path / "a.jpg", 1)
+        cache = detection._DecodeCache(None)
+        m = detection._compare_frames(cache, _entry(a, 0.0), _entry(a, 2.0), _PARAMS)
+        assert m.pixel_diff == 0.0
+        assert m.ssim > 0.99
+
+    def test_compare_distinct_high_change(self, tmp_path: Path) -> None:
+        a = _write_solid(tmp_path / "a.jpg", (255, 0, 0))
+        b = _write_solid(tmp_path / "b.jpg", (0, 0, 255))
+        cache = detection._DecodeCache(None)
+        m = detection._compare_frames(cache, _entry(a, 0.0), _entry(b, 2.0), _PARAMS)
+        assert m.pixel_diff > 0.5
+
+    def test_pip_none_without_motion(self, tmp_path: Path) -> None:
+        """Static identical frames → no PiP corner detected."""
+        a = _write_solid(tmp_path / "a.jpg", (40, 40, 40))
+        b = _write_solid(tmp_path / "b.jpg", (40, 40, 40))
+        assert detection._detect_pip([a, b], 320, 240) is None
+
+    def test_downscale_bounds_longest_side(self) -> None:
+        big = np.zeros((1080, 1920), dtype=np.uint8)
+        out = detection._downscale(big, 480)
+        assert max(out.shape[:2]) == 480
+        small = np.zeros((100, 120), dtype=np.uint8)
+        assert detection._downscale(small, 480).shape == small.shape
+
+
+# ── requires_ffmpeg: full detect over a real synthetic video ───────────
+
+
+@pytest.fixture
+def code_slides_video(tmp_path: Path) -> Path:
+    """3-scene synthetic video: blue → SMPTE bars (high-edge) → red.
+
+    Generated via ffmpeg (no committed binary). The bars segment is a
+    static high-edge "code-like" slide whose preservation through dedup
+    is the spike's hard gate.
+    """
+    out = tmp_path / "slides.mp4"
+    ffmpeg = shutil.which("ffmpeg")
+    assert ffmpeg is not None
+    subprocess.run(  # noqa: S603
+        [
+            ffmpeg,
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=blue:s=320x240:d=3:r=2",
+            "-f",
+            "lavfi",
+            "-i",
+            "smptebars=s=320x240:d=3:r=2",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=red:s=320x240:d=3:r=2",
+            "-filter_complex",
+            "[0:v][1:v][2:v]concat=n=3:v=1:a=0[v]",
+            "-map",
+            "[v]",
+            "-pix_fmt",
+            "yuv420p",
+            str(out),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return out
+
+
+@pytest.mark.requires_ffmpeg
+class TestDetectRealVideo:
+    async def test_detects_scenes_and_preserves_high_edge_frame(
+        self,
+        code_slides_video: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Real ffmpeg extraction + detection: multi-scene + bars kept."""
+        meta = VideoFileMetadata(duration_ms=9_000, codec="h264", resolution="320x240")
+        work = tmp_path / "work"
+        work.mkdir()
+
+        result = await detection.detect(code_slides_video, meta, work)
+
+        assert isinstance(result, DetectionResult)
+        # blue / bars / red are visually distinct → more than one scene.
+        assert len(result.scenes) >= 2
+        all_frames = [f for s in result.scenes for f in s.frames]
+        # Every kept frame references an existing raw JPEG.
+        assert all(f.frame_path.exists() for f in all_frames)
+        # The high-edge bars frame (mid video, ~3-6 s) survived dedup.
+        mid = [f for f in all_frames if 3_000 <= f.frame_position_ms <= 6_000]
+        assert mid, "high-edge bars frame was dropped by dedup"

--- a/tests/unit/test_ingestion/test_video_detection.py
+++ b/tests/unit/test_ingestion/test_video_detection.py
@@ -40,11 +40,11 @@ def _write_noise(path: Path, seed: int) -> Path:
 
 
 def _entry(path: Path, ts: float) -> detection._Entry:
-    bgr = cv2.imread(str(path))
+    gray = cv2.cvtColor(cv2.imread(str(path)), cv2.COLOR_BGR2GRAY)
     return detection._Entry(
         path=path,
         timestamp_sec=ts,
-        dhash=detection._compute_dhash(bgr, _PARAMS.hash_size),
+        dhash=detection._compute_dhash(gray, _PARAMS.hash_size),
     )
 
 

--- a/tests/unit/test_ingestion/test_video_pipeline_skeleton.py
+++ b/tests/unit/test_ingestion/test_video_pipeline_skeleton.py
@@ -1,11 +1,12 @@
 """Unit tests for the video_pipeline VideoProcessor (Phase 2.4).
 
-Krok 1-2 are real as of task 2.4.2 (ingestion + STT); the external
-toolchain (``media.download_video`` / ``probe_metadata`` /
-``extract_audio``) and the ``stt_router`` are mocked here so the unit
-layer needs neither ffmpeg nor a network. Krok 3-7 remain stubs. The
-real ffmpeg/ffprobe edge runs in the ``requires_ffmpeg`` integration
-test; the full orchestrator topology in ``tests/integration``.
+Krok 1-3 are real as of task 2.4.3 (ingestion + STT + detection); the
+external toolchain (``media.*``, the ``stt_router``, and Krok 3's
+``detection.detect``) is mocked here so the unit layer needs neither
+ffmpeg nor cv2 work nor a network. Krok 4-7 remain stubs. The real
+ffmpeg/cv2 detection edge runs in ``test_video_detection.py``
+(``requires_ffmpeg``); the full orchestrator topology in
+``tests/integration``.
 """
 
 from __future__ import annotations
@@ -23,6 +24,10 @@ from course_supporter.ingestion.schemas import (
 )
 from course_supporter.ingestion.video_pipeline import VideoProcessor, steps
 from course_supporter.ingestion.video_pipeline.schemas import (
+    ChangeClass,
+    DetectionResult,
+    SampledFrame,
+    Scene,
     SttResult,
     VideoFileMetadata,
 )
@@ -35,6 +40,7 @@ _PKG = "course_supporter.ingestion.video_pipeline"
 _DOWNLOAD = f"{_PKG}.media.download_video"
 _PROBE = f"{_PKG}.media.probe_metadata"
 _EXTRACT = f"{_PKG}.media.extract_audio"
+_STEP3 = f"{_PKG}.steps.step_3_detection"
 _STEP4 = f"{_PKG}.steps.step_4_pass1_vision"
 _GET_JOB_ID = f"{_PKG}.processor.get_current_job_id"
 
@@ -44,6 +50,27 @@ _JOB_ID = uuid.UUID("00000000-0000-0000-0000-0000000000aa")
 def _meta(duration_ms: int = 60_000) -> VideoFileMetadata:
     return VideoFileMetadata(
         duration_ms=duration_ms, codec="h264", resolution="1280x720"
+    )
+
+
+def _detection_result() -> DetectionResult:
+    """One-scene, one-frame detection stand-in for process_raw tests."""
+    return DetectionResult(
+        scenes=[
+            Scene(
+                scene_id=0,
+                start_ms=0,
+                end_ms=1000,
+                frames=[
+                    SampledFrame(
+                        frame_position_ms=0,
+                        change_class=ChangeClass.FIRST,
+                        frame_path=Path("/tmp/x/frames/frame_000001.jpg"),
+                    )
+                ],
+            )
+        ],
+        pip_mask=None,
     )
 
 
@@ -182,6 +209,7 @@ class TestProcessRawPipeline:
             patch(_GET_JOB_ID, return_value=_JOB_ID),
             patch(_PROBE, new=AsyncMock(return_value=meta)),
             patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))),
+            patch(_STEP3, new=AsyncMock(return_value=_detection_result())),
         ):
             doc = await proc.process_raw(_mock_authored_document())
 
@@ -205,6 +233,7 @@ class TestProcessRawPipeline:
             patch(_GET_JOB_ID, return_value=_JOB_ID),
             patch(_PROBE, new=AsyncMock(return_value=meta)),
             patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))),
+            patch(_STEP3, new=AsyncMock(return_value=_detection_result())),
         ):
             await proc.process_raw(_mock_authored_document())
 
@@ -275,6 +304,7 @@ class TestFailureInjectionSeam:
             patch(_GET_JOB_ID, return_value=_JOB_ID),
             patch(_PROBE, new=AsyncMock(return_value=meta)),
             patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))),
+            patch(_STEP3, new=AsyncMock(return_value=_detection_result())),
             patch(_STEP4, new=AsyncMock(side_effect=ProcessingError("vision boom"))),
             pytest.raises(ProcessingError, match="vision boom"),
         ):


### PR DESCRIPTION
Fills `step_3` with real algorithmic (zero-LLM) scene detection. Krok 4-7 stay stubs, so the pipeline still reaches `state=ready` on mock data. Builds on task 2.4.2 (PR #432).

## What changed
- **`detection.py` (new)** — a *fresh* implementation of the `vd/frame_sampler` knowledge (R0.2: that mature cv2/imagehash module is the **spec**, not imported/copied — isolation kept so `vd/` deletes wholesale in 2.4.9):
  - ffmpeg fps extraction → **PiP detect** (8-zone temporal diff) → **5-metric tiered dedup** (dHash / pixel_diff / colour-hist / SSIM / edge; Tier 1 strong-signal + Tier 2 voting) → **gap fill** → **3-gate scene boundary** (dHash AND colour AND incoherent optical-flow; time-gap forces one) → `change_class`.
  - `SamplingParams` = vd-derived defaults ported **verbatim** (internal; encapsulated from the public schema).
  - Perf vs reference: optical-flow coherence on **downscaled** grayscale (scale-tolerant, boundary candidates only) + **read-once masked-decode cache**.
- **`media.py`** — `extract_frames_fps` + `extract_single_frame` (ffmpeg).
- **schemas** — `DetectionResult{scenes, pip_mask}`; `SampledFrame` gains `frame_path` (raw JPEG, process_raw-scoped); `PiPMask` (own copy of the vd shape).
- **`step_3_detection(video_path, file_metadata, *, tmp) -> DetectionResult`** delegates to `detection.detect`; `process_raw` threads `video_path` through and feeds `detection_result.scenes` to the step_4 stub.

## Masking responsibility (clean split)
Krok 3 **detects** the PiP box and returns it; the output JPEGs stay **raw** (the mask is applied internally only to dedup/boundary *metrics*). Pass 1 (Krok 4) **applies** the mask when building the vision call.

## Spike (R0.6, revised — ratified)
Port-tested-defaults + a deterministic **light validation** (not a full sweep): a `requires_ffmpeg` synthetic video (blue / SMPTE-bars / red) → multi-scene detected + the high-edge bars frame survives dedup. The real-lecture recalibration sweep is deferred to **DD-2.4-B** (trigger: production code-slide loss).

## Debt scan
- All deps already present (`opencv-python-headless` / `imagehash` / `Pillow` / `numpy`; SSIM hand-rolled, no scenedetect) → **no Docker change, DD-2.3-AI not triggered**.
- Fixtures runtime-generated via ffmpeg (no committed binary) → **DD-2.2-AA untouched**.
- DD-2.4-A (duration-cap single-source) stays for 2.4.4 (policy touch); DD-2.3-AF (HeavySteps) stays for the LLM tasks (Krok 3 is zero-LLM).

## Tests
- Unit (cv2, no ffmpeg): dedup drops-identical / keeps-distinct, scene segmentation (time-gap boundary, single-scene), PiP-none, metrics, downscale.
- `requires_ffmpeg`: real ffmpeg extraction + full `detect` on the synthetic video.
- Integration (`--run-db`): topology Krok 1-3 (mocked detection) → `state=ready`; R1 failure; real-ffmpeg path on a 4 s `tiny_video` (real step_3).
- Non-db regression **2103 passed, 0 failed**; ruff + `mypy src/` (133) clean; `rg "from course_supporter.vd" video_pipeline/` → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)