### PR TITLE
task(2.4.11) HOTFIX: provider-level JSON normalization (gemini markdown-fence)

### DIFF
--- a/src/course_supporter/ingestion/audio.py
+++ b/src/course_supporter/ingestion/audio.py
@@ -422,6 +422,7 @@ class AudioProcessor(MaterialProcessor):
         router_result = await router.execute_for_stage(
             _PASS_2A_STAGE_NAME,
             response_validator=_audio_pass_2a_validator,
+            expects_json=True,
             words_count=total_word_count,
             words_json=words_json,
         )

--- a/src/course_supporter/ingestion/presentation.py
+++ b/src/course_supporter/ingestion/presentation.py
@@ -475,6 +475,7 @@ class PresentationProcessor(MaterialProcessor):
         router_result = await router.execute_for_stage(
             _PASS_2A_STAGE_NAME,
             response_validator=_validator,
+            expects_json=True,
             file_title=doc.title,
             n_slides=n_slides,
             slides_json=slides_json,

--- a/src/course_supporter/ingestion/text.py
+++ b/src/course_supporter/ingestion/text.py
@@ -315,6 +315,7 @@ class TextProcessor(MaterialProcessor):
         result = await router.execute_for_stage(
             "pass_2a_mapping",
             response_validator=_coverage_validator,
+            expects_json=True,
             text=text,
         )
         # Validator stored the parsed draft on the winning attempt;

--- a/src/course_supporter/ingestion/video_pipeline/steps.py
+++ b/src/course_supporter/ingestion/video_pipeline/steps.py
@@ -337,6 +337,7 @@ async def step_5_pass2a_mapping(
     await stage_router.execute_for_stage(
         _PASS_2A_STAGE_NAME,
         response_validator=_validator,
+        expects_json=True,
         words_count=total_word_count,
         words_json=words_json,
         visuals=visuals,

--- a/src/course_supporter/ingestion/web.py
+++ b/src/course_supporter/ingestion/web.py
@@ -190,6 +190,7 @@ class WebProcessor(MaterialProcessor):
         result = await router.execute_for_stage(
             "pass_2a_mapping",
             response_validator=_coverage_validator,
+            expects_json=True,
             text=text,
         )
         draft = parsed["draft"]

--- a/src/course_supporter/llm/json_extract.py
+++ b/src/course_supporter/llm/json_extract.py
@@ -1,0 +1,38 @@
+"""Shared JSON-output normalization for LLM provider responses.
+
+Some models (notably Gemini in free-text mode) wrap an otherwise valid
+JSON object in a markdown ```json ... ``` fence. The ingestion StageRouter
+path parses provider output as JSON directly, so an un-stripped fence makes
+``model_validate_json`` fail at the leading backtick ("expected value at
+line 1 column 1").
+
+This module is the single home for that normalization (previously duplicated
+in ``providers/anthropic.py`` and ``providers/dashscope.py``). Providers call
+:func:`strip_markdown_json` on their output when the caller declares it
+expects JSON (``LLMRequest.expects_json``), so downstream validators always
+receive bare JSON regardless of which provider answered.
+"""
+
+from __future__ import annotations
+
+import re
+
+_MD_JSON_RE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?\s*```", re.DOTALL)
+
+
+def strip_markdown_json(text: str) -> str:
+    """Return the inner JSON of a markdown fence, or the stripped text.
+
+    If ``text`` contains a ```` ```json ... ``` ```` (or bare ```` ``` ```` )
+    fenced block, return its inner content; otherwise return ``text`` with
+    surrounding whitespace removed. A no-op (modulo whitespace) for bare
+    JSON, so it is safe to apply unconditionally to any JSON-expecting
+    provider output.
+
+    >>> strip_markdown_json('```json\\n{"a": 1}\\n```')
+    '{"a": 1}'
+    >>> strip_markdown_json('{"a": 1}')
+    '{"a": 1}'
+    """
+    match = _MD_JSON_RE.search(text)
+    return match.group(1).strip() if match else text.strip()

--- a/src/course_supporter/llm/providers/anthropic.py
+++ b/src/course_supporter/llm/providers/anthropic.py
@@ -10,6 +10,7 @@ import anthropic
 from pydantic import BaseModel
 
 from course_supporter.llm.error_categories import ErrorCategory
+from course_supporter.llm.json_extract import strip_markdown_json
 from course_supporter.llm.providers.base import LLMProvider
 from course_supporter.llm.schemas import LLMRequest, LLMResponse
 
@@ -92,8 +93,11 @@ class AnthropicProvider(LLMProvider):
         with self._measure_latency() as timer:
             response = await client.messages.create(**kwargs)
 
+        content = response.content[0].text if response.content else ""
+        if request.expects_json:
+            content = strip_markdown_json(content)
         return LLMResponse(
-            content=response.content[0].text if response.content else "",
+            content=content,
             provider=self.provider_name,
             model_id=model,
             tokens_in=response.usage.input_tokens,
@@ -119,15 +123,6 @@ class AnthropicProvider(LLMProvider):
             update={"system_prompt": structured_system}
         )
         llm_response = await self.complete(modified_request)
-        raw = _strip_markdown_json(llm_response.content)
+        raw = strip_markdown_json(llm_response.content)
         parsed = self._parse_structured(raw, response_schema)
         return parsed, llm_response
-
-
-_MD_JSON_RE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?\s*```", re.DOTALL)
-
-
-def _strip_markdown_json(text: str) -> str:
-    """Strip markdown code fences from JSON response if present."""
-    match = _MD_JSON_RE.search(text)
-    return match.group(1).strip() if match else text.strip()

--- a/src/course_supporter/llm/providers/dashscope.py
+++ b/src/course_supporter/llm/providers/dashscope.py
@@ -44,6 +44,7 @@ from dashscope.common.error import (
 from pydantic import BaseModel
 
 from course_supporter.llm.error_categories import ErrorCategory
+from course_supporter.llm.json_extract import strip_markdown_json
 from course_supporter.llm.providers.base import LLMProvider
 from course_supporter.llm.schemas import LLMRequest, LLMResponse
 
@@ -78,8 +79,6 @@ _IMAGE_MIME_SIGNATURES: tuple[tuple[bytes, str], ...] = (
     (b"GIF89a", "image/gif"),
 )
 
-_MD_JSON_RE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?\s*```", re.DOTALL)
-
 
 def _detect_image_mime(data: bytes) -> str:
     """Detect image MIME type from magic bytes.
@@ -100,12 +99,6 @@ def _detect_image_mime(data: bytes) -> str:
     if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
         return "image/webp"
     return "application/octet-stream"
-
-
-def _strip_markdown_json(text: str) -> str:
-    """Strip markdown code fences from JSON response if present."""
-    match = _MD_JSON_RE.search(text)
-    return match.group(1).strip() if match else text.strip()
 
 
 class DashScopeResponseError(Exception):
@@ -301,6 +294,8 @@ class DashScopeProvider(LLMProvider):
             )
 
         content_text = self._extract_text(response)
+        if request.expects_json:
+            content_text = strip_markdown_json(content_text)
         usage = response.usage
         tokens_in = usage.get("input_tokens") if usage else None
         tokens_out = usage.get("output_tokens") if usage else None
@@ -339,6 +334,6 @@ class DashScopeProvider(LLMProvider):
             update={"system_prompt": structured_system}
         )
         llm_response = await self.complete(modified_request)
