### PR TITLE
task(2.4.12): tune video Pass 2a ladder + qwen3.7-max registry refresh

### DIFF
--- a/config/external_services.yaml
+++ b/config/external_services.yaml
@@ -209,14 +209,21 @@ providers:
     models:
       - id: qwen3.7-max-2026-05-20
         # Latest Qwen flagship "Max" (text reasoning; released 2026-05-20).
-        # PROVISIONAL: 3.7-max rates not yet on the public price list — proxied
-        # from qwen3-max (International ≤32k-prompt tier) pending publication.
+        # Context 1M / output 65536 confirmed from OpenRouter listing
+        # 2026-06-02. Pricing $2.50/$7.50 per 1M is the Alibaba direct
+        # durable regular rate (cross-checked via artificialanalysis.ai).
+        # OpenRouter / pricepertoken list $1.25/$3.75 — an exact 2× delta
+        # against the Alibaba direct rate (a 50% promo signature); registry
+        # convention prefers the durable regular rate to avoid a silent
+        # post-promo jump (precedent: deepseek-v4-pro). The Alibaba Model
+        # Studio public pricing page did not yet list qwen3.7-max as of
+        # 2026-06-02 — refresh this entry once it does and reconcile.
         capabilities: [structured_output, long_context]
-        max_context: 262144
-        max_output_tokens: 32768
+        max_context: 1048576
+        max_output_tokens: 65536
         unit_type: tokens
-        cost_per_1k_in: 0.0012
-        cost_per_1k_out: 0.006
+        cost_per_1k_in: 0.0025
+        cost_per_1k_out: 0.0075
       - id: qwen3-max-2026-01-23
         # Stable Qwen flagship "Max" (text). PROVISIONAL: public International
         # ≤32k-prompt tier ($1.2/$6 per 1M); higher tiers apply above 32k input.

--- a/config/ladders_video.yaml
+++ b/config/ladders_video.yaml
@@ -67,7 +67,11 @@ stages:
         model: gemini-2.5-flash
         max_output_tokens: 8192
 
-  # Pass 2a semantic mapping (KD-2.2-A/F/H word-idx contract; task 2.4.5).
+  # Pass 2a semantic mapping (KD-2.2-A/F/H word-idx contract; landed in task
+  # 2.4.5, retuned for RUN_SMOKE #2 in task 2.4.12 after RUN_SMOKE #1 exposed
+  # the prior ladder as both ceiling- and reasoning-constrained on long video:
+  # the 8K output pin truncated 23-min transcripts and gemini-2.5-flash as R1
+  # was weak for single-shot structural segmentation at 265K input).
   # Input: transcript word-stream (``words_json`` + ``words_count``) + a
   #   deterministic visual-overlay block (``visuals``) via Jinja render
   #   context; image bytes do NOT flow here (text-reasoning, not vision).
@@ -75,36 +79,56 @@ stages:
   #   word-idx schema) by the ``step_5_pass2a_mapping`` response_validator;
   #   a ``ValidationError`` → ``StructuralRetryError`` (Path 3, as audio).
   #
