### PR TITLE
task(2.4.10): DEBUG instrumentation for video pipeline (RUN_SMOKE precondition)

### DIFF
--- a/src/course_supporter/ingestion/video_pipeline/processor.py
+++ b/src/course_supporter/ingestion/video_pipeline/processor.py
@@ -37,8 +37,11 @@ the frame descriptions), so the vision ladder cannot arrive via the
 from __future__ import annotations
 
 import tempfile
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import structlog
 
 from course_supporter.ingestion.base import MaterialProcessor, ProcessingError
 from course_supporter.ingestion.video_pipeline import steps
@@ -70,6 +73,8 @@ if TYPE_CHECKING:
     from course_supporter.stt.router import STTRouter
 
 _STT_RESULT_TTL_SEC = 3600
+
+logger = structlog.get_logger()
 
 
 class VideoProcessor(MaterialProcessor):
@@ -115,26 +120,69 @@ class VideoProcessor(MaterialProcessor):
                 "the ARQ task entry must set it before invocation."
             )
 
+        raw_start = time.perf_counter()
         with tempfile.TemporaryDirectory(prefix="video_ingest_") as tmp_dir:
             tmp = Path(tmp_dir)
+
+            step_start = time.perf_counter()
             video_path, file_metadata = await steps.step_1_ingest(source, tmp=tmp)
+            logger.debug(
+                "video.step_1_ingest.done",
+                elapsed_ms=int((time.perf_counter() - step_start) * 1000),
+                duration_ms=file_metadata.duration_ms,
+            )
+
+            step_start = time.perf_counter()
             stt = await steps.step_2_stt(
                 video_path,
                 file_metadata,
                 stt_router=self._stt_router,
                 tmp=tmp,
             )
+            logger.debug(
+                "video.step_2_stt.done",
+                elapsed_ms=int((time.perf_counter() - step_start) * 1000),
+                words=len(stt.words),
+                pauses=len(stt.pauses),
+                language=stt.language,
+                detected_language=stt.detected_language,
+            )
+
             await self._store_stt_result(job_id, stt)
+
+            step_start = time.perf_counter()
             detection_result = await steps.step_3_detection(
                 video_path, file_metadata, tmp=tmp
             )
+            logger.debug(
+                "video.step_3_detection.done",
+                elapsed_ms=int((time.perf_counter() - step_start) * 1000),
+                scenes=len(detection_result.scenes),
+                pip=detection_result.pip_mask is not None,
+            )
+
+            step_start = time.perf_counter()
             frame_descriptions = await steps.step_4_pass1_vision(
                 detection_result, file_metadata, stage_router=self._stage_router
             )
+            logger.debug(
+                "video.step_4_pass1_vision.done",
+                elapsed_ms=int((time.perf_counter() - step_start) * 1000),
+                frame_descriptions=len(frame_descriptions),
+            )
+
             doc = self._assemble_source_document(source, stt, frame_descriptions)
 
         if stt.detected_language:
             doc.metadata["detected_language"] = stt.detected_language
+
+        logger.debug(
+            "video.process_raw.done",
+            elapsed_ms=int((time.perf_counter() - raw_start) * 1000),
+            transcript_words=len(stt.words),
+            visual_scenes=len(frame_descriptions),
+            detected_language=stt.detected_language,
+        )
         return doc
 
     async def _store_stt_result(self, job_id: uuid.UUID, stt: SttResult) -> None:
@@ -235,9 +283,16 @@ class VideoProcessor(MaterialProcessor):
         orchestrator (method-arg, as audio / presentation), distinct from the
         ``self._stage_router`` the Krok 4 vision Pass 1 uses.
         """
-        return await steps.step_5_pass2a_mapping(
+        macro_start = time.perf_counter()
+        summary_draft = await steps.step_5_pass2a_mapping(
             doc, redis=self._redis, stage_router=router
         )
+        logger.debug(
+            "video.process_macro.done",
+            elapsed_ms=int((time.perf_counter() - macro_start) * 1000),
+            segments=len(summary_draft.segments),
+        )
+        return summary_draft
 
     async def process_detail(
         self,
@@ -259,7 +314,14 @@ class VideoProcessor(MaterialProcessor):
         orchestrator/ABC change. The ``router`` kwarg is kept for ABC symmetry
         with AudioProcessor and is otherwise unused here.
         """
+        detail_start = time.perf_counter()
         sliced = await steps.step_6_pass2b_slice(doc, summary_draft)