-        raw = _strip_markdown_json(llm_response.content)
+        raw = strip_markdown_json(llm_response.content)
         parsed = self._parse_structured(raw, response_schema)
         return parsed, llm_response

--- a/src/course_supporter/llm/providers/gemini.py
+++ b/src/course_supporter/llm/providers/gemini.py
@@ -11,6 +11,7 @@ from google.genai import types
 from pydantic import BaseModel
 
 from course_supporter.llm.error_categories import ErrorCategory
+from course_supporter.llm.json_extract import strip_markdown_json
 from course_supporter.llm.providers.base import LLMProvider
 from course_supporter.llm.schemas import LLMRequest, LLMResponse
 
@@ -158,13 +159,22 @@ class GeminiProvider(LLMProvider):
         return super().classify_error(exc)
 
     async def complete(self, request: LLMRequest) -> LLMResponse:
-        """Generate text completion via Gemini."""
+        """Generate text completion via Gemini.
+
+        When ``request.expects_json`` is set, native JSON mode
+        (``response_mime_type="application/json"``) is requested so the
+        model returns bare JSON instead of a markdown-fenced block; the
+        output is also fence-stripped defensively.
+        """
         model = request.model or self._default_model
-        config = types.GenerateContentConfig(
-            temperature=request.temperature,
-            max_output_tokens=request.max_tokens,
-            system_instruction=request.system_prompt,
-        )
+        config_kwargs: dict[str, Any] = {
+            "temperature": request.temperature,
+            "max_output_tokens": request.max_tokens,
+            "system_instruction": request.system_prompt,
+        }
+        if request.expects_json:
+            config_kwargs["response_mime_type"] = "application/json"
+        config = types.GenerateContentConfig(**config_kwargs)
 
         contents = _build_contents(request)
 
