### PR TITLE
task(2.4.4): Pass 1 vision chain-diff — fill video pipeline Krok 4

### DIFF
--- a/config/ladders_video.yaml
+++ b/config/ladders_video.yaml
@@ -1,0 +1,68 @@
+# Video source-type stage ladders (Phase 2.4, KD8/KD-2.3-X + KD-2.3-R/S).
+#
+# Per-source-type calibration lives in its own file (loader at
+# ``src/course_supporter/llm/ladder_config.py`` discovers it via the
+# ``ladders_*.yaml`` glob; stage names are globally unique across files).
+# The video Pass 1 ("Eyes") profile differs from presentation Pass 1:
+# multi-frame chunk-diff (N frames per call, chain-diff anchor/diff) rather
+# than one image per call — but the canonical multimodal vehicle is the same
+# ``StageRouter.execute_for_stage(..., contents=[jpeg_bytes, ...])`` (KD-2.3-R).
+#
+# One stage lives here:
+#   * ``video_pass_1_vision`` — Pass 1 chain-diff frame description.
+#     Plain-text output (NOT JSON), parsed into N ``FrameDescription`` by
+#     the ``[FRAME HH:MM:SS]`` marker (symmetric with presentation Pass 1 /
+#     audio Pass 2c plain-text shape). Image bytes flow through
+#     ``contents=`` (PiP-masked by Pass 1 before the call).
+#
+# Ladder rationale (Phase 2.4 task 2.4.4; mechanism CI-landed,
+# preservation/N calibration is the operator-run RUN_SMOKE spike, C6):
+#
+# Pass 1 — 3 rungs (mirrors presentation Pass 1; same VL model family):
+#   1. dashscope/qwen3-vl-32b-instruct — cost-first primary (OCR / document
+#      strength; perfect Ukrainian preservation on the Phase 2.3 slide set).
+#      Routes through ``DashScopeProvider`` (KD-2.3-A native client). Per-rung
+#      ``reasoning: {exclude: true}`` (KD-2.3-S) keeps the non-reasoning VL
+#      model from being asked to reason. ``max_output_tokens: 8192`` is the
+#      model's hard output ceiling — the chunk packer (vision.py
+#      ``_BUDGET_TOKENS = 6144``) targets 3/4 of it so a real chunk's output
+#      stays clear of truncation; the explicit value lifts it above the
+#      provider default (4096), which is too small for a multi-frame chunk.
+#   2. gemini/gemini-3-flash-preview — fallback 1. Multi-image native
+#      (``GeminiProvider._build_contents`` wraps each bytes item as a Part).
+#      Registry ceiling is 65536, but the per-rung ``max_output_tokens: 8192``
+#      pins the budget contract rung-uniform so truncation surfaces as the
+#      same chunk-parse mismatch regardless of which rung answered (it never
+#      hides behind a silent fallback). Preview-tier pricing is PROVISIONAL.
+#   3. gemini/gemini-2.5-flash — fallback 2 / stable deep tier. Same 8192 pin.
+#
+# Anthropic (Claude) vision R3 rung **deferred** per DD-2.3-AD: no Claude
+# *vision* model is registered (presentation ladder is likewise Qwen→Gemini,
+# Anthropic native top-up not performed). Promote to a third rung when a
+# Claude vision model is registered AND a ladder-exhaustion trigger fires.
+#
+# Snapshot convention: gemini / dashscope models use aliases (latest stable;
+# provider-side stability per repo convention).
+
+stages:
+  # Pass 1 chain-diff frame description (KD-2.3-R + KD8/KD-2.3-X).
+  # Input: N PiP-masked frame JPEGs through ``contents=`` +
+  #   ``n_frames`` / ``frames`` (marker + mode per frame) Jinja render context.
+  # Output: plain-text — N marked blocks, parsed by the ``[FRAME HH:MM:SS]``
+  #   marker into N ``FrameDescription`` (anchor/diff). ``count != N`` or a
+  #   marker mismatch raises ``StructuralRetryError`` (one retry → fallback).
+  # Invocation site: ``video_pipeline.vision.run_pass_1`` (per-chunk
+  #   bounded-concurrency gather inside ``VideoProcessor.process_raw``).
+  video_pass_1_vision:
+    prompt_ref: "prompts/video_pass_1_vision/v1.md"
+    ladder:
+      - provider: dashscope
+        model: qwen3-vl-32b-instruct
+        reasoning: {exclude: true}
+        max_output_tokens: 8192
+      - provider: gemini
+        model: gemini-3-flash-preview
+        max_output_tokens: 8192
+      - provider: gemini
+        model: gemini-2.5-flash
+        max_output_tokens: 8192

--- a/prompts/video_pass_1_vision/v1.md
+++ b/prompts/video_pass_1_vision/v1.md
@@ -1,0 +1,19 @@
+## System
+You are an expert visual describer for an educational video-lecture summarisation pipeline. You receive {{ n_frames }} frame image(s) sampled in chronological order from a lecture, plus, below, the marker and mode for each frame in the same order. The k-th image corresponds to the k-th marker.
+
+Produce EXACTLY {{ n_frames }} description block(s), one per frame, in order. Each block MUST begin, on its own line, with that frame's marker copied verbatim, followed by the description on the next line(s):
+
+[FRAME HH:MM:SS]
+<description>
+
+Modes:
+- ANCHOR — a full, self-contained description of everything visible. Reproduce ALL on-screen text exactly as shown (including Ukrainian or other non-English characters). Render any code literally inside a Markdown fenced block (```python ... ```), preserving indentation, operators (e.g. == vs =), and comments. Describe the layout of any diagrams or visual structures clearly.
+- DIFF — describe ONLY what changed versus the immediately preceding frame in this set (added / removed / edited text, new code lines, an advanced slide step). Do not repeat unchanged content. If nothing substantive changed, write exactly: No substantive change.
+
+Output ONLY the {{ n_frames }} marked block(s) — no preamble, numbering, extra headers, or commentary. Emit each marker exactly once, verbatim, in the given order.
+
+## User
+Describe these {{ n_frames }} frame(s), in order (the k-th line below corresponds to the k-th image):
+{% for f in frames %}
+{{ f.marker }} — {{ f.kind }}
+{%- endfor %}

