### PR TITLE
task(2.4.6): Pass 2b algorithmic slice + visual merge

### DIFF
--- a/migrations/versions/phase24_segment_visual_content.py
+++ b/migrations/versions/phase24_segment_visual_content.py
@@ -1,0 +1,62 @@
+"""Phase 2.4 task 2.4.6: add document_segments.visual_content JSONB column
+
+Revision ID: phase24_segment_visual_content
+Revises: phase22_audio_source_type
+Create Date: 2026-05-23 00:00:00.000000
+
+Adds the ``visual_content`` JSONB column to ``document_segments`` to
+persist a video segment's time-anchored visual stream (Pass 1 frame
+descriptions partitioned over the segment timeline at Pass 2b). The
+visual stream is genuine authored content for video and is persisted
+nowhere else, so an ORM column is the only place it survives ingestion
+(task 2.4.6 §1).
+
+Non-expansive / backward-compatible: not-null with ``server_default
+'[]'::jsonb`` so every existing row backfills to an empty array and no
+caller of another source type changes. Only the video pipeline writes a
+non-empty value. Mirrors the ``main_concepts`` / ``secondary_concepts``
+JSONB + server_default mechanics on the same table.
+
+The column joins the ``DocumentSegment.content_hash`` formula (KD-2.1-F)
+CONDITIONALLY (only when non-empty) so historical and non-video segment
+hashes stay byte-identical -- see ``storage/content_hash.py`` and task
+2.4.6 D1.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "phase24_segment_visual_content"
+down_revision: str | Sequence[str] | None = "phase22_audio_source_type"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the not-null visual_content JSONB column (default empty array)."""
+    op.add_column(
+        "document_segments",
+        sa.Column(
+            "visual_content",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+            comment=(
+                "Time-anchored visual descriptions for video segments "
+                "(task 2.4.6): JSONB array of VisualSceneRef dicts "
+                "(position_ms / description / kind / scene_id), kept in "
+                "temporal (frame) order. Empty [] for non-video and "
+                "visual-less segments. Mirrors the main_concepts "
+                "JSONB+server_default mechanics; included in content_hash "
+                "(KD-2.1-F) only when non-empty (task 2.4.6 D1)."
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the visual_content column."""
+    op.drop_column("document_segments", "visual_content")

--- a/src/course_supporter/ingestion/schemas.py
+++ b/src/course_supporter/ingestion/schemas.py
@@ -58,6 +58,42 @@ from __future__ import annotations
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 
+class VisualSceneRef(BaseModel):
+    """One time-anchored visual description attached to a video segment.
+
+    Minimal draft carrier for the visual stream of a video segment
+    (task 2.4.6): each ref is a Pass 1 frame description (the ``text``
+    of a ``VISUAL_SCENE`` chunk) plus the temporal/scene metadata that
+    chunk carried (B', task 2.4.5). It is intentionally *not* a
+    ``ContentChunk`` — that is the heavyweight assembled-document type;
+    this is a per-segment draft field materialised into the
+    ``DocumentSegment.visual_content`` JSONB column at Pass 2b.
+
+    Refs are kept in temporal (frame) order within a segment — that
+    order is meaningful and is preserved through the ORM and the
+    ``content_hash`` formula (it is NOT sorted, unlike concept sets).
+    """
+
+    position_ms: int = Field(
+        description="Frame timestamp in ms from the start of the video "
+        "(``VISUAL_SCENE`` chunk ``metadata.frame_position_ms``).",
+    )
+    description: str = Field(
+        description="Pass 1 visual description of the frame (the chunk text).",
+    )
+    kind: str = Field(
+        default="",
+        description="Frame role (e.g. ``anchor`` / ``diff``) from the chunk "
+        "``metadata.kind``; empty string when unknown.",
+    )
+    scene_id: int = Field(
+        default=0,
+        description="Scene grouping id (``VISUAL_SCENE`` chunk "
+        "``metadata.scene_id``) so consecutive frames of one scene can be "
+        "grouped downstream.",
+    )
+
+
 class DocumentSegmentDraft(BaseModel):
     """In-flight segment draft (Pass 2a metadata + Pass 2b content, pre-ORM).
 
@@ -153,6 +189,18 @@ class DocumentSegmentDraft(BaseModel):
             "noisy-badge per KD-2.2-J item 5. Default ``False`` for "
             "text / web / video — non-audio source_types preserve "
             "backward-compat without caller changes."
+        ),
+    )
+    visual_content: list[VisualSceneRef] | None = Field(
+        default=None,
+        description=(
+            "Time-anchored visual descriptions for this segment (task "
+            "2.4.6, video source_type only). Populated at Pass 2b by the "
+            "start-time partition of ``VISUAL_SCENE`` chunks over the "
+            "segment timeline; ``None`` for audio / text / web / "
+            "presentation (the second authored stream exists only for "
+            "video). Refs are kept in temporal order; materialised into "
+            "the ``DocumentSegment.visual_content`` JSONB column."
         ),
     )
 

--- a/src/course_supporter/ingestion/video_pipeline/steps.py
+++ b/src/course_supporter/ingestion/video_pipeline/steps.py
@@ -39,6 +39,7 @@ from course_supporter.ingestion.schemas import (
     AudioPass2aResult,
     DocumentSegmentDraft,
     DocumentSummaryDraft,
+    VisualSceneRef,
 )
 from course_supporter.ingestion.video_pipeline import detection, media, vision
 from course_supporter.ingestion.video_pipeline.schemas import (
@@ -371,25 +372,86 @@ async def step_5_pass2a_mapping(
 # ── Krok 6-7 — invoked from process_detail ─────────────────────────
 
 
+def _partition_visuals(
+    doc: SourceDocument,
+    segments: list[DocumentSegmentDraft],
+) -> dict[int, list[VisualSceneRef]]:
+    """Assign each ``VISUAL_SCENE`` chunk to exactly one segment (task 2.4.6).
+
+    Partition (NOT interval membership) over the segment timeline by
+    **segment start times**, half-open ``[start_i, start_{i+1})``:
+
+    * a frame at ``fp`` belongs to segment ``i`` where
+      ``start_i <= fp < start_{i+1}``;
+    * frames before the first segment's start clamp to segment 0;
+    * frames after the last start fall into the last segment.
+
+    Why a partition and not ``start_time_sec <= fp <= end_time_sec``: Pass 2a
+    sets ``end_time_sec = words[end_word_idx-1].end_ms/1000`` (exclusive word
+    index), so adjacent segments are time-*disjoint* — an inter-word pause
+    gapes between them. A slide change typically happens *during* that pause
+    (the lecturer stops, clicks, then resumes), so an interval-membership
+    filter would systematically drop the most synchronisation-relevant frames.
+    A partition covers the whole axis with no gaps or overlaps, so every frame
+    lands in exactly one segment. The bisect mirrors the word-anchor bisect in
+    :func:`_build_visual_overlay`. Refs are kept in temporal (frame) order.
+
+    Returns a ``{segment_index: [VisualSceneRef, ...]}`` map (every segment
+    index present, possibly with an empty list).
+    """
+    result: dict[int, list[VisualSceneRef]] = {i: [] for i in range(len(segments))}
+    visual_chunks = [c for c in doc.chunks if c.chunk_type == ChunkType.VISUAL_SCENE]
+    starts = [seg.start_time_sec for seg in segments]
+    if not visual_chunks or not segments or any(s is None for s in starts):
+        # No visuals, no segments, or no timeline (non-video draft) — nothing
+        # to partition; every segment keeps its empty list.
+        return result
+    start_secs: list[float] = [s for s in starts if s is not None]
+    for chunk in sorted(
+        visual_chunks,
+        key=lambda c: int(c.metadata.get("frame_position_ms", 0)),
+    ):
+        fp_ms = int(chunk.metadata.get("frame_position_ms", 0))
+        idx = max(0, bisect.bisect_right(start_secs, fp_ms / 1000.0) - 1)
+        result[idx].append(
+            VisualSceneRef(
+                position_ms=fp_ms,
+                description=chunk.text,
+                kind=str(chunk.metadata.get("kind", "")),
+                scene_id=int(chunk.metadata.get("scene_id", 0)),
+            )
+        )
+    return result
+
+
 async def step_6_pass2b_slice(
     doc: SourceDocument,
     summary_draft: DocumentSummaryDraft,
 ) -> list[DocumentSegmentDraft]:
-    """Krok 6 — Pass 2b algorithmic slice (§1).
+    """Krok 6 — Pass 2b algorithmic slice + visual merge (§1).
 
-    Zero-LLM by design (task 2.4.6 finalises the transcript/visual merge
-    format). Skeleton mirrors the audio Pass 2b slice: fill ``content``
-    for each draft from ``doc.assemble_text()[start_pos:end_pos]`` when
-    not already populated.
+    Zero-LLM, deterministic. Materialises the two time-aligned streams of a
+    video segment (architectural direction (c), task 2.4.6):
+
+    * ``content`` — transcript slice ``doc.assemble_text()[start_pos:end_pos]``
+      (the audio/text Pass 2b precedent), filled when Pass 2a left it ``None``;
+    * ``visual_content`` — the ``VISUAL_SCENE`` chunks whose frame timestamps
+      partition into this segment's time range (see :func:`_partition_visuals`).
+
+    Since this step runs only for video, every segment receives a
+    ``visual_content`` list (possibly empty when no frame falls in its range).
+    The two streams stay structurally separate so Pass 2c (task 2.4.7) cleans
+    only the transcript ``content`` — the visual stream is clean by
+    construction (KD2d).
     """
     reference = doc.assemble_text()
+    visuals_by_idx = _partition_visuals(doc, summary_draft.segments)
     sliced: list[DocumentSegmentDraft] = []
-    for draft in summary_draft.segments:
-        if draft.content is not None:
-            sliced.append(draft)
-            continue
-        raw_content = reference[draft.start_pos : draft.end_pos]
-        sliced.append(draft.model_copy(update={"content": raw_content}))
+    for idx, draft in enumerate(summary_draft.segments):
+        update: dict[str, object] = {"visual_content": visuals_by_idx[idx]}
+        if draft.content is None:
+            update["content"] = reference[draft.start_pos : draft.end_pos]
+        sliced.append(draft.model_copy(update=update))
     return sliced
 
 

--- a/src/course_supporter/ingestion_callback.py
+++ b/src/course_supporter/ingestion_callback.py
@@ -125,6 +125,30 @@ class IngestionCallback:
             entry_repo = AuthoredDocumentRepository(session)
             await entry_repo.fail_processing(material_id, error_message=error_message)
 
+            # Orphan-Summary observer (task 2.4.6, Q4 / DD-2.4-G). Pass 2a
+            # commits the DocumentSummary before process_detail runs
+            # (api/tasks.py), so a later Pass 2b/2c failure leaves that
+            # summary committed under a now-ERROR document. This is a
+            # pre-existing cross-source_type window (Phase 2.1+); here we
+            # only OBSERVE it (read-only warning in this already-open failure
+            # session) so the condition is visible before task 2.4.7's Pass 2c
+            # introduces a real process_detail failure surface. Resolution
+            # (single-commit / rollback / accept) is deferred to DD-2.4-G; the
+            # orchestrator commit sequence is NOT touched.
+            from course_supporter.storage.document_summary_repository import (
+                DocumentSummaryRepository,
+            )
+
+            orphan = await DocumentSummaryRepository(
+                session
+            ).get_by_authored_document_id(material_id)
+            if orphan is not None:
+                log.warning(
+                    "ingestion_orphan_summary_detected",
+                    summary_id=str(orphan.id),
+                    error=error_message,
+                )
+
             from course_supporter.security.exceptions import ErrorCategory
 
             if error_category == ErrorCategory.STAGE2_REJECTED:

--- a/src/course_supporter/storage/content_hash.py
+++ b/src/course_supporter/storage/content_hash.py
@@ -329,14 +329,31 @@ class ContentHashService:
         they actually have ``deleted_at`` set.
         """
         if isinstance(entity, DocumentSegment):
-            local = _encode_local_fields(
-                {
-                    "content": entity.content or "",
-                    "main_concepts": sorted(entity.main_concepts or []),
-                    "secondary_concepts": sorted(entity.secondary_concepts or []),
-                }
-            )
-            return compute_content_hash(local, [])
+            payload: dict[str, object] = {
+                "content": entity.content or "",
+                "main_concepts": sorted(entity.main_concepts or []),
+                "secondary_concepts": sorted(entity.secondary_concepts or []),
+            }
+            # visual_content (task 2.4.6): a video segment's visual stream is
+            # genuine authored content (like concepts), so a Pass 1
+            # re-description must invalidate the Merkle chain. It joins the
+            # formula CONDITIONALLY — only when non-empty (truthy, NOT
+            # ``is not None``: the column is not-null and defaults to ``[]``,
+            # which is falsy).
+            #
+            # The asymmetry vs concepts is deliberate, NOT an oversight: main_/
+            # secondary_concepts are baked into every historical segment hash
+            # since Phase 1, so they are always included; visual_content is new
+            # in 2.4.6 and historical payloads never carried it. Including it
+            # only when non-empty keeps every pre-2.4.6 row — and every
+            # non-video / visual-less segment, where it is ``[]`` — byte-
+            # identical (zero hash perturbation). Do NOT "normalise" this to an
+            # unconditional include: that would re-hash every existing segment
+            # in production. Order is NOT sorted — frame order is temporally
+            # meaningful, unlike the order-free concept sets.
+            if entity.visual_content:
+                payload["visual_content"] = entity.visual_content
+            return compute_content_hash(_encode_local_fields(payload), [])
 
         if isinstance(entity, DocumentSummary):
             local = _encode_local_fields(

--- a/src/course_supporter/storage/document_segment_repository.py
+++ b/src/course_supporter/storage/document_segment_repository.py
@@ -124,6 +124,12 @@ class DocumentSegmentRepository:
                     content_char_count=len(content),
                     main_concepts=list(draft.main_concepts),
                     secondary_concepts=list(draft.secondary_concepts),
+                    # Video visual stream (task 2.4.6); [] for every other
+                    # source type (draft.visual_content is None) -- coerced so
+                    # the not-null JSONB column always receives a real array.
+                    visual_content=[
+                        ref.model_dump() for ref in (draft.visual_content or [])
+                    ],
                 )
             )
 

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -696,6 +696,17 @@ class DocumentSegment(SoftDeleteMixin, Base):
         server_default=text("'[]'::jsonb"),
         comment="List of concept strings mentioned but not taught (KD-gamma).",
     )
+    visual_content: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+        comment="Time-anchored visual descriptions for video segments (task "
+        "2.4.6): JSONB array of VisualSceneRef dicts "
+        "(position_ms / description / kind / scene_id), kept in temporal "
+        "(frame) order. Empty [] for non-video and visual-less segments. "
+        "Mirrors the main_concepts JSONB+server_default mechanics; included "
+        "in content_hash (KD-2.1-F) only when non-empty (task 2.4.6 D1).",
+    )
     content_char_count: Mapped[int | None] = mapped_column(
         Integer,
         comment="Char count of content (size-metric for weighting per vision "

--- a/tests/integration/test_arq_task_e2e.py
+++ b/tests/integration/test_arq_task_e2e.py
@@ -36,11 +36,17 @@ _HEAVY = "course_supporter.api.tasks.create_heavy_steps"
 def _build_ctx(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> dict[str, Any]:
-    """Build a minimal ARQ worker context dict."""
+    """Build a minimal ARQ worker context dict.
+
+    ``redis`` is the ArqRedis pool that arq injects into every job ctx
+    (the shared task unpacks it for the audio/video processor factory,
+    task 2.4.2); mocked here since this factory is patched out.
+    """
     return {
         "session_factory": session_factory,
         "model_router": MagicMock(),
         "stage_router": MagicMock(),
+        "redis": MagicMock(),
     }
 
 

--- a/tests/integration/test_document_segment_repository.py
+++ b/tests/integration/test_document_segment_repository.py
@@ -33,7 +33,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from course_supporter.ingestion.base import ProcessingError
-from course_supporter.ingestion.schemas import DocumentSegmentDraft
+from course_supporter.ingestion.schemas import DocumentSegmentDraft, VisualSceneRef
 from course_supporter.models.source import (
     ChunkType,
     ContentChunk,
@@ -80,6 +80,7 @@ def _draft(
     main: list[str] | None = None,
     secondary: list[str] | None = None,
     content: str | None = None,
+    visual: list[VisualSceneRef] | None = None,
 ) -> DocumentSegmentDraft:
     return DocumentSegmentDraft(
         order=order,
@@ -90,6 +91,7 @@ def _draft(
         main_concepts=main or [],
         secondary_concepts=secondary or [],
         content=content,
+        visual_content=visual,
     )
 
 
@@ -190,6 +192,56 @@ class TestCreateBatch:
 
         assert segments[0].content == "pre-filled"
         assert segments[0].content_char_count == len("pre-filled")
+
+    async def test_persists_visual_content_round_trip(
+        self,
+        db_session: AsyncSession,
+        seed_root_node: CourseNode,
+        seed_material_entry: AuthoredDocument,
+    ) -> None:
+        """Task 2.4.6: a video draft's visual stream round-trips through the
+        JSONB column as ordered dicts; a draft without it persists ``[]``
+        (not-null server_default)."""
+        summary = await _make_summary(db_session, seed_material_entry)
+        text = "video transcript alpha beta"
+        doc = _source_doc(text)
+        drafts = [
+            _draft(
+                order=0,
+                start_pos=0,
+                end_pos=10,
+                content="alpha",
+                visual=[
+                    VisualSceneRef(position_ms=0, description="slide A", kind="anchor"),
+                    VisualSceneRef(position_ms=9000, description="slide B", scene_id=1),
+                ],
+            ),
+            _draft(order=1, start_pos=10, end_pos=len(text), content="beta"),
+        ]
+
+        repo = DocumentSegmentRepository(db_session)
+        segments = await repo.create_batch(summary.id, drafts, source_doc=doc)
+
+        assert segments[0].visual_content == [
+            {
+                "position_ms": 0,
+                "description": "slide A",
+                "kind": "anchor",
+                "scene_id": 0,
+            },
+            {"position_ms": 9000, "description": "slide B", "kind": "", "scene_id": 1},
+        ]
+        # Non-video / visual-less draft -> empty array, never NULL.
+        assert segments[1].visual_content == []
+
+        # Re-read from a fresh query to confirm JSONB persistence (not just
+        # the in-session instance).
+        reloaded = (
+            await db_session.execute(
+                select(DocumentSegment).where(DocumentSegment.id == segments[0].id)
+            )
+        ).scalar_one()
+        assert reloaded.visual_content[0]["description"] == "slide A"
 
     async def test_cascade_propagates_content_hash_to_root(
         self,

--- a/tests/integration/test_ingest_text_stage2_pass.py
+++ b/tests/integration/test_ingest_text_stage2_pass.py
@@ -49,6 +49,10 @@ def _build_ctx(
         "session_factory": session_factory,
         "model_router": MagicMock(),
         "stage_router": MagicMock(),
+        # ArqRedis pool injected into every job ctx; the shared task unpacks
+        # it for the audio/video processor factory (task 2.4.2). Mocked here
+        # since create_processors is patched out.
+        "redis": MagicMock(),
     }
 
 

--- a/tests/integration/test_ingest_text_stage2_reject.py
+++ b/tests/integration/test_ingest_text_stage2_reject.py
@@ -43,6 +43,10 @@ def _build_ctx(
         "session_factory": session_factory,
         "model_router": MagicMock(),
         "stage_router": MagicMock(),
+        # ArqRedis pool injected into every job ctx; the shared task unpacks
+        # it for the audio/video processor factory (task 2.4.2). Mocked here
+        # since create_processors is patched out.
+        "redis": MagicMock(),
     }
 
 

--- a/tests/storage/test_content_hash_formulas.py
+++ b/tests/storage/test_content_hash_formulas.py
@@ -31,7 +31,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from course_supporter.storage.content_hash import ContentHashService
+from course_supporter.storage.content_hash import (
+    ContentHashService,
+    _encode_local_fields,
+    compute_content_hash,
+)
 from course_supporter.storage.orm import DocumentSegment, DocumentSummary
 
 
@@ -193,6 +197,94 @@ class TestDocumentSegmentFormula:
         assert await svc._compute_hash_for(
             a, exclude_ids=None
         ) == await svc._compute_hash_for(b, exclude_ids=None)
+
+    async def test_empty_visual_content_byte_identical_to_pre_2_4_6(self) -> None:
+        """D1 hard-gate (task 2.4.6): visual_content empty (``[]``) or absent
+        (``None``, in-memory) must NOT perturb the hash of any existing
+        segment. The hash must equal the pre-2.4.6 formula
+        ``compute_content_hash(content + sorted(concepts))`` byte-for-byte,
+        so every non-video / visual-less row keeps its stored content_hash.
+        """
+        seg_none = _make_segment(
+            content="body",
+            main_concepts=["b", "a"],
+            secondary_concepts=["c"],
+        )
+        seg_empty = _make_segment(
+            content="body",
+            main_concepts=["b", "a"],
+            secondary_concepts=["c"],
+        )
+        seg_empty.visual_content = []  # flushed not-null default shape
+
+        expected_pre_2_4_6 = compute_content_hash(
+            _encode_local_fields(
+                {
+                    "content": "body",
+                    "main_concepts": sorted(["b", "a"]),
+                    "secondary_concepts": ["c"],
+                }
+            ),
+            [],
+        )
+        svc = ContentHashService(AsyncMock())
+        assert seg_none.visual_content is None  # _make_segment leaves it unset
+        assert (
+            await svc._compute_hash_for(seg_none, exclude_ids=None)
+            == expected_pre_2_4_6
+        )
+        assert (
+            await svc._compute_hash_for(seg_empty, exclude_ids=None)
+            == expected_pre_2_4_6
+        )
+
+    async def test_non_empty_visual_content_changes_hash(self) -> None:
+        """A populated visual stream (video) joins the formula, so a segment
+        with visuals hashes differently from the same transcript without.
+        """
+        without = _make_segment(content="body")
+        with_visual = _make_segment(content="body")
+        with_visual.main_concepts = list(without.main_concepts or [])
+        with_visual.secondary_concepts = list(without.secondary_concepts or [])
+        with_visual.visual_content = [
+            {
+                "position_ms": 0,
+                "description": "slide A",
+                "kind": "anchor",
+                "scene_id": 0,
+            }
+        ]
+        svc = ContentHashService(AsyncMock())
+        assert await svc._compute_hash_for(
+            without, exclude_ids=None
+        ) != await svc._compute_hash_for(with_visual, exclude_ids=None)
+
+    async def test_visual_content_order_sensitive(self) -> None:
+        """Frame order is temporally meaningful (NOT sorted, unlike concept
+        sets): reordering the visual refs must flip the hash.
+        """
+        ref_a = {
+            "position_ms": 0,
+            "description": "slide A",
+            "kind": "anchor",
+            "scene_id": 0,
+        }
+        ref_b = {
+            "position_ms": 5000,
+            "description": "slide B",
+            "kind": "diff",
+            "scene_id": 1,
+        }
+        forward = _make_segment(content="body")
+        reversed_ = _make_segment(content="body")
+        reversed_.main_concepts = list(forward.main_concepts or [])
+        reversed_.secondary_concepts = list(forward.secondary_concepts or [])
+        forward.visual_content = [ref_a, ref_b]
+        reversed_.visual_content = [ref_b, ref_a]
+        svc = ContentHashService(AsyncMock())
+        assert await svc._compute_hash_for(
+            forward, exclude_ids=None
+        ) != await svc._compute_hash_for(reversed_, exclude_ids=None)
 
 
 # ── DocumentSummary formula ───────────────────────────────────────

--- a/tests/unit/test_ingestion/test_ingestion_schemas.py
+++ b/tests/unit/test_ingestion/test_ingestion_schemas.py
@@ -31,7 +31,37 @@ from pydantic import ValidationError
 from course_supporter.ingestion.schemas import (
     DocumentSegmentDraft,
     DocumentSummaryDraft,
+    VisualSceneRef,
 )
+
+
+class TestVisualSceneRef:
+    """Validation contract for the visual-stream draft carrier (task 2.4.6)."""
+
+    def test_minimal_required_fields_with_defaults(self) -> None:
+        ref = VisualSceneRef(position_ms=4200, description="slide with for-loop")
+        assert ref.position_ms == 4200
+        assert ref.description == "slide with for-loop"
+        assert ref.kind == ""
+        assert ref.scene_id == 0
+
+    def test_all_fields_roundtrip(self) -> None:
+        ref = VisualSceneRef(
+            position_ms=0,
+            description="title slide",
+            kind="anchor",
+            scene_id=3,
+        )
+        assert ref.model_dump() == {
+            "position_ms": 0,
+            "description": "title slide",
+            "kind": "anchor",
+            "scene_id": 3,
+        }
+
+    def test_missing_position_ms_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            VisualSceneRef(description="no timestamp")  # type: ignore[call-arg]
 
 
 class TestDocumentSegmentDraft:
@@ -52,6 +82,21 @@ class TestDocumentSegmentDraft:
         assert draft.content is None
         assert draft.main_concepts == []
         assert draft.secondary_concepts == []
+        assert draft.visual_content is None
+
+    def test_visual_content_accepts_refs(self) -> None:
+        draft = DocumentSegmentDraft(
+            order=0,
+            start_pos=0,
+            end_pos=42,
+            description="Walks through the slide.",
+            visual_content=[
+                VisualSceneRef(position_ms=0, description="slide A", kind="anchor"),
+                VisualSceneRef(position_ms=9000, description="slide B", kind="diff"),
+            ],
+        )
+        assert draft.visual_content is not None
+        assert [r.position_ms for r in draft.visual_content] == [0, 9000]
 
     def test_concept_lists_preserved(self) -> None:
         draft = DocumentSegmentDraft(

--- a/tests/unit/test_ingestion/test_video_pipeline_skeleton.py
+++ b/tests/unit/test_ingestion/test_video_pipeline_skeleton.py
@@ -406,6 +406,157 @@ class TestMacroAndDetail:
         )
 
 
+_TRANSCRIPT = "alpha beta gamma delta epsilon zeta eta theta words here"
+
+
+def _video_doc_with_visuals(frames_ms: list[int]) -> SourceDocument:
+    """A video SourceDocument: one TRANSCRIPT chunk + N VISUAL_SCENE chunks.
+
+    Each visual chunk carries the B' metadata (``frame_position_ms`` /
+    ``kind`` / ``scene_id``) that Pass 2b reads to build the visual stream.
+    """
+    from course_supporter.models.source import ContentChunk
+
+    chunks = [ContentChunk(chunk_type=ChunkType.TRANSCRIPT, text=_TRANSCRIPT, index=0)]
+    for i, fp in enumerate(frames_ms):
+        chunks.append(
+            ContentChunk(
+                chunk_type=ChunkType.VISUAL_SCENE,
+                text=f"frame@{fp}ms",
+                index=i + 1,
+                metadata={"frame_position_ms": fp, "kind": "anchor", "scene_id": i},
+            )
+        )
+    return SourceDocument(
+        source_type=SourceType.VIDEO,
+        source_url="s3://bucket/lecture.mp4",
+        title="lecture.mp4",
+        chunks=chunks,
+    )
+
+
+def _summary_two_segments() -> DocumentSummaryDraft:
+    """Two contiguous segments with a temporal gap between them.
+
+    seg0 time-range [1.0s, 2.0s], seg1 [5.0s, 8.0s] -> the inter-segment
+    pause [2.0s, 5.0s] is exactly where a slide change tends to land.
+    Start-times for the partition: [1.0, 5.0].
+    """
+    half = len(_TRANSCRIPT) // 2
+    return DocumentSummaryDraft(
+        title="t",
+        description="d",
+        main_concepts=[],
+        secondary_concepts=[],
+        segments=[
+            DocumentSegmentDraft(
+                order=0,
+                start_pos=0,
+                end_pos=half,
+                description="d0",
+                start_time_sec=1.0,
+                end_time_sec=2.0,
+            ),
+            DocumentSegmentDraft(
+                order=1,
+                start_pos=half,
+                end_pos=len(_TRANSCRIPT),
+                description="d1",
+                start_time_sec=5.0,
+                end_time_sec=8.0,
+            ),
+        ],
+    )
+
+
+class TestStep6VisualPartition:
+    """Krok 6 start-time partition of VISUAL_SCENE chunks (task 2.4.6 §3)."""
+
+    async def test_partitions_frames_and_keeps_content_slice(self) -> None:
+        # 0ms: before seg0.start (1.0s) -> head clamp to seg0.
+        # 3000ms: in the inter-segment pause [2.0s, 5.0s] -> seg0 (PREVIOUS).
+        # 5000ms: exactly seg1.start -> seg1 (half-open).
+        # 9000ms: after the last word end (8.0s) -> seg1 (tail).
+        doc = _video_doc_with_visuals([0, 3000, 5000, 9000])
+        summary = _summary_two_segments()
+
+        sliced = await steps.step_6_pass2b_slice(doc, summary)
+
+        seg0, seg1 = sliced
+        # Content slice (unchanged transcript-only contract).
+        ref = doc.assemble_text()
+        assert seg0.content == ref[seg0.start_pos : seg0.end_pos]
+        assert seg1.content == ref[seg1.start_pos : seg1.end_pos]
+        # Visual partition.
+        assert seg0.visual_content is not None and seg1.visual_content is not None
+        assert [v.position_ms for v in seg0.visual_content] == [0, 3000]
+        assert [v.position_ms for v in seg1.visual_content] == [5000, 9000]
+
+    async def test_gap_frame_goes_to_previous_segment_not_dropped(self) -> None:
+        """The distinguishing test vs interval-membership: a frame in the
+        inter-segment pause (3.0s, outside both [1,2] and [5,8]) must be
+        ASSIGNED to the preceding segment, never dropped. A naive
+        ``start <= fp <= end`` filter would lose this slide-transition frame.
+        """
+        doc = _video_doc_with_visuals([3000])
+        summary = _summary_two_segments()
+
+        seg0, seg1 = await steps.step_6_pass2b_slice(doc, summary)
+
+        all_positions = [
+            v.position_ms for seg in (seg0, seg1) for v in (seg.visual_content or [])
+        ]
+        assert all_positions == [3000]  # not lost
+        assert seg0.visual_content and seg0.visual_content[0].position_ms == 3000
+        assert seg1.visual_content == []
+
+    async def test_ref_carries_metadata_and_temporal_order(self) -> None:
+        # Both frames land in seg0 (time-range catches < 5.0s); 3000 and 1500
+        # are given out of order on input to prove the partition sorts them.
+        doc = _video_doc_with_visuals([3000, 1500])
+        summary = _summary_two_segments()
+
+        seg0, _seg1 = await steps.step_6_pass2b_slice(doc, summary)
+
+        assert seg0.visual_content is not None
+        # Sorted into temporal order regardless of chunk input order.
+        assert [v.position_ms for v in seg0.visual_content] == [1500, 3000]
+        first = seg0.visual_content[0]
+        assert first.description == "frame@1500ms"
+        assert first.kind == "anchor"
+
+    async def test_no_visual_chunks_yields_empty_lists(self) -> None:
+        doc = _video_doc_with_visuals([])
+        summary = _summary_two_segments()
+
+        sliced = await steps.step_6_pass2b_slice(doc, summary)
+
+        assert all(s.visual_content == [] for s in sliced)
+        assert all(s.content for s in sliced)
+
+    async def test_step7_cleans_only_content_leaving_visual_untouched(self) -> None:
+        """2.4.7-readiness: the Pass 2c stub touches only ``content``; the
+        visual stream passes through unchanged (clean by construction, KD2d).
+        """
+        from course_supporter.ingestion.schemas import VisualSceneRef
+
+        visual = [VisualSceneRef(position_ms=0, description="slide", kind="anchor")]
+        draft = DocumentSegmentDraft(
+            order=0,
+            start_pos=0,
+            end_pos=5,
+            description="d",
+            content="raw transcript",
+            noisy=True,
+            visual_content=visual,
+        )
+
+        cleaned = await steps.step_7_pass2c_cleanup([draft])
+
+        assert cleaned[0].content == "[cleaned] raw transcript"
+        assert cleaned[0].visual_content == visual
+
+
 class TestVideoPipelineIsolation:
     """Acceptance #3/#8 — namespace has zero ``course_supporter.vd`` imports."""
 

--- a/tests/unit/test_ingestion_callback.py
+++ b/tests/unit/test_ingestion_callback.py
@@ -4,6 +4,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from structlog.testing import capture_logs
 
 from course_supporter.ingestion_callback import IngestionCallback
 
@@ -12,6 +13,9 @@ _ENTRY_REPO = (
     "course_supporter.storage.authored_document_repository.AuthoredDocumentRepository"
 )
 _JOB_REPO = "course_supporter.ingestion_callback.JobRepository"
+_SUMMARY_REPO = (
+    "course_supporter.storage.document_summary_repository.DocumentSummaryRepository"
+)
 
 
 def _mock_session_factory() -> MagicMock:
@@ -19,6 +23,12 @@ def _mock_session_factory() -> MagicMock:
     session = AsyncMock()
     session.commit = AsyncMock()
     session.rollback = AsyncMock()
+    # Orphan-Summary observer (task 2.4.6) runs the real
+    # DocumentSummaryRepository over this session: default to "no orphan
+    # summary" so failure-path tests that do not patch it stay clean.
+    _no_orphan_result = MagicMock()
+    _no_orphan_result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=_no_orphan_result)
 
     ctx_manager = AsyncMock()
     ctx_manager.__aenter__ = AsyncMock(return_value=session)
@@ -307,6 +317,71 @@ class TestOnFailureStage2Discrimination:
 
         mock_soft_delete.assert_not_awaited()
         entry_cls.return_value.fail_processing.assert_awaited_once()
+
+
+class TestOnFailureOrphanSummaryObserver:
+    """on_failure orphan-Summary observer (task 2.4.6, Q4 / DD-2.4-G).
+
+    Read-only: warns when a DocumentSummary was committed by Pass 2a and
+    survives a later process_detail failure. No commit-sequence change.
+    """
+
+    async def test_warns_when_committed_summary_exists(self) -> None:
+        callback, _ = _make_callback()
+        jid, mid, sid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        summary = MagicMock()
+        summary.id = sid
+
+        with (
+            patch(_JOB_REPO) as job_cls,
+            patch(_ENTRY_REPO) as entry_cls,
+            patch(_SUMMARY_REPO) as summary_cls,
+            capture_logs() as logs,
+        ):
+            _setup_job_mock(job_cls)
+            entry_cls.return_value.fail_processing = AsyncMock()
+            summary_cls.return_value.get_by_authored_document_id = AsyncMock(
+                return_value=summary
+            )
+            await callback.on_failure(
+                job_id=jid, material_id=mid, error_message="pass 2b blew up"
+            )
+
+        summary_cls.return_value.get_by_authored_document_id.assert_awaited_once_with(
+            mid
+        )
+        orphan_events = [
+            e for e in logs if e["event"] == "ingestion_orphan_summary_detected"
+        ]
+        assert len(orphan_events) == 1
+        assert orphan_events[0]["summary_id"] == str(sid)
+        assert orphan_events[0]["material_id"] == str(mid)
+        assert orphan_events[0]["error"] == "pass 2b blew up"
+
+    async def test_silent_when_no_committed_summary(self) -> None:
+        """Pre-Pass-2a failure (Stage 1/2, infra): no summary yet -> no warning."""
+        callback, _ = _make_callback()
+
+        with (
+            patch(_JOB_REPO) as job_cls,
+            patch(_ENTRY_REPO) as entry_cls,
+            patch(_SUMMARY_REPO) as summary_cls,
+            capture_logs() as logs,
+        ):
+            _setup_job_mock(job_cls)
+            entry_cls.return_value.fail_processing = AsyncMock()
+            summary_cls.return_value.get_by_authored_document_id = AsyncMock(
+                return_value=None
+            )
+            await callback.on_failure(
+                job_id=uuid.uuid4(),
+                material_id=uuid.uuid4(),
+                error_message="stage 1 rejected",
+            )
+
+        assert not [
+            e for e in logs if e["event"] == "ingestion_orphan_summary_detected"
+        ]
 
 
 class TestOnSuccessErrors:


### PR DESCRIPTION
## Task 2.4.6 — Pass 2b algorithmic slice + visual merge (Krok 6)

Krok 6 becomes real: a video segment now carries **two time-aligned streams** — `content` (transcript slice, unchanged) + `visual_content` (time-anchored Pass 1 frame descriptions). Zero-LLM, deterministic. Krok 7 (Pass 2c) stays a stub; the pipeline reaches `state=ready`. Implements `PHASE-2-4-task-6.md` v0.2 (ratified after the pre-flight critique).

### What's in it

- **Direction (c) — two-stream segment.** Separate fields (not interleave), mirroring the 2.4.5 `assemble_text`/`safety_text` split down to the segment level. Pass 2c (2.4.7) will clean only `content`; the visual stream is clean by construction (KD2d).
- **§3 START-TIME PARTITION (not interval-membership).** Visual chunk → segment `i` where `start_time_sec[i] <= fp < start_time_sec[i+1]` (half-open). Pass 2a sets `end_time` exclusive, so segments are time-disjoint and a slide change in the inter-segment pause would be **dropped** by a `[start,end]` filter. The partition assigns every frame to exactly one segment (gap → preceding; head clamps to seg 0; tail → last). Bisect mirrors the existing word-anchor bisect.
- **D1 — `content_hash` CONDITIONAL include.** `visual_content` joins the `DocumentSegment` hash formula **only when non-empty** (`if entity.visual_content:` — truthy, not `is not None`). Deliberate asymmetry vs concepts (baked into every historical hash): historical / non-video / visual-less rows stay **byte-identical** (zero perturbation), while a populated visual stream invalidates the Merkle chain. Frame order is significant (NOT sorted). Hard-gate test pins the byte-identity.
- **Persistence.** New not-null JSONB column `document_segments.visual_content` (`server_default '[]'`, mirrors `main_concepts` mechanics) + migration `phase24_segment_visual_content`. The visual stream is genuine authored content persisted nowhere else.
- **Q4 orphan-Summary observer.** Read-only `log.warning("ingestion_orphan_summary_detected")` in `IngestionCallback.on_failure` when a Pass-2a-committed `DocumentSummary` survives a later `process_detail` failure. Pre-existing cross-source_type window (Phase 2.1+); resolution deferred to DD-2.4-G/2.4.7. Orchestrator commit sequence untouched.
- New `VisualSceneRef` draft model (`position_ms` / `description` / `kind` / `scene_id`).

### Bonus fix — `test(2.4.2)`

`task 2.4.2` added the required `redis = ctx["redis"]` to the shared `arq_ingest_material` (audio/video processor factory), but three e2e/Stage-2 integration fixtures' `_build_ctx()` helpers were never updated → `KeyError: 'redis'`. Reds slipped through 2.4.2–2.4.5 because only 3 targeted `--run-db` tests ran; the full DB suite first ran here. Fixed test-only (mock `redis` in the three fixtures, symmetric with the existing router mocks); production `ctx["redis"]` stays a **required** lookup (redis is real infra for audio/video, not optional like `ctx.get("s3_client")`; arq auto-injects it). Verified pre-existing via worktree at parent `2aea303`.

### Gates

- ruff + `mypy --strict` (134) clean; `vd`-isolation 0.
- Non-db regression: **2149 passed** (+14 new).
- DB: alembic upgrade `phase22 → phase24` + `downgrade -1` + re-upgrade round-trip; column `visual_content | jsonb | NOT NULL | '[]'::jsonb`; `test_schema_sync` ✓; segment-repo visual round-trip ✓; content_hash persistence ✓.
- **Full `--run-db` suite: 2308 passed / 17 skipped / 0 failed.**

### Commits
- `task(2.4.6): Pass 2b algorithmic slice + visual merge`
- `test(2.4.2): supply ctx['redis'] in e2e/stage2 fixtures`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