@@ -176,9 +186,12 @@ class GeminiProvider(LLMProvider):
                 config=config,
             )
 
+        content = response.text or ""
+        if request.expects_json:
+            content = strip_markdown_json(content)
         usage = response.usage_metadata
         return LLMResponse(
-            content=response.text or "",
+            content=content,
             provider=self.provider_name,
             model_id=model,
             tokens_in=usage.prompt_token_count if usage else None,

--- a/src/course_supporter/llm/providers/openai_compat.py
+++ b/src/course_supporter/llm/providers/openai_compat.py
@@ -21,6 +21,7 @@ from openai.types.chat import ChatCompletionMessageParam
 from pydantic import BaseModel
 
 from course_supporter.llm.error_categories import ErrorCategory
+from course_supporter.llm.json_extract import strip_markdown_json
 from course_supporter.llm.providers.base import LLMProvider, StructuredOutputError
 from course_supporter.llm.schemas import LLMRequest, LLMResponse
 
@@ -196,8 +197,11 @@ class OpenAICompatProvider(LLMProvider):
 
         choice = response.choices[0]
         usage = response.usage
+        content = choice.message.content or ""
+        if request.expects_json:
+            content = strip_markdown_json(content)
         return LLMResponse(
-            content=choice.message.content or "",
+            content=content,
             provider=self.provider_name,
             model_id=model,
             tokens_in=usage.prompt_tokens if usage else None,

--- a/src/course_supporter/llm/schemas.py
+++ b/src/course_supporter/llm/schemas.py
@@ -21,6 +21,11 @@ class LLMRequest(BaseModel):
     # Qwen3-VL via DashScope). Providers that recognise the field propagate
     # it verbatim; others ignore it.
     reasoning: dict[str, Any] | None = None
+    # Caller declares the response must be JSON. Providers honour it by
+    # returning bare JSON: native JSON mode where available (Gemini
+    # ``response_mime_type``), and/or stripping markdown fences. Default
+    # ``False`` leaves plain-text stages (e.g. Pass 2c denoise) untouched.
+    expects_json: bool = False
 
 
 class LLMResponse(BaseModel):

--- a/src/course_supporter/llm/stage_router.py
+++ b/src/course_supporter/llm/stage_router.py
@@ -129,6 +129,7 @@ class StageRouter:
         *,
         response_validator: Callable[[str], None] | None = None,
         contents: list[bytes] | None = None,
+        expects_json: bool = False,
         **render_context: Any,
     ) -> StageResult:
         """Execute the LLM call ladder for a named stage.
@@ -153,6 +154,11 @@ class StageRouter:
                 multimodal input (e.g. DashScope, Gemini) encode each
                 ``bytes`` element as an inline image; text-only
                 providers ignore the field.
+            expects_json: Declare that the stage output must be JSON.
+                Propagated to :class:`LLMRequest.expects_json` so each
+                provider returns bare JSON (native JSON mode and/or
+                markdown-fence stripping). Leave ``False`` for
+                plain-text stages (e.g. Pass 2c denoise).
             **render_context: Variables for the prompt template's
                 Jinja2 placeholders.
 
@@ -205,7 +211,9 @@ class StageRouter:
                 attempts.append((entry.provider, entry.model, "provider disabled"))
                 continue
 
-            request = self._build_request(prompt, entry, stage_name, contents=contents)
+            request = self._build_request(
+                prompt, entry, stage_name, contents=contents, expects_json=expects_json
+            )
             response, used_count, reason = await self._attempt_entry(
                 provider, entry, request, stage_name, response_validator
             )
@@ -232,6 +240,7 @@ class StageRouter:
         stage_name: str,
         *,
         contents: list[bytes] | None = None,
+        expects_json: bool = False,
     ) -> LLMRequest:
         """Map StagePrompt + LadderEntry to the legacy LLMRequest.
 
@@ -250,6 +259,7 @@ class StageRouter:
             contents=contents,
             reasoning=entry.reasoning,
             max_tokens=entry.max_output_tokens,
+            expects_json=expects_json,
         )
 
     async def _attempt_entry(

--- a/src/course_supporter/security/stage2.py
+++ b/src/course_supporter/security/stage2.py
@@ -166,6 +166,7 @@ async def run_stage2_safety_check(
     )
     result = await router.execute_for_stage(
         stage_name,
+        expects_json=True,
         **render_context,
     )
 

--- a/tests/unit/test_llm/test_json_extract.py
+++ b/tests/unit/test_llm/test_json_extract.py
@@ -1,0 +1,118 @@
+"""Shared JSON-output normalization + per-provider ``expects_json`` honor.
+
+Covers the hotfix (task 2.4.11): the shared ``strip_markdown_json`` helper
+and each provider's contract that a JSON-expecting call returns bare JSON
+(native JSON mode and/or fence stripping), while plain-text calls pass
+through untouched.
+"""
+
+from __future__ import annotations
+
+import itertools
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from course_supporter.llm.json_extract import strip_markdown_json
+from course_supporter.llm.schemas import LLMRequest
+
+_FENCED = '```json\n{"a": 1}\n```'
+_BARE = '{"a": 1}'
+
+
+class TestStripMarkdownJson:
+    """Pure-function behaviour of the shared helper."""
+
+    def test_fenced_json(self) -> None:
+        assert strip_markdown_json(_FENCED) == _BARE
+
+    def test_fence_without_lang_tag(self) -> None:
+        assert strip_markdown_json('```\n{"a": 1}\n```') == _BARE
+
+    def test_bare_json_unchanged(self) -> None:
+        assert strip_markdown_json(_BARE) == _BARE
+
+    def test_surrounding_whitespace_stripped(self) -> None:
+        assert strip_markdown_json('  {"a": 1}\n') == _BARE
+
+    def test_multiline_fenced_json_inner_preserved(self) -> None:
+        text = '```json\n{\n  "a": 1,\n  "b": 2\n}\n```'
+        assert strip_markdown_json(text) == '{\n  "a": 1,\n  "b": 2\n}'
+
+    def test_plain_text_without_fence_is_noop(self) -> None:
+        # A Pass 2c denoised transcript (plain text) must pass through
+        # untouched — the helper is only ever called for JSON stages, but
+        # this guards the no-op contract regardless.
+        text = "Привіт, це чистий транскрипт без JSON."
+        assert strip_markdown_json(text) == text
+
+
+async def test_gemini_honors_expects_json() -> None:
+    """Gemini: native JSON mode + fence strip when ``expects_json``; raw otherwise."""
+    from course_supporter.llm.providers.gemini import GeminiProvider
+
+    with patch("course_supporter.llm.providers.gemini.genai.Client"):
+        prov = GeminiProvider(api_keys=("k",), default_model="gemini-2.5-flash")
+
+    resp = MagicMock()
+    resp.text = _FENCED
+    resp.usage_metadata = MagicMock(prompt_token_count=10, candidates_token_count=5)
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=resp)
+    prov._client_cycle = itertools.cycle([mock_client])
+
+    out = await prov.complete(
+        LLMRequest(prompt="x", model="gemini-2.5-flash", expects_json=True)
+    )
+    assert out.content == _BARE
+    cfg = mock_client.aio.models.generate_content.call_args.kwargs["config"]
+    assert cfg.response_mime_type == "application/json"
+
+    out_raw = await prov.complete(
+        LLMRequest(prompt="x", model="gemini-2.5-flash", expects_json=False)
+    )
+    assert out_raw.content == _FENCED
+    cfg_raw = mock_client.aio.models.generate_content.call_args.kwargs["config"]
+    assert cfg_raw.response_mime_type is None
+
+
+async def test_openai_compat_honors_expects_json() -> None:
+    """OpenAI-compat (DeepSeek/Mistral): fence strip when ``expects_json``."""
+    from course_supporter.llm.providers.openai_compat import OpenAICompatProvider
+
+    with patch("course_supporter.llm.providers.openai_compat.openai.AsyncOpenAI"):
+        prov = OpenAICompatProvider(
+            api_keys=("k",), default_model="deepseek-chat", provider_name="deepseek"
+        )
+
+    resp = MagicMock()
+    resp.choices = [MagicMock(message=MagicMock(content=_FENCED))]
+    resp.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=resp)
+    prov._client_cycle = itertools.cycle([mock_client])
+
+    out = await prov.complete(LLMRequest(prompt="x", expects_json=True))
+    assert out.content == _BARE
+
+    out_raw = await prov.complete(LLMRequest(prompt="x", expects_json=False))
+    assert out_raw.content == _FENCED
+
+
+async def test_anthropic_honors_expects_json() -> None:
+    """Anthropic: fence strip when ``expects_json``."""
+    from course_supporter.llm.providers.anthropic import AnthropicProvider
+
+    with patch("course_supporter.llm.providers.anthropic.anthropic.AsyncAnthropic"):
+        prov = AnthropicProvider(api_keys=("k",), default_model="claude-x")
+
+    resp = MagicMock()
+    resp.content = [MagicMock(text=_FENCED)]
+    resp.usage = MagicMock(input_tokens=10, output_tokens=5)
+    mock_client = MagicMock()
+    mock_client.messages.create = AsyncMock(return_value=resp)
+    prov._client_cycle = itertools.cycle([mock_client])
+
+    out = await prov.complete(LLMRequest(prompt="x", expects_json=True))
+    assert out.content == _BARE
+
+    out_raw = await prov.complete(LLMRequest(prompt="x", expects_json=False))
+    assert out_raw.content == _FENCED