-  # Ladder rationale (text-reasoning; mechanism CI-landed, ranking is the
-  # operator-run RUN_SMOKE spike per KD8/KD-2.3-X — calibrated *within* the
-  # registered text pool, NOT a unique per-source model):
-  #   1. gemini/gemini-2.5-flash — cost-first primary. Proven Pass-2a-capable
-  #      (audio Pass 2a rung). Clean JSON via the prompt directive (no
-  #      markdown-fence strip needed — the validator mirrors audio's).
-  #   2. gemini/gemini-2.5-pro — premium fallback (deeper reasoning for long
-  #      transcripts; presentation Pass 2a fallback precedent).
-  #   3. anthropic/claude-sonnet-4-5-20250929 — provider-diverse deep fallback
-  #      (rare; only if both gemini rungs exhaust). Current Sonnet snapshot —
-  #      NOT the deprecated claude-sonnet-4-20250514.
-  # Per-rung ``max_output_tokens: 8192`` guards a long segment+subsegment JSON
-  # against mid-object truncation (which would otherwise surface as a spurious
-  # validation failure). All three are registered in external_services.yaml
-  # (cost-tracked) — deliberately NOT a literal copy of the audio pool, two of
-  # whose rungs (gemini-3.1-flash-lite, claude-haiku-4-5) lack registry
-  # entries; the spike re-ranks and may diversify (a Mistral rung would need
-  # the markdown-fence strip, KD-2.3-T).
+  # Ladder rationale (text-reasoning; per-source_type calibration per
+  # KD-2.3-X — calibrated *within* the registered text pool, NOT a unique
+  # per-source model; ranking observed in RUN_SMOKE #2):
+  #   1. gemini/gemini-3.1-flash-lite — cost-first preview-tier primary.
+  #      Single-shot reasoning is sharper than gemini-2.5-flash on long
+  #      context, at comparable cost ($0.25/$1.50 vs $0.30/$2.50 per 1M).
+  #      Preview-tier status is an accepted trade-off.
+  #   2. dashscope/qwen3.7-max-2026-05-20 — diverse-provider rescue (NOT
+  #      Gemini, guards against a Gemini-API common issue). Reasoning-tier
+  #      flagship with 1M context and 65536 output (92.4% GPQA Diamond,
+  #      80.4% SWE-Verified). 1M context covers the longest video
+  #      transcripts (RUN_SMOKE #1 hit ~265K input). NOT calibrated on
+  #      video Pass 2a yet — performance observed in RUN_SMOKE #2.
+  #   3. gemini/gemini-2.5-flash — stable Gemini fallback (the proven
+  #      baseline; passed text / presentation Pass 2a in RUN_SMOKE #1).
+  #   4. gemini/gemini-2.5-pro — reasoning escalation on the hardest
+  #      materials ($1.25/$10 per 1M; the priciest rung, last resort).
+  #
+  # Anthropic/Sonnet R3 rung removed — no Anthropic credits make the rung a
+  # dead tier (separate operator concern). Promote back as a fifth tier
+  # once credits are restored.
+  # DeepSeek V4 Pro intentionally NOT added here — its reasoning mode needs
+  # a dedicated ``DeepSeekThinkingProvider`` (future work, separate task).
+  #
+  # Output-pin policy (DD-2.4-H): per-rung ``max_output_tokens: 65536``
+  # lifts the budget from the sprint-wide 8192 baseline to the per-rung
+  # model ceiling — the 8K pin actively truncated long-video transcripts
+  # in RUN_SMOKE #1 (the Gemini 65K model ceiling was artificially
+  # constrained by the pin). All four rungs share the same 65536 cap
+  # (Gemini 3.1-flash-lite / 2.5-flash / 2.5-pro registry-confirmed 65536;
+  # Qwen 3.7-Max confirmed 65536 from OpenRouter listing 2026-06-02), so
+  # intra-ladder rung-uniformity still holds at the new, higher pin. Other
+  # Pass 2a stages (audio / presentation / text) keep the 8192 pin →
+  # DD-2.4-H stays live sprint-wide; for video Pass 2a it is lifted "as a
+  # class" per the ratified optional clause in task 2.4.12.
   video_pass_2a_mapping:
     prompt_ref: "prompts/video_pass_2a_mapping/v1.md"
     ladder:
       - provider: gemini
+        model: gemini-3.1-flash-lite
+        max_output_tokens: 65536
+      - provider: dashscope
+        model: qwen3.7-max-2026-05-20
+        max_output_tokens: 65536
+      - provider: gemini
         model: gemini-2.5-flash
-        max_output_tokens: 8192
+        max_output_tokens: 65536
       - provider: gemini
         model: gemini-2.5-pro
-        max_output_tokens: 8192
-      - provider: anthropic
-        model: claude-sonnet-4-5-20250929
-        max_output_tokens: 8192
+        max_output_tokens: 65536
 
   # Pass 2c selective denoise (KD2d + KD8/KD-2.3-X; task 2.4.7).
   # Input: one noisy transcript segment per call — ``content`` (raw slice) +


### PR DESCRIPTION
## Summary

Config-only ladder retune for video Pass 2a + matching `qwen3.7-max-2026-05-20` registry refresh ahead of RUN_SMOKE #2. **No code-path touched.**