--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -161,7 +161,11 @@ async def arq_ingest_material(
 
     stt_router = create_stt_router(get_settings(), session_factory)
     processors = create_processors(
-        heavy, vd_pipeline=vd, stt_router=stt_router, redis=redis
+        heavy,
+        vd_pipeline=vd,
+        stt_router=stt_router,
+        redis=redis,
+        stage_router=stage_router,
     )
     s3: S3Client | None = ctx.get("s3_client")
 

--- a/src/course_supporter/ingestion/factory.py
+++ b/src/course_supporter/ingestion/factory.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from course_supporter.config import Settings
     from course_supporter.ingestion.base import MaterialProcessor
     from course_supporter.llm.router import ModelRouter
+    from course_supporter.llm.stage_router import StageRouter
     from course_supporter.stt.router import STTRouter
     from course_supporter.vd.pipeline import VDPipeline
 
@@ -124,26 +125,33 @@ def create_processors(
     vd_pipeline: VDPipeline | None = None,
     stt_router: STTRouter | None = None,
     redis: ArqRedis | None = None,
+    stage_router: StageRouter | None = None,
 ) -> dict[SourceType, MaterialProcessor]:
     """Create processor instances wired with heavy steps.
 
     Args:
         heavy: Bundle of heavy step callables.
         vd_pipeline: Optional VDPipeline (legacy ``vd/`` visual analysis).
-            Unused by the new video_pipeline namespace; retained for the
-            real Pass 1 vision wiring (task 2.4.4). Passing it into the
-            VIDEO processor would couple the new namespace to legacy
-            ``vd/`` types (isolation per 2.4.1 acceptance #3).
+            Unused by the new video_pipeline namespace (its Pass 1 wiring
+            is ``stage_router`` below). Passing it into the VIDEO processor
+            would couple the new namespace to legacy ``vd/`` types
+            (isolation per 2.4.1 acceptance #3).
         stt_router: Optional STTRouter for VIDEO + AUDIO transcription.
         redis: Optional ArqRedis client for the STT inter-stage carriers
             (video ``video_stt_result``; audio word-cache KD-2.2-D).
+        stage_router: Optional StageRouter for the VIDEO Pass 1 vision
+            ladder (Krok 4). VIDEO-only — AUDIO routes its Pass 2a/2c via
+            the ``process_macro`` / ``process_detail`` method argument, so
+            it needs no injected stage_router.
 
     Returns:
-        Mapping from SourceType to fully-wired processor instances.
-        ``SourceType.VIDEO`` and ``SourceType.AUDIO`` are absent when the
-        combined guard below is unsatisfied (both need STT + Redis);
-        factory dispatch in ``api/tasks.py`` raises ``KeyError`` for
-        unwired source types.
+        Mapping from SourceType to fully-wired processor instances. The
+        dispatch guard is **asymmetric**: AUDIO needs STT + Redis; VIDEO
+        needs STT + Redis **and** ``stage_router`` (its Pass 1 lives in
+        ``process_raw``, before Stage 2 safety, so the vision ladder is
+        injected rather than passed to ``process_macro``). Each is absent
+        when its deps are unmet; factory dispatch in ``api/tasks.py``
+        raises ``KeyError`` for an unwired source type.
     """
     result: dict[SourceType, MaterialProcessor] = {
         SourceType.PRESENTATION: PresentationProcessor(),
@@ -153,18 +161,22 @@ def create_processors(
         ),
     }
 
-    # VIDEO + AUDIO share the same two deps: STT in stage 1 + a Redis
-    # inter-stage carrier across stages. Phase 2.4 task 2.4.2 wired the
-    # real VideoProcessor (``ingestion.video_pipeline``); the legacy
-    # ``ingestion.video`` processors are removed in 2.4.9.
+    # AUDIO needs STT (stage 1) + a Redis inter-stage carrier. VIDEO needs
+    # those two plus the StageRouter for its Krok 4 Pass 1 vision call —
+    # injected because Pass 1 runs inside ``process_raw`` (the vision
+    # ladder can't arrive via the ``process_macro`` method arg). Phase 2.4
+    # task 2.4.2 wired the real VideoProcessor (``ingestion.video_pipeline``);
+    # the legacy ``ingestion.video`` processors are removed in 2.4.9.
     if stt_router is not None and redis is not None:
-        result[SourceType.VIDEO] = VideoProcessor(
-            stt_router=stt_router,
-            redis=redis,
-        )
         result[SourceType.AUDIO] = AudioProcessor(
             stt_router=stt_router,
             redis=redis,
         )
+        if stage_router is not None:
+            result[SourceType.VIDEO] = VideoProcessor(
+                stt_router=stt_router,
+                redis=redis,
+                stage_router=stage_router,
+            )
 
     return result

--- a/src/course_supporter/ingestion/video_pipeline/processor.py
+++ b/src/course_supporter/ingestion/video_pipeline/processor.py
@@ -24,9 +24,14 @@ per task 2.4.1 acceptance #3).
 Factory dispatch invariant: ``create_processors`` routes by
 ``source_type`` so this processor only receives ``SourceType.VIDEO``
 inputs; no entry guard is needed (matches AudioProcessor / Phase 2.2).
-``stt_router`` + ``redis`` are required constructor deps (STT in Krok 2 +
-the Redis carrier) — the factory registers VIDEO only when both are
-present, symmetric with AUDIO.
+``stt_router`` + ``redis`` + ``stage_router`` are required constructor
+deps (STT in Krok 2, the Redis carrier, and the Pass 1 vision ladder in
+Krok 4) — the factory registers VIDEO only when all three are present.
+``stage_router`` is the VIDEO-only extra over AUDIO: Pass 1 lives in
+``process_raw`` (Stage 2 safety reads ``doc.assemble_text()`` built from
+the frame descriptions), so the vision ladder cannot arrive via the
+``process_macro`` method argument and is injected here instead
+(direct-injection, the video step of DD-2.3-AF).
 """
 
 from __future__ import annotations
@@ -70,9 +75,10 @@ _STT_RESULT_KEY_TMPL = "video_stt_result:{job_id}"
 class VideoProcessor(MaterialProcessor):
     """Video source-type processor — three-stage ingestion over 7 gnízda.
 
-    See module docstring for the 7-step → 3-method mapping and the Redis
-    inter-stage carrier. Requires ``stt_router`` (Krok 2 transcription)
-    and ``redis`` (STT-carrier write) — mirrors ``AudioProcessor``.
+    See module docstring for the 7-step → 3-method mapping, the Redis
+    inter-stage carrier, and the asymmetry vs ``AudioProcessor``. Requires
+    ``stt_router`` (Krok 2 transcription), ``redis`` (STT-carrier write),
+    and ``stage_router`` (Krok 4 Pass 1 vision ladder).
     """
 
     def __init__(
@@ -80,10 +86,12 @@ class VideoProcessor(MaterialProcessor):
         *,
         stt_router: STTRouter,
         redis: ArqRedis,
+        stage_router: StageRouter,
     ) -> None:
         super().__init__()
         self._stt_router = stt_router
         self._redis = redis
+        self._stage_router = stage_router
 
     async def process_raw(
         self,
@@ -94,11 +102,11 @@ class VideoProcessor(MaterialProcessor):
         """Krok 1-4 → ``SourceDocument``.
 
         Reads ``job_id`` from the ContextVar (set at ARQ task entry) for
-        the Redis carrier key. All transient files (yt-dlp download +
-        extracted audio) live in a processor-owned tempdir cleaned on
-        exit. The ``router`` parameter is accepted for ABC symmetry but
-        unused (the real Pass 1 vision call wires its own ladder in task
-        2.4.4).
+        the Redis carrier key. All transient files (yt-dlp download,
+        extracted audio, sampled frame JPEGs) live in a processor-owned
+        tempdir cleaned on exit. The ``router`` (``ModelRouter``) parameter
+        is accepted for ABC symmetry but unused; Pass 1 (Krok 4) uses the
+        injected ``self._stage_router`` (the vision ladder), not this arg.
         """
         job_id = get_current_job_id()
         if job_id is None:
@@ -121,7 +129,7 @@ class VideoProcessor(MaterialProcessor):
                 video_path, file_metadata, tmp=tmp
             )
             frame_descriptions = await steps.step_4_pass1_vision(
-                detection_result.scenes
+                detection_result, file_metadata, stage_router=self._stage_router
             )
             doc = self._assemble_source_document(source, stt, frame_descriptions)
 

--- a/src/course_supporter/ingestion/video_pipeline/steps.py
+++ b/src/course_supporter/ingestion/video_pipeline/steps.py
@@ -33,12 +33,10 @@ from course_supporter.ingestion.schemas import (
     DocumentSegmentDraft,
     DocumentSummaryDraft,
 )
-from course_supporter.ingestion.video_pipeline import detection, media
+from course_supporter.ingestion.video_pipeline import detection, media, vision
 from course_supporter.ingestion.video_pipeline.schemas import (
     DetectionResult,
     FrameDescription,
-    FrameKind,
-    Scene,
     SttPause,
     SttResult,
     SttWord,
@@ -46,6 +44,7 @@ from course_supporter.ingestion.video_pipeline.schemas import (
 )
 
 if TYPE_CHECKING:
+    from course_supporter.llm.stage_router import StageRouter
     from course_supporter.models.source import SourceDocument
     from course_supporter.storage.orm import AuthoredDocument
     from course_supporter.stt.router import STTRouter
@@ -178,24 +177,23 @@ async def step_3_detection(
     return await detection.detect(video_path, file_metadata, tmp)
 
 
-async def step_4_pass1_vision(scenes: list[Scene]) -> list[FrameDescription]:
-    """Krok 4 — Pass 1 / «Eyes» vision description (§1).
+async def step_4_pass1_vision(
+    detection_result: DetectionResult,
+    file_metadata: VideoFileMetadata,
+    *,
+    stage_router: StageRouter,
+) -> list[FrameDescription]:
+    """Krok 4 — Pass 1 / «Eyes» vision chain-diff description (§1).
 
-    Skeleton: no vision LLM / chunking (task 2.4.4). Emits one anchor
-    description per sampled frame.
+    Delegates to :func:`vision.run_pass_1`: budget-driven chunking, chain-diff
+    (anchor/diff per frame), PiP masking applied here, and chunk-response
+    parsing into ``FrameDescription`` by the ``[FRAME HH:MM:SS]`` marker.
+    Ladder ``video_pass_1_vision`` (Qwen3-VL → Gemini). Ladder exhaustion or
+    a persistent chunk-parse mismatch → ``ProcessingError`` (R1).
     """
-    descriptions: list[FrameDescription] = []
-    for scene in scenes:
-        for frame in scene.frames:
-            descriptions.append(
-                FrameDescription(
-                    scene_id=scene.scene_id,
-                    frame_position_ms=frame.frame_position_ms,
-                    description="Mock slide: title and bullet points.",
-                    kind=FrameKind.ANCHOR,
-                )
-            )
-    return descriptions
+    return await vision.run_pass_1(
+        detection_result, file_metadata, stage_router=stage_router
+    )
 
 
 # ── Krok 5 — invoked from process_macro ────────────────────────────

--- a/src/course_supporter/ingestion/video_pipeline/vision.py
+++ b/src/course_supporter/ingestion/video_pipeline/vision.py
@@ -1,0 +1,357 @@
+"""Krok 4 — Pass 1 / «Eyes» vision chain-diff description (Phase 2.4).
+
+The first real LLM call in the video pipeline. A vision model (Qwen3-VL
+rung 1 → Gemini fallback, ``config/ladders_video.yaml``) describes the
+kept frames as time-bound text in a *chain-diff* mode: an ``anchor`` is a
+full, self-contained description; a ``diff`` records only what changed
+versus the previous frame.
+
+Frames are packed into chunks under an output-token budget (one vision
+call per chunk, N frames per call); the first frame of every chunk is an
+anchor so the chunk is self-sufficient. The chain is **within-chunk
+only** — no cross-chunk memory is carried, so chunks are independent and
+run with bounded concurrency. This is a thinner reuse of the
+``vd.visual_analyzer`` knowledge (R0.2: anchor/diff idea + prompt shape),
+which described frames one at a time rather than in chunks.
+
+PiP responsibility split (sealed Krok3→Krok4 contract): Krok 3 *detects*
+the talking-head box and leaves the output JPEGs raw; Pass 1 *applies*
+the mask here (grey-fills the box) before the frame is sent to the model,
+so the vision model never describes the overlay.
+
+Output is plain text (NOT JSON, symmetric with presentation Pass 1):
+one marked block per frame, parsed back into ``FrameDescription`` by the
+``[FRAME HH:MM:SS]`` marker. A wrong block count or a misaligned marker
+raises ``StructuralRetryError`` so the router's instructor-style retry +
+ladder fallback handles it; terminal failure raises ``ProcessingError``
+(R1 ``state=ERROR``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import cv2
+import structlog
+
+from course_supporter.ingestion.base import ProcessingError
+from course_supporter.ingestion.video_pipeline.schemas import (
+    ChangeClass,
+    FrameDescription,
+    FrameKind,
+)
+from course_supporter.llm.error_categories import StructuralRetryError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from course_supporter.ingestion.video_pipeline.schemas import (
+        DetectionResult,
+        PiPMask,
+        SampledFrame,
+        Scene,
+        VideoFileMetadata,
+    )
+    from course_supporter.llm.stage_router import StageRouter
+
+logger = structlog.get_logger()
+
+_STAGE_NAME = "video_pass_1_vision"
+
+# ── calibration constants (seed; spike/RUN_SMOKE-tuned, C6) ──────────────
+# Output-token budget per chunk: the greedy packer adds frames until the
+# *estimated* output reaches this. 6144 = 3/4 of the Qwen3-VL output ceiling
+# (8192), leaving ~2048 headroom for chain-diff verbosity spread. The hard
+# ceiling stays 8192 (the per-rung ``max_output_tokens`` in
+# ``ladders_video.yaml``); the spike confirms real output < 8192 at the chosen
+# frame count — if it nears the ceiling, lower the count, never raise the
+# budget.
+_BUDGET_TOKENS = 6144
+# Max images per vision call. ``vd/`` sent <= 3; the chunk-diff jump to many
+# frames is bounded here pending the DashScope / Gemini per-request image-cap
+# probe (RUN_SMOKE C4 — neither provider enforces a cap in our code, so this
+# is likely the binding constraint, not the token budget). Conservative seed.
+_IMAGE_BUDGET = 12
+# Per-frame output-token estimates driving the greedy packer. An anchor carries
+# a full description, a diff only a delta — seed values, calibrated against ESC
+# ``tokens_out`` during the spike.
+_EST_ANCHOR_TOKENS = 700
+_EST_DIFF_TOKENS = 200
+# Bounded concurrency over chunks. Chunks are independent (within-chunk chain
+# only), so they may run concurrently; kept low to stay under provider rate
+# limits on heavy multi-image calls (tune at RUN_SMOKE).
+_CHUNK_CONCURRENCY = 2
+# Neutral mid-grey written over the PiP box before a frame is sent to the
+# vision model (so it does not describe the talking-head overlay). Independent
+# of ``detection._PIP_MASK_GRAY`` — same value, different rationale: detection
+# needs a *constant* fill across frames for stable dedup metrics, here it is a
+# *visually neutral* fill for the LLM. They coincide at 128 by choice.
+_PIP_FILL_GRAY = 128
+
+# Anchored to line start (the prompt requires each marker on its own line),
+# so a ``[FRAME ..]``-shaped string inside a description does not split a block.
+_MARKER_RE = re.compile(r"^\[FRAME \d{2}:\d{2}:\d{2}\]", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class _PF:
+    """A planned frame paired with its scene id (scene id lives on ``Scene``)."""
+
+    sampled: SampledFrame
+    scene_id: int
+
+
+def _format_marker(position_ms: int) -> str:
+    """``frame_position_ms`` → the ``[FRAME HH:MM:SS]`` marker (HH for 150-min)."""
+    total_sec = position_ms // 1000
+    hours, rem = divmod(total_sec, 3600)
+    minutes, seconds = divmod(rem, 60)
+    return f"[FRAME {hours:02d}:{minutes:02d}:{seconds:02d}]"
+
+
+def _kind_at(index_in_chunk: int, change_class: ChangeClass) -> FrameKind:
+    """Anchor iff first-in-chunk (self-sufficient) or a natural scene start."""
+    if index_in_chunk == 0:
+        return FrameKind.ANCHOR
+    if change_class in (ChangeClass.FIRST, ChangeClass.BOUNDARY):
+        return FrameKind.ANCHOR
+    return FrameKind.DIFF
+
+
+def _est_cost(kind: FrameKind) -> int:
+    return _EST_ANCHOR_TOKENS if kind is FrameKind.ANCHOR else _EST_DIFF_TOKENS
+
+
+def _chunk_cost(frames: list[_PF]) -> int:
+    """Estimated output tokens for a chunk (first frame anchored)."""
+    return sum(
+        _est_cost(_kind_at(i, pf.sampled.change_class)) for i, pf in enumerate(frames)
+    )
+
+
+# ── chunk planning (budget + image cap + soft scene boundary) ────────────
+
+
+def _split_unit(frames: list[_PF]) -> list[list[_PF]]:
+    """Split one over-budget scene into sub-chunks (greedy; first = anchor)."""
+    out: list[list[_PF]] = []
+    cur: list[_PF] = []
+    cur_cost = 0
+    for pf in frames:
+        kind = _kind_at(len(cur), pf.sampled.change_class)
+        cost = _est_cost(kind)
+        if cur and (cur_cost + cost > _BUDGET_TOKENS or len(cur) >= _IMAGE_BUDGET):
+            out.append(cur)
+            cur, cur_cost = [], 0
+            cost = _est_cost(FrameKind.ANCHOR)  # new chunk → first frame anchored
+        cur.append(pf)
+        cur_cost += cost
+    if cur:
+        out.append(cur)
+    return out
+
+
+def _scene_units(scenes: list[Scene]) -> list[list[_PF]]:
+    """One unit per scene; over-budget scenes are pre-split so each unit fits.
+
+    Keeping a scene whole (unless it alone exceeds the budget) is the soft
+    "do not break a scene" rule — chunk boundaries fall between scenes, not
+    inside one, except for a single scene too large to fit.
+    """
+    units: list[list[_PF]] = []
+    for scene in scenes:
+        pfs = [_PF(sampled=f, scene_id=scene.scene_id) for f in scene.frames]
+        if not pfs:
+            continue
+        if _chunk_cost(pfs) <= _BUDGET_TOKENS and len(pfs) <= _IMAGE_BUDGET:
+            units.append(pfs)
+        else:
+            units.extend(_split_unit(pfs))
+    return units
+
+
+def _plan_chunks(scenes: list[Scene]) -> list[list[_PF]]:
+    """Pack scene units into chunks under the token budget + image cap."""
+    chunks: list[list[_PF]] = []
+    cur: list[_PF] = []
+    for unit in _scene_units(scenes):
+        if cur and (
+            _chunk_cost(cur) + _chunk_cost(unit) > _BUDGET_TOKENS
+            or len(cur) + len(unit) > _IMAGE_BUDGET
+        ):
+            chunks.append(cur)
+            cur = []
+        cur.extend(unit)
+    if cur:
+        chunks.append(cur)
+    return chunks
+
+
+# ── PiP masking (applied here, not in Krok 3) ────────────────────────────
+
+
+def _read_masked_jpeg(path: Path, mask: PiPMask | None) -> bytes:
+    """Read a raw frame JPEG, grey-fill the PiP box, return re-encoded JPEG.
+
+    The mask box (from Krok 3) is in the same pixel space as the frame
+    (ffmpeg extracts at native resolution, no scale filter), so no
+    coordinate scaling is needed — only a defensive clamp to the decoded
+    frame dimensions (guards a rotated container whose coded size differs).
+    """
+    img = cv2.imread(str(path))
+    if img is None:
+        raise ProcessingError(f"Pass 1 cannot read frame {path.name}.")
+    if mask is not None:
+        height, width = img.shape[:2]
+        x1 = max(0, min(mask.x, width))
+        y1 = max(0, min(mask.y, height))
+        x2 = max(0, min(mask.x + mask.width, width))
+        y2 = max(0, min(mask.y + mask.height, height))
+        if x2 > x1 and y2 > y1:
+            img[y1:y2, x1:x2] = _PIP_FILL_GRAY
+    ok, buf = cv2.imencode(".jpg", img)
+    if not ok:
+        raise ProcessingError(f"Pass 1 cannot re-encode frame {path.name}.")
+    return bytes(buf.tobytes())
+
+
+def _prep_images(chunk: list[_PF], mask: PiPMask | None) -> list[bytes]:
+    """Decode + PiP-mask every frame JPEG in a chunk (blocking cv2 work)."""
+    return [_read_masked_jpeg(pf.sampled.frame_path, mask) for pf in chunk]
+
+
+# ── chunk-response parsing (plain text → N FrameDescription) ─────────────
+
+
+def _parse_chunk(content: str, chunk: list[_PF]) -> list[FrameDescription]:
+    """Split the chunk response into one ``FrameDescription`` per frame.
+
+    Markers delimit the blocks; frames are assigned ordinally with the
+    marker doubling as a checksum. A wrong block count or a marker that
+    does not match its expected frame raises ``StructuralRetryError`` so
+    the router retries once with feedback, then falls back.
+    """
+    matches = list(_MARKER_RE.finditer(content))
+    if len(matches) != len(chunk):
+        raise StructuralRetryError(
+            f"expected {len(chunk)} [FRAME HH:MM:SS] block(s), got "
+            f"{len(matches)}; emit exactly one marked block per frame, in order."
+        )
+
+    descriptions: list[FrameDescription] = []
+    for i, (pf, match) in enumerate(zip(chunk, matches, strict=True)):
+        expected = _format_marker(pf.sampled.frame_position_ms)
+        if match.group() != expected:
+            raise StructuralRetryError(
+                f"block {i + 1} marker mismatch: expected {expected}, got "
+                f"{match.group()}; copy each marker verbatim, in order."
+            )
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(content)
+        descriptions.append(
+            FrameDescription(
+                scene_id=pf.scene_id,
+                frame_position_ms=pf.sampled.frame_position_ms,
+                description=content[start:end].strip(),
+                kind=_kind_at(i, pf.sampled.change_class),
+            )
+        )
+    return descriptions
+
+
+# ── orchestration ────────────────────────────────────────────────────────
+
+
+async def _describe_chunk(
+    chunk: list[_PF],
+    mask: PiPMask | None,
+    stage_router: StageRouter,
+) -> list[FrameDescription]:
+    """One vision call for a chunk → its parsed frame descriptions."""
+    images = await asyncio.to_thread(_prep_images, chunk, mask)
+    frames_ctx = [
+        {
+            "marker": _format_marker(pf.sampled.frame_position_ms),
+            "kind": _kind_at(i, pf.sampled.change_class).name,
+        }
+        for i, pf in enumerate(chunk)
+    ]
+
+    parsed: dict[str, list[FrameDescription]] = {}
+
+    def _validator(content: str) -> None:
+        parsed["frames"] = _parse_chunk(content, chunk)
+
+    await stage_router.execute_for_stage(
+        _STAGE_NAME,
+        response_validator=_validator,
+        contents=images,
+        n_frames=len(chunk),
+        frames=frames_ctx,
+    )
+    # ``execute_for_stage`` only returns on a validated success (it raises
+    # ``LadderExhaustedError`` otherwise), so the validator has run and
+    # populated ``parsed`` — guard defensively against an empty-content path.
+    result = parsed.get("frames")
+    if result is None:
+        raise ProcessingError("Pass 1 chunk produced no parseable description.")
+    return result
+
+
+async def run_pass_1(
+    detection_result: DetectionResult,
+    file_metadata: VideoFileMetadata,
+    *,
+    stage_router: StageRouter,
+) -> list[FrameDescription]:
+    """Krok 4 — describe every kept frame via chunked chain-diff vision calls.
+
+    Chunks are independent (within-chunk chain only) and run with bounded
+    concurrency; results are flattened in chunk order so the descriptions
+    stay chronological. Any chunk failure (ladder exhausted, persistent
+    parse mismatch, unreadable frame) is fail-fast → ``ProcessingError``
+    (R1 ``state=ERROR``).
+    """
+    chunks = _plan_chunks(detection_result.scenes)
+    if not chunks:
+        return []
+
+    mask = detection_result.pip_mask
+    logger.info(
+        "video_pass1_start",
+        chunks=len(chunks),
+        frames=sum(len(c) for c in chunks),
+        resolution=file_metadata.resolution,
+        pip=mask is not None,
+    )
+
+    sem = asyncio.Semaphore(_CHUNK_CONCURRENCY)
+
+    async def _run_one(chunk: list[_PF]) -> list[FrameDescription]:
+        async with sem:
+            return await _describe_chunk(chunk, mask, stage_router)
+
+    results = await asyncio.gather(
+        *(_run_one(chunk) for chunk in chunks), return_exceptions=True
+    )
+
+    descriptions: list[FrameDescription] = []
+    errors: list[tuple[int, BaseException]] = []
+    for idx, result in enumerate(results):
+        if isinstance(result, BaseException):
+            errors.append((idx, result))
+        else:
+            descriptions.extend(result)
+
+    if errors:
+        first_idx, first_exc = errors[0]
+        raise ProcessingError(
+            f"Pass 1 failed on chunk {first_idx}: {first_exc}; "
+            f"{len(errors)}/{len(chunks)} chunks failed"
+        )
+
+    logger.info("video_pass1_done", descriptions=len(descriptions))
+    return descriptions

--- a/tests/integration/test_video_skeleton.py
+++ b/tests/integration/test_video_skeleton.py
@@ -68,6 +68,7 @@ _PKG = "course_supporter.ingestion.video_pipeline"
 _PROBE = f"{_PKG}.media.probe_metadata"
 _EXTRACT = f"{_PKG}.media.extract_audio"
 _STEP3 = f"{_PKG}.steps.step_3_detection"
+_STEP4 = f"{_PKG}.steps.step_4_pass1_vision"
 
 _SOURCE_URL = "s3://bucket/lecture.mp4"
 _MOCK_META = VideoFileMetadata(duration_ms=60_000, codec="h264", resolution="1280x720")
@@ -147,11 +148,16 @@ def _build_ctx(
 def _video_processors(
     stt_router: AsyncMock | None = None,
 ) -> dict[SourceType, VideoProcessor]:
-    """Inject the real VideoProcessor at the VIDEO dispatch key."""
+    """Inject the real VideoProcessor at the VIDEO dispatch key.
+
+    The vision call (Krok 4) is patched at the ``step_4_pass1_vision`` seam
+    in each test, so the injected ``stage_router`` is a bare mock here.
+    """
     return {
         SourceType.VIDEO: VideoProcessor(
             stt_router=stt_router or _stt_router_with_words(),
             redis=AsyncMock(),
+            stage_router=MagicMock(),
         )
     }
 
@@ -282,6 +288,7 @@ class TestVideoTopology:
             patch(_PROBE, new=AsyncMock(return_value=_MOCK_META)),
             patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))),
             patch(_STEP3, new=AsyncMock(return_value=_detection_result())),
+            patch(_STEP4, new=AsyncMock(return_value=[])),
         ):
             await arq_ingest_material(ctx, str(job_id), str(mid), "video", _SOURCE_URL)
 
@@ -353,6 +360,9 @@ class TestVideoRealFfmpeg:
             patch(_HEAVY),
             patch(_FACTORY, return_value=_video_processors()),
             patch(_STAGE2, new=AsyncMock(return_value=_safe_verdict())),
+            # Real ffprobe + ffmpeg + cv2 detection; the vision LLM (Krok 4)
+            # stays mocked — real Pass 1 is the RUN_SMOKE calibration concern.
+            patch(_STEP4, new=AsyncMock(return_value=[])),
         ):
             await arq_ingest_material(
                 ctx, str(job_id), str(mid), "video", str(tiny_video)

--- a/tests/unit/test_ingestion/test_factory.py
+++ b/tests/unit/test_ingestion/test_factory.py
@@ -16,6 +16,7 @@ from course_supporter.ingestion.presentation import PresentationProcessor
 from course_supporter.ingestion.text import TextProcessor
 from course_supporter.ingestion.video_pipeline import VideoProcessor
 from course_supporter.ingestion.web import WebProcessor
+from course_supporter.llm.stage_router import StageRouter
 from course_supporter.models.source import SourceType
 from course_supporter.stt.router import STTRouter
 
@@ -63,11 +64,16 @@ class TestCreateHeavySteps:
 
 class TestCreateProcessors:
     def test_returns_all_source_types(self) -> None:
-        """With STT + Redis present the dict contains all five SourceType keys."""
+        """All five keys present with STT + Redis + StageRouter (VIDEO needs all)."""
         heavy = create_heavy_steps()
         mock_router = AsyncMock(spec=STTRouter)
         mock_redis = AsyncMock()
-        processors = create_processors(heavy, stt_router=mock_router, redis=mock_redis)
+        processors = create_processors(
+            heavy,
+            stt_router=mock_router,
+            redis=mock_redis,
+            stage_router=AsyncMock(spec=StageRouter),
+        )
 
         assert set(processors.keys()) == {
             SourceType.VIDEO,
@@ -80,24 +86,41 @@ class TestCreateProcessors:
     def test_video_maps_to_video_pipeline_processor(self) -> None:
         """VIDEO maps to the ``ingestion.video_pipeline`` VideoProcessor.
 
-        Phase 2.4 task 2.4.2 wired the real VideoProcessor with the
-        ``stt_router`` + ``redis`` deps (STT in Krok 2 + the Redis STT
-        carrier), so VIDEO now follows the AUDIO combined-guard: present
-        only when both deps are supplied, absent otherwise.
+        Task 2.4.4 added a third VIDEO dep — ``stage_router`` for the Krok 4
+        Pass 1 vision ladder. The dispatch guard is asymmetric: VIDEO needs
+        STT + Redis **and** stage_router; AUDIO needs only STT + Redis (its
+        Pass 2a/2c route via the method argument). VIDEO is absent if any of
+        its three deps is missing.
         """
         heavy = create_heavy_steps()
         mock_router = AsyncMock(spec=STTRouter)
         mock_redis = AsyncMock()
+        mock_stage = AsyncMock(spec=StageRouter)
 
-        with_deps = create_processors(heavy, stt_router=mock_router, redis=mock_redis)
+        with_deps = create_processors(
+            heavy,
+            stt_router=mock_router,
+            redis=mock_redis,
+            stage_router=mock_stage,
+        )
         video = with_deps[SourceType.VIDEO]
         assert isinstance(video, VideoProcessor)
-        # Deps are actually wired in (symmetric with the AUDIO assertions).
+        # All three deps are actually wired in.
         assert video._stt_router is mock_router
         assert video._redis is mock_redis
+        assert video._stage_router is mock_stage
 
-        without_redis = create_processors(heavy, stt_router=mock_router)
+        without_redis = create_processors(
+            heavy, stt_router=mock_router, stage_router=mock_stage
+        )
         assert SourceType.VIDEO not in without_redis
+
+        # D2 split: without stage_router, VIDEO is absent but AUDIO remains.
+        without_stage = create_processors(
+            heavy, stt_router=mock_router, redis=mock_redis
+        )
+        assert SourceType.VIDEO not in without_stage
+        assert SourceType.AUDIO in without_stage
 
         without_deps = create_processors(heavy)
         assert SourceType.VIDEO not in without_deps

--- a/tests/unit/test_ingestion/test_video_pipeline_skeleton.py
+++ b/tests/unit/test_ingestion/test_video_pipeline_skeleton.py
@@ -26,6 +26,8 @@ from course_supporter.ingestion.video_pipeline import VideoProcessor, steps
 from course_supporter.ingestion.video_pipeline.schemas import (
     ChangeClass,
     DetectionResult,
+    FrameDescription,
+    FrameKind,
     SampledFrame,
     Scene,
     SttResult,
@@ -99,22 +101,37 @@ def _stt_router(words_sec: list[tuple[str, float, float]]) -> AsyncMock:
     return router
 
 
+def _frame_descriptions() -> list[FrameDescription]:
+    """A one-anchor Pass 1 stand-in for the process_raw chaining tests."""
+    return [
+        FrameDescription(
+            scene_id=0,
+            frame_position_ms=0,
+            description="Slide: intro title.",
+            kind=FrameKind.ANCHOR,
+        )
+    ]
+
+
 def _make_processor(
     *,
     stt_router: AsyncMock | None = None,
     redis: AsyncMock | None = None,
+    stage_router: Mock | None = None,
 ) -> VideoProcessor:
     return VideoProcessor(
         stt_router=stt_router or _stt_router([("Hello", 0.0, 0.5)]),
         redis=redis or AsyncMock(),
+        stage_router=stage_router or AsyncMock(),
     )
 
 
 class TestVideoProcessorConstruction:
-    def test_requires_stt_router_and_redis(self) -> None:
-        """VideoProcessor wires with the two real-edge deps (mirror audio)."""
-        proc = VideoProcessor(stt_router=Mock(), redis=Mock())
-        assert isinstance(proc, VideoProcessor)
+    def test_requires_stt_router_redis_and_stage_router(self) -> None:
+        """VideoProcessor wires the three real-edge deps (STT/Redis/vision)."""
+        stt, redis, stage = Mock(), Mock(), Mock()
+        proc = VideoProcessor(stt_router=stt, redis=redis, stage_router=stage)
+        assert proc._stage_router is stage
 
 
 class TestStep1Ingest:
@@ -210,6 +227,7 @@ class TestProcessRawPipeline:
             patch(_PROBE, new=AsyncMock(return_value=meta)),
             patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))),
             patch(_STEP3, new=AsyncMock(return_value=_detection_result())),
+            patch(_STEP4, new=AsyncMock(return_value=_frame_descriptions())),
         ):
             doc = await proc.process_raw(_mock_authored_document())
 
@@ -234,6 +252,7 @@ class TestProcessRawPipeline:
             patch(_PROBE, new=AsyncMock(return_value=meta)),
             patch(_EXTRACT, new=AsyncMock(return_value=Path("/tmp/x/audio.mp3"))),
             patch(_STEP3, new=AsyncMock(return_value=_detection_result())),
+            patch(_STEP4, new=AsyncMock(return_value=_frame_descriptions())),
         ):
             await proc.process_raw(_mock_authored_document())
 

--- a/tests/unit/test_ingestion/test_video_vision.py
+++ b/tests/unit/test_ingestion/test_video_vision.py
@@ -10,6 +10,7 @@ RUN_SMOKE spike (C6), not exercised here.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -76,7 +77,9 @@ def _valid_content(render_context: dict[str, Any]) -> str:
 class _FakeStageRouter:
     """StageRouter double: records calls, echoes a valid chunk response."""
 
-    def __init__(self, content_fn: Any = _valid_content) -> None:
+    def __init__(
+        self, content_fn: Callable[[dict[str, Any]], str] = _valid_content
+    ) -> None:
         self.calls: list[dict[str, Any]] = []
         self._content_fn = content_fn
 

--- a/tests/unit/test_ingestion/test_video_vision.py
+++ b/tests/unit/test_ingestion/test_video_vision.py
@@ -1,0 +1,342 @@
+"""Unit tests for the Krok 4 Pass 1 vision chain-diff mechanism (Phase 2.4).
+
+CI-level (no real LLM, no ffmpeg): the chunk planner, the plain-text
+chunk-response parser (including the ``!= N`` and marker-mismatch retry
+edges), the PiP-mask application (real cv2 round-trip on a synthetic
+JPEG), and the ``run_pass_1`` orchestrator against a fake StageRouter.
+Preservation / N sweet-spot / image-cap calibration is the operator-run
+RUN_SMOKE spike (C6), not exercised here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+import pytest
+
+from course_supporter.ingestion.base import ProcessingError
+from course_supporter.ingestion.video_pipeline import vision
+from course_supporter.ingestion.video_pipeline.schemas import (
+    ChangeClass,
+    DetectionResult,
+    FrameKind,
+    PiPMask,
+    SampledFrame,
+    Scene,
+    VideoFileMetadata,
+)
+from course_supporter.llm.error_categories import StructuralRetryError
+from course_supporter.llm.stage_router import StageResult
+
+# ── builders ─────────────────────────────────────────────────────────────
+
+
+def _meta() -> VideoFileMetadata:
+    return VideoFileMetadata(duration_ms=600_000, codec="h264", resolution="1280x720")
+
+
+def _frame(
+    position_ms: int, change_class: ChangeClass, path: Path = Path("/tmp/f.jpg")
+) -> SampledFrame:
+    return SampledFrame(
+        frame_position_ms=position_ms, change_class=change_class, frame_path=path
+    )
+
+
+def _scene(scene_id: int, frames: list[SampledFrame]) -> Scene:
+    return Scene(
+        scene_id=scene_id,
+        start_ms=frames[0].frame_position_ms,
+        end_ms=frames[-1].frame_position_ms,
+        frames=frames,
+    )
+
+
+def _pf(position_ms: int, change_class: ChangeClass, scene_id: int = 0) -> vision._PF:
+    return vision._PF(sampled=_frame(position_ms, change_class), scene_id=scene_id)
+
+
+def _write_jpeg(directory: Path, name: str, fill: int = 200) -> Path:
+    path = directory / f"frame_{name}.jpg"
+    cv2.imwrite(str(path), np.full((64, 64, 3), fill, dtype=np.uint8))
+    return path
+
+
+def _valid_content(render_context: dict[str, Any]) -> str:
+    """A well-formed chunk response built from the render context markers."""
+    return "\n".join(
+        f"{f['marker']}\nDescription for {f['marker']}."
+        for f in render_context["frames"]
+    )
+
+
+class _FakeStageRouter:
+    """StageRouter double: records calls, echoes a valid chunk response."""
+
+    def __init__(self, content_fn: Any = _valid_content) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._content_fn = content_fn
+
+    async def execute_for_stage(
+        self,
+        stage_name: str,
+        *,
+        response_validator: Any = None,
+        contents: Any = None,
+        **render_context: Any,
+    ) -> StageResult:
+        self.calls.append(
+            {
+                "stage": stage_name,
+                "contents": contents,
+                "render_context": render_context,
+            }
+        )
+        content = self._content_fn(render_context)
+        if response_validator is not None:
+            response_validator(content)
+        return StageResult(
+            content=content,
+            provider_used="dashscope",
+            model_used="qwen3-vl-32b-instruct",
+            attempt_count=1,
+        )
+
+
+class _RaisingStageRouter:
+    async def execute_for_stage(self, *args: Any, **kwargs: Any) -> StageResult:
+        raise RuntimeError("ladder boom")
+
+
+# ── marker + kind helpers ─────────────────────────────────────────────────
+
+
+class TestMarkerAndKind:
+    @pytest.mark.parametrize(
+        ("ms", "expected"),
+        [
+            (0, "[FRAME 00:00:00]"),
+            (5_000, "[FRAME 00:00:05]"),
+            (83_000, "[FRAME 00:01:23]"),
+            (3_661_000, "[FRAME 01:01:01]"),  # > 1 h — HH field needed (150-min cap)
+        ],
+    )
+    def test_format_marker(self, ms: int, expected: str) -> None:
+        assert vision._format_marker(ms) == expected
+
+    def test_first_in_chunk_is_anchor_even_when_low(self) -> None:
+        # index 0 forces anchor regardless of change_class.
+        assert vision._kind_at(0, ChangeClass.LOW) is FrameKind.ANCHOR
+
+    def test_scene_start_is_anchor_mid_chunk(self) -> None:
+        assert vision._kind_at(3, ChangeClass.BOUNDARY) is FrameKind.ANCHOR
+        assert vision._kind_at(3, ChangeClass.FIRST) is FrameKind.ANCHOR
+
+    def test_low_medium_mid_chunk_is_diff(self) -> None:
+        assert vision._kind_at(2, ChangeClass.LOW) is FrameKind.DIFF
+        assert vision._kind_at(2, ChangeClass.MEDIUM) is FrameKind.DIFF
+
+
+# ── chunk planning (constants monkeypatched so the algorithm, not the seed,
+#    is under test) ─────────────────────────────────────────────────────────
+
+
+class TestChunkPlanning:
+    def test_image_cap_splits_a_long_scene(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(vision, "_IMAGE_BUDGET", 3)
+        monkeypatch.setattr(vision, "_BUDGET_TOKENS", 100_000)  # token cap inactive
+        frames = [_frame(0, ChangeClass.FIRST)] + [
+            _frame(i * 1000, ChangeClass.LOW) for i in range(1, 7)
+        ]
+        chunks = vision._plan_chunks([_scene(0, frames)])
+
+        assert [len(c) for c in chunks] == [3, 3, 1]
+        # first frame of every chunk is an anchor (self-sufficient chunk).
+        for chunk in chunks:
+            assert vision._kind_at(0, chunk[0].sampled.change_class) is FrameKind.ANCHOR
+
+    def test_token_budget_splits_a_long_scene(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(vision, "_IMAGE_BUDGET", 100)  # image cap inactive
+        monkeypatch.setattr(vision, "_BUDGET_TOKENS", 1000)
+        monkeypatch.setattr(vision, "_EST_ANCHOR_TOKENS", 700)
+        monkeypatch.setattr(vision, "_EST_DIFF_TOKENS", 200)
+        # anchor(700) + diff(200) = 900 fits; a second diff (1100) overflows.
+        frames = [_frame(0, ChangeClass.FIRST)] + [
+            _frame(i * 1000, ChangeClass.LOW) for i in range(1, 6)
+        ]
+        chunks = vision._plan_chunks([_scene(0, frames)])
+
+        assert [len(c) for c in chunks] == [2, 2, 2]
+
+    def test_small_scenes_merge_into_one_chunk(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(vision, "_IMAGE_BUDGET", 10)
+        monkeypatch.setattr(vision, "_BUDGET_TOKENS", 100_000)
+        scenes = [
+            _scene(
+                i,
+                [
+                    _frame(i * 100, ChangeClass.BOUNDARY if i else ChangeClass.FIRST),
+                    _frame(i * 100 + 50, ChangeClass.LOW),
+                ],
+            )
+            for i in range(3)
+        ]
+        chunks = vision._plan_chunks(scenes)
+
+        assert len(chunks) == 1
+        assert len(chunks[0]) == 6
+        # scene_ids are preserved through the flatten.
+        assert [pf.scene_id for pf in chunks[0]] == [0, 0, 1, 1, 2, 2]
+
+    def test_scenes_do_not_merge_past_image_cap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(vision, "_IMAGE_BUDGET", 3)
+        monkeypatch.setattr(vision, "_BUDGET_TOKENS", 100_000)
+        scenes = [
+            _scene(0, [_frame(0, ChangeClass.FIRST), _frame(50, ChangeClass.LOW)]),
+            _scene(
+                1, [_frame(100, ChangeClass.BOUNDARY), _frame(150, ChangeClass.LOW)]
+            ),
+        ]
+        chunks = vision._plan_chunks(scenes)
+
+        assert [len(c) for c in chunks] == [2, 2]
+
+
+# ── chunk-response parsing ─────────────────────────────────────────────────
+
+
+class TestParseChunk:
+    def test_parses_blocks_ordinally_with_kinds(self) -> None:
+        chunk = [_pf(0, ChangeClass.FIRST), _pf(5_000, ChangeClass.LOW)]
+        content = (
+            "[FRAME 00:00:00]\nFull anchor description.\n"
+            "[FRAME 00:00:05]\nOnly the delta."
+        )
+        result = vision._parse_chunk(content, chunk)
+
+        assert [d.frame_position_ms for d in result] == [0, 5_000]
+        assert result[0].kind is FrameKind.ANCHOR
+        assert result[0].description == "Full anchor description."
+        assert result[1].kind is FrameKind.DIFF
+        assert result[1].description == "Only the delta."
+        assert result[1].scene_id == 0
+
+    def test_wrong_block_count_raises_structural_retry(self) -> None:
+        chunk = [_pf(0, ChangeClass.FIRST), _pf(5_000, ChangeClass.LOW)]
+        content = "[FRAME 00:00:00]\nOnly one block, two expected."
+
+        with pytest.raises(StructuralRetryError, match="expected 2"):
+            vision._parse_chunk(content, chunk)
+
+    def test_marker_mismatch_raises_structural_retry(self) -> None:
+        chunk = [_pf(0, ChangeClass.FIRST), _pf(5_000, ChangeClass.LOW)]
+        # second marker should be 00:00:05 but the model emitted 00:00:09.
+        content = "[FRAME 00:00:00]\nAnchor.\n[FRAME 00:00:09]\nWrong marker."
+
+        with pytest.raises(StructuralRetryError, match="marker mismatch"):
+            vision._parse_chunk(content, chunk)
+
+
+# ── PiP masking ────────────────────────────────────────────────────────────
+
+
+class TestPipMask:
+    def test_masks_region_and_preserves_outside(self, tmp_path: Path) -> None:
+        cv2.imwrite(
+            str(tmp_path / "f.jpg"), np.full((100, 200, 3), 255, dtype=np.uint8)
+        )
+        mask = PiPMask(x=10, y=10, width=40, height=30, confidence=0.9)
+
+        out = vision._read_masked_jpeg(tmp_path / "f.jpg", mask)
+        decoded = cv2.imdecode(np.frombuffer(out, np.uint8), cv2.IMREAD_COLOR)
+
+        # well inside the box → grey ~128 (JPEG is lossy → tolerance).
+        assert abs(int(decoded[22, 28, 0]) - vision._PIP_FILL_GRAY) < 12
+        # well outside the box → original white preserved.
+        assert int(decoded[80, 180, 0]) > 230
+
+    def test_none_mask_keeps_image(self, tmp_path: Path) -> None:
+        cv2.imwrite(str(tmp_path / "f.jpg"), np.full((40, 40, 3), 255, dtype=np.uint8))
+
+        out = vision._read_masked_jpeg(tmp_path / "f.jpg", None)
+        decoded = cv2.imdecode(np.frombuffer(out, np.uint8), cv2.IMREAD_COLOR)
+
+        assert int(decoded[20, 20, 0]) > 230
+
+    def test_out_of_bounds_box_is_clamped(self, tmp_path: Path) -> None:
+        cv2.imwrite(str(tmp_path / "f.jpg"), np.full((40, 40, 3), 255, dtype=np.uint8))
+        # box extends past the frame — clamp must not raise / overrun.
+        mask = PiPMask(x=30, y=30, width=100, height=100, confidence=0.5)
+
+        out = vision._read_masked_jpeg(tmp_path / "f.jpg", mask)
+        decoded = cv2.imdecode(np.frombuffer(out, np.uint8), cv2.IMREAD_COLOR)
+
+        assert abs(int(decoded[35, 35, 0]) - vision._PIP_FILL_GRAY) < 12
+
+    def test_unreadable_frame_raises_processing_error(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nope.jpg"
+
+        with pytest.raises(ProcessingError, match="cannot read frame"):
+            vision._read_masked_jpeg(missing, None)
+
+
+# ── run_pass_1 orchestrator ────────────────────────────────────────────────
+
+
+class TestRunPass1:
+    async def test_describes_chunks_and_wires_the_stage_call(
+        self, tmp_path: Path
+    ) -> None:
+        frames = [
+            _frame(0, ChangeClass.FIRST, _write_jpeg(tmp_path, "0")),
+            _frame(5_000, ChangeClass.LOW, _write_jpeg(tmp_path, "5")),
+        ]
+        detection = DetectionResult(scenes=[_scene(0, frames)], pip_mask=None)
+        router = _FakeStageRouter()
+
+        result = await vision.run_pass_1(detection, _meta(), stage_router=router)
+
+        assert [d.frame_position_ms for d in result] == [0, 5_000]
+        assert result[0].kind is FrameKind.ANCHOR
+        assert result[1].kind is FrameKind.DIFF
+
+        assert len(router.calls) == 1
+        call = router.calls[0]
+        assert call["stage"] == "video_pass_1_vision"
+        assert len(call["contents"]) == 2  # one masked JPEG per frame
+        assert all(isinstance(b, bytes) for b in call["contents"])
+        assert call["render_context"]["n_frames"] == 2
+        assert call["render_context"]["frames"][0]["marker"] == "[FRAME 00:00:00]"
+        assert call["render_context"]["frames"][0]["kind"] == "ANCHOR"
+        assert call["render_context"]["frames"][1]["kind"] == "DIFF"
+
+    async def test_empty_scenes_returns_empty(self) -> None:
+        detection = DetectionResult(scenes=[], pip_mask=None)
+
+        result = await vision.run_pass_1(
+            detection, _meta(), stage_router=_FakeStageRouter()
+        )
+
+        assert result == []
+
+    async def test_chunk_failure_is_fail_fast_processing_error(
+        self, tmp_path: Path
+    ) -> None:
+        frames = [_frame(0, ChangeClass.FIRST, _write_jpeg(tmp_path, "0"))]
+        detection = DetectionResult(scenes=[_scene(0, frames)], pip_mask=None)
+
+        with pytest.raises(ProcessingError, match="chunk 0"):
+            await vision.run_pass_1(
+                detection, _meta(), stage_router=_RaisingStageRouter()
+            )


### PR DESCRIPTION
## What

Replaces the `step_4_pass1_vision` stub with a real **chunked chain-diff vision pass** (Krok 4, the first real LLM call in the video pipeline). A vision model (Qwen3-VL rung 1 → Gemini fallback) describes the kept frames as time-bound text: **anchor** (full description) for the first-in-chunk frame and scene starts, **diff** (delta vs the previous frame) otherwise. Krok 5-7 stay stubs; the pipeline reaches `state=ready`.

Output is **plain text**, parsed back into `FrameDescription` by the `[FRAME HH:MM:SS]` marker. A wrong block count or marker mismatch raises `StructuralRetryError` (router retry → ladder fallback); terminal failure → `ProcessingError` (R1 `state=ERROR`).

## Key pieces

- **`video_pipeline/vision.py`** (new) — budget+image greedy chunking (scene-aware: a scene is kept whole unless it alone exceeds budget; small scenes merge), PiP-mask application (grey-fill, applied here per the sealed Krok3→Krok4 contract), chunk-response parser (ordinal + marker-checksum, line-anchored), bounded-concurrency `run_pass_1` (chunks are independent — within-chunk chain only).
- **`config/ladders_video.yaml`** (new) — stage `video_pass_1_vision`: Qwen3-VL (`reasoning: {exclude: true}`) → gemini-3-flash-preview → gemini-2.5-flash, per-rung `max_output_tokens: 8192` uniform (chunk packer targets 6144).
- **`prompts/video_pass_1_vision/v1.md`** (new) — chain-diff multi-frame prompt (anchor/diff modes, verbatim markers, code-fence + Ukrainian preservation).
- **C1 direct-injection** — `StageRouter` injected into `VideoProcessor.__init__`; the factory dispatch guard is now **asymmetric**: AUDIO needs `{stt, redis}`, VIDEO needs `{stt, redis, stage_router}` (Pass 1 lives in `process_raw`, before Stage 2 safety, so the vision ladder can't arrive via the `process_macro` method arg). This is the **video step of DD-2.3-AF**.

## Spike split (C6)
- **Mechanism (this PR, CI):** chain-diff + chunking + parse + ladder wiring + pip-mask, deterministic with a fake StageRouter.
- **Calibration (RUN_SMOKE, operator):** ranked-ladder preservation, N sweet-spot, DashScope/Gemini multi-image cap (C4), real output < 8192, est-cost tuning. Real fixture = DD-2.2-AA.

## DD-scan
DD-2.4-A de-bundled (Pass 1 reads the ladder, not ContextPolicy) · DD-2.3-AF partially advanced (video on direct-injection; full HeavySteps removal ~2.4.9) · DD-2.3-AD Claude vision deferred (ladder Qwen→Gemini) · DD-2.3-AI not triggered (cv2 already a dep).

## Gates
- ruff format + check clean; `mypy src/` clean (134 files)
- unit **52** (marker/kind, chunking, parse incl ±N + marker-mismatch, pip-mask cv2 round-trip, `run_pass_1` + fail-fast + empty)
- integration `--run-db` **3/3** (topology happy + R1 failure + `requires_ffmpeg` real ffprobe/ffmpeg/cv2)
- non-db regression **2124 passed, 0 failed**
- `rg "from course_supporter.vd" video_pipeline/` → **0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)