--- a/tests/unit/test_llm/test_providers_dashscope.py
+++ b/tests/unit/test_llm/test_providers_dashscope.py
@@ -31,7 +31,6 @@ from course_supporter.llm.providers.dashscope import (
     DashScopeProvider,
     DashScopeResponseError,
     _detect_image_mime,
-    _strip_markdown_json,
 )
 from course_supporter.llm.schemas import LLMRequest
 
@@ -99,18 +98,6 @@ class TestPureHelpers:
         # ``application/octet-stream`` so the SDK surfaces a clear error
         # rather than silently mislabeling bytes.
         assert _detect_image_mime(b"\x00garbage bytes") == "application/octet-stream"
-
-    def test_strip_markdown_json_fenced(self) -> None:
-        text = '```json\n{"status": "ok"}\n```'
-        assert _strip_markdown_json(text) == '{"status": "ok"}'
-
-    def test_strip_markdown_json_no_fence(self) -> None:
-        text = '{"status": "ok"}'
-        assert _strip_markdown_json(text) == '{"status": "ok"}'
-
-    def test_strip_markdown_json_fence_without_lang_tag(self) -> None:
-        text = '```\n{"status": "ok"}\n```'
-        assert _strip_markdown_json(text) == '{"status": "ok"}'
 
 
 # ── __init__ side effects ───────────────────────────────────────