-        return await steps.step_7_pass2c_cleanup(
+        result = await steps.step_7_pass2c_cleanup(
             sliced, stage_router=self._stage_router
         )
+        logger.debug(
+            "video.process_detail.done",
+            elapsed_ms=int((time.perf_counter() - detail_start) * 1000),
+            segments=len(result),
+        )
+        return result

--- a/src/course_supporter/ingestion/video_pipeline/steps.py
+++ b/src/course_supporter/ingestion/video_pipeline/steps.py
@@ -367,6 +367,15 @@ async def step_5_pass2a_mapping(
         all_secondary.update(seg.secondary_concepts)
     all_secondary -= all_main
 
+    logger.debug(
+        "video.pass2a.done",
+        job_id=str(job_id),
+        segments=len(segment_drafts),
+        main_concepts=len(all_main),
+        secondary_concepts=len(all_secondary),
+        words=total_word_count,
+        noisy=sum(1 for seg in result.segments if seg.noisy),
+    )
     return DocumentSummaryDraft(
         title=result.title or "",
         description=result.description,
@@ -459,6 +468,13 @@ async def step_6_pass2b_slice(
         if draft.content is None:
             update["content"] = reference[draft.start_pos : draft.end_pos]
         sliced.append(draft.model_copy(update=update))
+
+    logger.debug(
+        "video.pass2b.done",
+        segments=len(sliced),
+        visual_refs=sum(len(s.visual_content or []) for s in sliced),
+        segments_with_visuals=sum(bool(s.visual_content) for s in sliced),
+    )
     return sliced
 
 
@@ -539,6 +555,12 @@ async def step_7_pass2c_cleanup(
     (R1) up through ``process_detail``.
     """
     noisy_indices = [i for i, d in enumerate(segments) if d.noisy and d.content]
+    logger.debug(
+        "video.pass2c.selected",
+        noisy_orders=[segments[i].order for i in noisy_indices],
+        count=len(noisy_indices),
+        total_segments=len(segments),
+    )
     if not noisy_indices:
         return segments
 
@@ -548,4 +570,5 @@ async def step_7_pass2c_cleanup(
     result = list(segments)
     for i, cleaned in zip(noisy_indices, cleaned_contents, strict=True):
         result[i] = result[i].model_copy(update={"content": cleaned})
+    logger.debug("video.pass2c.done", denoised=len(noisy_indices))
     return result


### PR DESCRIPTION
## Context

RUN_SMOKE GATE #0 precondition. A pre-flight probe of the video pipeline found the orchestrator (`video_pipeline/processor.py`) had **zero logging** and there was **no per-stage timing anywhere**, so a video-ingest failure during the (billable) RUN_SMOKE could not be reconstructed post-factum without re-running. This adds a structured DEBUG trail — **logging-only, no behavior change**.

## What changed

**`processor.py`** (was zero logs): per-step `perf_counter` timing across `step_1..step_4` in `process_raw` (+ a `process_raw.done` rollup), plus `process_macro.done` / `process_detail.done`. The orchestrator is the only place that brackets the step calls, so it owns the missing timing axis.

**`steps.py`**: done-summaries at the decision site for the three steps that lacked one (`detection` + Pass 1 `vision` already log their own summaries):
- `video.pass2a.done` — segments / concepts / words / noisy count
- `video.pass2b.done` — segments / visual refs partitioned
- `video.pass2c.selected` + `.done` — **which segment `order`s were flagged noisy and denoised**. This closes the runbook's A.4 "noisy-precision" check, since `noisy` is a draft-only field never persisted to `document_segments`.

## Design notes

- Level is **DEBUG** (RUN_SMOKE runs at DEBUG; quiet under prod INFO).
- `job_id` auto-correlates per material via the structlog ContextVar already bound at ARQ task entry — not passed explicitly except where already in scope.
- LLM per-call model / tokens / cost stays in the **`ExternalServiceCall`** table (the durable trail) — deliberately **not** duplicated into logs.
- Out of scope: `detection.py` / `vision.py` (already have summaries), per-frame dedup logging (chatty, redundant with ESC), `audio.py`.

## Gates

- `ruff check` + `ruff format` clean
- `mypy --strict` — 125 files, 0 issues
- video unit/integration — 39 passed
- full `--run-db` — **2115 passed / 0 failed** (= 2.4.9A baseline; logging-only → zero test delta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)