### PR TITLE
task(2.4.8) B1: re-accept htm + markdown in authored whitelist

### DIFF
--- a/src/course_supporter/security/file_type.py
+++ b/src/course_supporter/security/file_type.py
@@ -67,6 +67,7 @@ _EXTENSION_TO_MIME_FAMILIES: dict[str, tuple[str, ...]] = {
     "pdf": ("application/pdf",),
     "txt": ("text/",),
     "md": ("text/",),
+    "markdown": ("text/",),
     "html": ("text/",),
     "htm": ("text/",),
     "csv": ("text/", "application/csv"),

--- a/src/course_supporter/security/policies.py
+++ b/src/course_supporter/security/policies.py
@@ -119,7 +119,7 @@ AUTHORED_POLICY: Final[ContextPolicy] = ContextPolicy(
             "m4a",
             "ogg",
             "flac",
-            # documents (7)
+            # documents (9)
             "pdf",
             "pptx",
             "ppt",
@@ -127,6 +127,17 @@ AUTHORED_POLICY: Final[ContextPolicy] = ContextPolicy(
             "docx",
             "txt",
             "html",
+            # htm == html, markdown == md — identical MIME (text/) and the same
+            # alias-aware TextProcessor handler (text.py {.md,.markdown} /
+            # {.html,.htm}). Re-added in task 2.4.8 B1, deliberately reversing
+            # the Phase 0.6 "one canonical extension per MIME" contraction
+            # (Phase 1.2 dropped both as legacy aliases, see
+            # phase-1-2/POST-MERGE-NOTES.md §1): the service ingests legacy
+            # course material too, so fewer upload rejections is preferred over
+            # the canonical-alias hygiene. _EXTENSION_TO_MIME_FAMILIES carries
+            # both so the policy/MIME consistency gate stays green.
+            "htm",
+            "markdown",
         }
     ),
     max_file_size_bytes=100 * 1024 * 1024,

--- a/tests/integration/test_authored_upload_validation.py
+++ b/tests/integration/test_authored_upload_validation.py
@@ -6,7 +6,10 @@ with canonical ``security/run_stage1`` invocation against
 authored uploads, with 8 net behavioral changes (the "ratified whitelist
 drift" — see ``phases/phase-1-2/POST-MERGE-NOTES.md``):
 
-* 2 contraction (was accepted, now rejected): ``htm``, ``markdown``.
+* 2 contraction (was accepted, now rejected) — **reversed in task 2.4.8 B1**,
+  re-accepted as legacy aliases (same MIME / TextProcessor handler as
+  ``html`` / ``md``; the service ingests legacy course material): ``htm``,
+  ``markdown``.
 * 6 expansion (was rejected, now accepted): ``flac``, ``m4a``, ``mov``,
   ``mp3``, ``ogg``, ``wav``.
 
@@ -63,9 +66,12 @@ _STUB_TENANT = TenantContext(
 #   schema body.
 # * ``accepted`` — endpoint returns 200 with ``PresignedUrlResponse``.
 _DRIFT_CASES: list[tuple[str, str, str]] = [
-    # 2 contraction — was accepted (hand-rolled), now rejected (policy):
-    ("htm", "rejected", "drift-rejection-htm"),
-    ("markdown", "rejected", "drift-rejection-markdown"),
+    # Phase 1.2 contracted htm / markdown as legacy aliases ("one canonical
+    # extension per MIME"); task 2.4.8 B1 reversed that — both are accepted
+    # again (identical MIME / alias-aware TextProcessor handler as html / md;
+    # the service ingests legacy course material → fewer upload rejections).
+    ("htm", "accepted", "reaccept-2-4-8-htm"),
+    ("markdown", "accepted", "reaccept-2-4-8-markdown"),
     # 6 expansion — was rejected (hand-rolled), now accepted (policy):
     ("flac", "accepted", "drift-acceptance-flac"),
     ("m4a", "accepted", "drift-acceptance-m4a"),

--- a/tests/unit/security/test_policies.py
+++ b/tests/unit/security/test_policies.py
@@ -39,9 +39,17 @@ class TestAuthoredPolicy:
         )
 
     def test_extensions_include_documents(self) -> None:
-        assert {"pdf", "pptx", "ppt", "md", "docx", "txt", "html"} <= (
-            AUTHORED_POLICY.allowed_extensions
-        )
+        assert {
+            "pdf",
+            "pptx",
+            "ppt",
+            "md",
+            "markdown",
+            "docx",
+            "txt",
+            "html",
+            "htm",
+        } <= AUTHORED_POLICY.allowed_extensions
 
     def test_no_archive_extensions(self) -> None:
         # Authored context does not accept archive uploads.


### PR DESCRIPTION
## Task 2.4.8 — B1 (backend, first of two PRs for #443)

Re-accept `htm` + `markdown` in `AUTHORED_POLICY.allowed_extensions` (17 → 19), deliberately reversing the Phase 0.6 *"one canonical extension per MIME"* contraction.

### Why (probe-grounded)
`htm`-absence was **not an oversight** — Phase 1.2 C3 ratified dropping `htm` + `markdown` as legacy-alias cleanup (`phases/phase-1-2/POST-MERGE-NOTES.md` §1: *"`.htm` legacy alias dropped per Phase 0.6 sealed-library design"*; locked by `test_authored_upload_validation.py`). The impl-side probe surfaced this conflict (the 2.4.8 vision-probe had read only `test_policies.py`).

Technical assessment: `htm ≡ html`, `markdown ≡ md` — identical MIME (`text/`), identical alias-aware `TextProcessor` handler (`text.py:72` `{.md,.markdown}`, `:76` `{.html,.htm}`), identical content signature. Re-accepting them adds **zero** technical/security surface. **Operator decision (2026-05-24):** the service ingests legacy course material → fewer upload rejections is preferred over canonical-alias hygiene; re-add **both** symmetrically (they were contracted together).

### Changes
- `policies.py` — `AUTHORED_POLICY.allowed_extensions` += `htm`, `markdown`.
- `file_type.py` — `_EXTENSION_TO_MIME_FAMILIES` += `"markdown": ("text/",)` (htm already present). **Required** so the policy↔MIME consistency gate stays green (`allowed_extensions ⊆ MIME map`, `test_policies.py:205`).
- `test_policies.py` — `test_extensions_include_documents` asserts both.
- `test_authored_upload_validation.py` — `htm` + `markdown` flip from the Phase 1.2 "contraction" (rejected) cases to **accepted**; header documents the 2.4.8 reversal.

### Gates
- ruff + ruff-format + mypy --strict clean.
- `test_policies.py` 31 passed (consistency gate green with markdown in the MIME map).
- `test_authored_upload_validation.py --run-db` 10 passed (htm + markdown now accepted).
- full `--run-db` **2318 passed / 0 failed**.

### Scope / sequencing
Backend-only. Does **not** `Closes #443` — issue #443 spans backend + UI; closes after the UI PR (U1-U3, `course-supporter-ui`) merges. Downstream verified clean (`TextProcessor` alias-aware; `homework.py`/`archive.py` ext-lists are separate HOMEWORK scope, untouched). Ref #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)