@@ -381,6 +368,32 @@ class TestCompleteAsync:
         assert response.tokens_out == 3
         assert response.provider == "dashscope"
         assert response.model_id == "qwen3-vl-32b-instruct"
+
+    @pytest.mark.asyncio
+    async def test_expects_json_strips_fence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fenced = '```json\n{"status": "ok"}\n```'
+        monkeypatch.setattr(
+            ds_module.AioMultiModalConversation,
+            "call",
+            AsyncMock(return_value=_success_response(text=fenced)),
+        )
+
+        # expects_json -> fence stripped to bare JSON
+        stripped = await provider.complete(
+            LLMRequest(prompt="hi", model="qwen3-vl-32b-instruct", expects_json=True)
+        )
+        assert stripped.content == '{"status": "ok"}'
+
+        # default (plain text) -> raw passthrough
+        raw = await provider.complete(
+            LLMRequest(prompt="hi", model="qwen3-vl-32b-instruct")
+        )
+        assert raw.content == fenced
 
     @pytest.mark.asyncio
     async def test_non_200_raises_response_error(


### PR DESCRIPTION
## Context — RUN_SMOKE GATE #3 (video) failure

Video Pass 2a failed: ladder exhausted with `Invalid JSON: expected value at line 1 column 1`. An **isolated probe** of the real `video_pass_2a_mapping` prompt against `GeminiProvider.complete()` showed the raw output is a **valid JSON object wrapped in a ` ```json ` markdown fence**. The ingestion `StageRouter` path parses the raw content, so `model_validate_json("```json…")` fails at the leading backtick.

**Root cause is structural, not gemini-specific:** no provider normalizes its `complete()` output, so the pipeline silently depends on each model emitting bare JSON — true for DeepSeek (text Pass 2a) and Mistral (presentation Pass 2a), but not Gemini (the only gemini-led stage). Fence-stripping already existed but only in `complete_structured()` (which `StageRouter` never calls) and was duplicated in `anthropic.py` + `dashscope.py`.

Excluded by evidence: context window (265K fit Gemini's 1M; error was STRUCTURAL not INPUT_OVERFLOW), output truncation (`tokens_out` 164/1459 ≪ 8192 cap), empty response (valid JSON present), thinking budget, video length.

## Fix — provider-level encapsulation, intent-driven

- **`LLMRequest.expects_json`** (default `False`) carries the caller's "JSON expected" intent; `StageRouter.execute_for_stage(expects_json=…)` threads it into the request.
- **Each provider's `complete()` honours it:** Gemini sets native JSON mode (`response_mime_type="application/json"`) so it stops fencing at the source; all providers additionally strip fences defensively.
- **Shared `strip_markdown_json`** hoisted to `llm/json_extract.py` (removes the anthropic/dashscope duplicates).
- **JSON stages opt in:** Pass 2a (video / audio / text / web / presentation) + Stage 2 safety. **Plain-text stages stay `False`** (Pass 2c denoise, Pass 1 vision) → untouched, so the default is **zero behaviour change**.

## Gates

- `ruff` + `ruff format` clean; `mypy --strict` — 126 files, 0 issues.
- Full `--run-db` — **2122 passed / 0 failed** (= 2.4.10 baseline + 7 new tests: shared-helper + per-provider `expects_json` honor, incl. raw-passthrough when `False`).
- **Post-merge acceptance:** live re-run of the failing video (`youtu.be/1A-sxO1MeJQ`) → Pass 2a produces a `DocumentSummary` (no JSON ladder-exhaust).

## Out of scope (separate findings)

Anthropic fallback-rung credits (`credit balance too low`); presentation empty-concepts (prompt); `cost_usd=NULL` (DD-2.4-F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)