RUN_SMOKE #1 (2026-05-24) exposed video Pass 2a as ceiling- and reasoning-constrained on long video: the sprint-wide 8K output pin truncated 23-min transcripts and `gemini-2.5-flash` as R1 was weak for single-shot structural segmentation at ~265K input. Anthropic R3 (Sonnet) was effectively dead — no credits.

### Ladder (4 rungs, all `max_output_tokens: 65536`)
- R1 `gemini/gemini-3.1-flash-lite` — cost-first preview-tier primary (sharper single-shot reasoning than 2.5-flash, comparable cost).
- R2 `dashscope/qwen3.7-max-2026-05-20` — diverse-provider rescue (NOT Gemini), 1M context (covers ~265K input with headroom).
- R3 `gemini/gemini-2.5-flash` — stable Gemini fallback (RUN_SMOKE #1 baseline).
- R4 `gemini/gemini-2.5-pro` — reasoning escalation, last resort.

### Output-pin policy
Per-rung pin lifted from sprint-wide 8192 (DD-2.4-H) to 65536 (model ceiling). All four rungs share 65536 so **intra-ladder rung-uniformity holds at the new pin**. Other Pass 2a stages (audio / presentation / text) keep the 8192 pin → DD-2.4-H stays live sprint-wide; for video Pass 2a it is lifted "as a class" per the ratified optional clause in task 2.4.12.

### `qwen3.7-max-2026-05-20` registry refresh (verified 2026-06-02)
- `max_context`: 262144 → **1048576** (1M) — OpenRouter listing.
- `max_output_tokens`: 32768 → **65536** — OpenRouter listing.
- `cost_per_1k_in`: 0.0012 → **0.0025** ($2.50/1M).
- `cost_per_1k_out`: 0.006 → **0.0075** ($7.50/1M).
- Pricing source: Alibaba direct durable regular rate (cross-checked via artificialanalysis.ai). OpenRouter / pricepertoken list `$1.25/$3.75` — an exact 2× delta against the Alibaba direct rate (a 50% promo signature); registry convention prefers the durable regular rate (precedent: `deepseek-v4-pro`).
- Alibaba Model Studio public pricing page did not yet list `qwen3.7-max` as of 2026-06-02 — refresh when it does and reconcile.

### Explicit out-of-scope
- Prompt `prompts/video_pass_2a_mapping/v1.md` — separate task (language debt + presentation concepts).
- Validator / schema (`AudioPass2aResult` reuse — KD-2.2-A/F/H invariant).
- Other ladders (audio / presentation / text Pass 2a; video Pass 1 / 2c) — 8K pins remain.
- Anthropic / Sonnet rung — not added (no credits).
- DeepSeek V4 Pro — separate future work (needs `DeepSeekThinkingProvider`).

### Vision sections cited
KD-2.3-X (per-source_type empirical calibration), KD-2.2-A/F/H (word-idx contract — untouched), DD-2.4-H (sprint-wide output-pin debt — lifted for video Pass 2a only).

## Test plan

- [x] `ruff check config/` — clean.
- [x] Loader smoke: `load_ladder_config(Path('config'))` + `load_registry(Path('config/external_services.yaml'))` — both succeed.
- [x] Ladder-rung-in-registry membership assert — 4/4 video Pass 2a rungs registered; per-rung pin == registry `max_output_tokens` (65536) for all four.
- [x] Pre-commit hooks — `check yaml` Passed; `ruff` / `ruff format` / `mypy` Skipped (no Python files touched).
- [ ] **NOT run:** `--run-db` — config-only; no code-path touched. Per task §Acceptance criteria.
- [ ] Live billable RUN_SMOKE #2 — separate post-merge step, operator-gated.

### Known follow-up (raised as DD-2.4-I in POST-MERGE-NOTES, not for this PR)
`load_ladder_config` validates only the Pydantic schema; ladder-rungs are NOT cross-checked against the registry for membership / capabilities (unlike action-chains in `ModelRegistryConfig`). A typo in a rung's model id loads silently and only fails at runtime. Candidate: config-time membership + capability assert in `load_ladder_config` (parity with action-chain validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)