### PR TITLE
task(2.4.13): course default_language mandatory at root + ISO 639-3 + config-language endpoint (backend)

### DIFF
--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -1,0 +1,93 @@
+# ============================================================
+# Allowed course languages — single source of truth (Task 2.4.13).
+# ============================================================
+#
+# Storage format: ISO 639-3 (three-letter). Accepting 639-3 across the
+# board lets us represent languages that have no 639-1 (two-letter) code
+# (e.g. Cantonese ``yue``). All API input — 639-1, 639-3, or English name
+# — flows through ``course_supporter.language.normalize_and_validate``
+# before it reaches the DB; storage and API responses are always 639-3.
+#
+# Set composition: ElevenLabs Scribe WER-tier "Excellent + High"
+# (≤10% WER per the official model card, verified 2026-06-02). The list
+# is grouped only for human readability — the loader treats it as a
+# flat 57-entry whitelist. Tier metadata (Excellent vs High) lives in
+# the comments below; if a downstream consumer ever needs it, lift the
+# split into structured YAML at that point (reactive trigger).
+#
+# Product framing: oriented at Europe / North America / the Balkans /
+# Turkey; Russian is mandatory because many Ukrainian-authored courses
+# are recorded in Russian. The set bounds the STT branch (audio/video)
+# precisely; text/web/presentation paths use Gemini/Qwen with far
+# wider language coverage but share this whitelist for symmetry —
+# accepted simplification.
+#
+# Caveats:
+#   * Albanian is absent from ElevenLabs Scribe entirely (no tier).
+#   * The set is shared across all source_types deliberately, even
+#     though only STT is genuinely constrained by it.
+#
+# When this file changes, the in-process registry is cached (per
+# ``course_supporter.language.get_language_registry``) — restart the
+# API / worker to pick up edits.
+
+languages:
+  # Excellent tier (≤5% WER), 36 codes:
+  - bel  # Belarusian
+  - bos  # Bosnian
+  - bul  # Bulgarian
+  - cat  # Catalan
+  - hrv  # Croatian
+  - ces  # Czech
+  - dan  # Danish
+  - nld  # Dutch
+  - eng  # English
+  - est  # Estonian
+  - fin  # Finnish
+  - fra  # French
+  - glg  # Galician
+  - deu  # German
+  - ell  # Greek
+  - hun  # Hungarian
+  - isl  # Icelandic
+  - ind  # Indonesian
+  - ita  # Italian
+  - jpn  # Japanese
+  - kan  # Kannada
+  - lav  # Latvian
+  - mkd  # Macedonian
+  - msa  # Malay
+  - mal  # Malayalam
+  - nor  # Norwegian
+  - pol  # Polish
+  - por  # Portuguese
+  - ron  # Romanian
+  - rus  # Russian
+  - slk  # Slovak
+  - spa  # Spanish
+  - swe  # Swedish
+  - tur  # Turkish
+  - ukr  # Ukrainian
+  - vie  # Vietnamese
+  # High tier (>5–≤10% WER), 21 codes:
+  - hye  # Armenian
+  - aze  # Azerbaijani
+  - ben  # Bengali
+  - yue  # Cantonese (no 639-1 code — example of why we store 639-3)
+  - fil  # Filipino
+  - kat  # Georgian
+  - guj  # Gujarati
+  - hin  # Hindi
+  - kaz  # Kazakh
+  - lit  # Lithuanian
+  - mlt  # Maltese
+  - cmn  # Mandarin Chinese
+  - mar  # Marathi
+  - nep  # Nepali
+  - ori  # Odia (Oriya)
+  - fas  # Persian (Farsi)
+  - srp  # Serbian
+  - slv  # Slovenian
+  - swa  # Swahili
+  - tam  # Tamil
+  - tel  # Telugu

--- a/migrations/versions/phase24_root_lang_required.py
+++ b/migrations/versions/phase24_root_lang_required.py
@@ -1,0 +1,258 @@
+"""Make course (root) default_language mandatory + convert to ISO 639-3.
+
+Phase 2.4 task 2.4.13:
+* Backfill NULL ``default_language`` on root ``course_nodes`` to ``'ukr'``
+  (operator-ratified: all existing courses are Ukrainian; local DB only).
+* Convert existing ISO 639-1 codes in ``course_nodes.default_language``
+  and ``authored_documents.language`` to canonical ISO 639-3.
+* Enforce ``course_nodes_root_language_required`` CHECK constraint —
+  ``parent_id IS NOT NULL OR default_language IS NOT NULL``. Children
+  remain nullable (their language is dead-data — runtime inheritance
+  always reads ``get_root_for`` per ``api/tasks.py:185``).
+
+Inline 639-1 → 639-3 mapping (no app-code import, per Task 2.4.13
+corrective 2): one row per allowed-whitelist language that has a
+639-1 form. Codes already in 639-3 form (or 3-letter macrolanguage
+codes like ``zh`` → ``cmn``) are passed through the map too. Anything
+outside the map raises so operator can decide explicitly.
+
+Revision ID: phase24_root_lang_required
+Revises: phase24_segment_visual_content
+Create Date: 2026-06-02 16:00:00.000000
+"""
+
+from collections.abc import Sequence
+from typing import Final
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "phase24_root_lang_required"
+down_revision: str | Sequence[str] | None = "phase24_segment_visual_content"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# ISO 639-1 (and a couple of common 2-letter macrolanguage shorthands) → 639-3.
+# Coverage = the 57 whitelisted languages from ``config/languages.yaml``.
+# Languages without a 639-1 form (yue, fil, cmn) are mapped only from their
+# 639-3 to themselves; their 639-1 entries simply do not exist. ``zh`` is
+# routed to ``cmn`` because Mandarin is the whitelisted variant.
+_LANG_MAP: Final[dict[str, str]] = {
+    # Excellent tier
+    "be": "bel",
+    "bs": "bos",
+    "bg": "bul",
+    "ca": "cat",
+    "hr": "hrv",
+    "cs": "ces",
+    "da": "dan",
+    "nl": "nld",
+    "en": "eng",
+    "et": "est",
+    "fi": "fin",
+    "fr": "fra",
+    "gl": "glg",
+    "de": "deu",
+    "el": "ell",
+    "hu": "hun",
+    "is": "isl",
+    "id": "ind",
+    "it": "ita",
+    "ja": "jpn",
+    "kn": "kan",
+    "lv": "lav",
+    "mk": "mkd",
+    "ms": "msa",
+    "ml": "mal",
+    "no": "nor",
+    "pl": "pol",
+    "pt": "por",
+    "ro": "ron",
+    "ru": "rus",
+    "sk": "slk",
+    "es": "spa",
+    "sv": "swe",
+    "tr": "tur",
+    "uk": "ukr",
+    "vi": "vie",
+    # High tier
+    "hy": "hye",
+    "az": "aze",
+    "bn": "ben",
+    "ka": "kat",
+    "gu": "guj",
+    "hi": "hin",
+    "kk": "kaz",
+    "lt": "lit",
+    "mt": "mlt",
+    "zh": "cmn",
+    "mr": "mar",
+    "ne": "nep",
+    "or": "ori",
+    "fa": "fas",
+    "sr": "srp",
+    "sl": "slv",
+    "sw": "swa",
+    "ta": "tam",
+    "te": "tel",
+}
+
+# Idempotency: codes already in the canonical 639-3 form pass through unchanged.
+_PASSTHROUGH: Final[frozenset[str]] = frozenset(
+    {
+        "bel",
+        "bos",
+        "bul",
+        "cat",
+        "hrv",
+        "ces",
+        "dan",
+        "nld",
+        "eng",
+        "est",
+        "fin",
+        "fra",
+        "glg",
+        "deu",
+        "ell",
+        "hun",
+        "isl",
+        "ind",
+        "ita",
+        "jpn",
+        "kan",
+        "lav",
+        "mkd",
+        "msa",
+        "mal",
+        "nor",
+        "pol",
+        "por",
+        "ron",
+        "rus",
+        "slk",
+        "spa",
+        "swe",
+        "tur",
+        "ukr",
+        "vie",
+        "hye",
+        "aze",
+        "ben",
+        "yue",
+        "fil",
+        "kat",
+        "guj",
+        "hin",
+        "kaz",
+        "lit",
+        "mlt",
+        "cmn",
+        "mar",
+        "nep",
+        "ori",
+        "fas",
+        "srp",
+        "slv",
+        "swa",
+        "tam",
+        "tel",
+    }
+)
+
+
+def _normalize(raw: str) -> str:
+    """Canonical 639-3 for any supported input.
+
+    Raises ``RuntimeError`` for unknown codes so the migration aborts
+    loudly and the operator decides how to map the row by hand.
+    """
+    value = raw.strip().lower()
+    if value in _PASSTHROUGH:
+        return value
+    if value in _LANG_MAP:
+        return _LANG_MAP[value]
+    raise RuntimeError(
+        f"Cannot map language code {raw!r} to the project whitelist (see "
+        f"config/languages.yaml). Backfill manually before re-running."
+    )
+
+
+# Reverse map for downgrade (639-3 → 639-1). Languages without a 639-1
+# form (yue, fil, cmn) have no reverse entry and are left unchanged
+# (retain 639-3) on downgrade — best-effort, irreversible by construction.
+_REVERSE_MAP: Final[dict[str, str]] = {v: k for k, v in _LANG_MAP.items()}
+
+
+def upgrade() -> None:
+    """Backfill, normalize, then add the CHECK constraint."""
+    conn = op.get_bind()
+
+    # Step 1 — backfill NULL ``default_language`` on root nodes to 'ukr'.
+    # Operator-ratified silent default (all existing courses Ukrainian per
+    # Task 2.4.13). Children remain NULL by design (dead-data per §1).
+    conn.execute(
+        sa.text(
+            "UPDATE course_nodes "
+            "SET default_language = 'ukr' "
+            "WHERE parent_id IS NULL AND default_language IS NULL"
+        )
+    )
+
+    # Step 2 — convert existing 639-1 codes to 639-3 on both columns.
+    for table, column in (
+        ("course_nodes", "default_language"),
+        ("authored_documents", "language"),
+    ):
+        # ``table``/``column`` are hard-coded loop literals — not user
+        # input — so the f-string is safe; ruff S608 is a false positive.
+        rows = conn.execute(
+            sa.text(f"SELECT id, {column} FROM {table} WHERE {column} IS NOT NULL")  # noqa: S608
+        ).fetchall()
+        for row_id, raw in rows:
+            normalized = _normalize(raw)
+            if normalized != raw:
+                conn.execute(
+                    sa.text(f"UPDATE {table} SET {column} = :new WHERE id = :id"),  # noqa: S608
+                    {"new": normalized, "id": row_id},
+                )
+
+    # Step 3 — enforce root-language invariant via CHECK constraint.
+    op.create_check_constraint(
+        "course_nodes_root_language_required",
+        "course_nodes",
+        "parent_id IS NOT NULL OR default_language IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    """Drop the CHECK and reverse-map 639-3 → 639-1 best-effort.
+
+    Cannot restore NULL on root rows backfilled in upgrade Step 1
+    (information lost by construction); those rows keep their 639-1 form
+    after this downgrade. Documented as irreversible.
+    """
+    op.drop_constraint(
+        "course_nodes_root_language_required",
+        "course_nodes",
+        type_="check",
+    )
+
+    conn = op.get_bind()
+    for table, column in (
+        ("course_nodes", "default_language"),
+        ("authored_documents", "language"),
+    ):
+        # ``table``/``column`` are hard-coded loop literals — not user
+        # input — so the f-string is safe; ruff S608 is a false positive.
+        rows = conn.execute(
+            sa.text(f"SELECT id, {column} FROM {table} WHERE {column} IS NOT NULL")  # noqa: S608
+        ).fetchall()
+        for row_id, raw in rows:
+            mapped = _REVERSE_MAP.get(raw)
+            if mapped is not None:
+                conn.execute(
+                    sa.text(f"UPDATE {table} SET {column} = :new WHERE id = :id"),  # noqa: S608
+                    {"new": mapped, "id": row_id},
+                )

--- a/src/course_supporter/api/app.py
+++ b/src/course_supporter/api/app.py
@@ -19,6 +19,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 
 from course_supporter.api.middleware import RequestLoggingMiddleware
+from course_supporter.api.routes.config import router as config_router
 from course_supporter.api.routes.cost import router as cost_router
 from course_supporter.api.routes.documents import router as documents_router
 from course_supporter.api.routes.homework import router as homework_router
@@ -246,3 +247,4 @@ app.include_router(homework_router, prefix="/api/v1")
 app.include_router(jobs_router, prefix="/api/v1")
 app.include_router(cost_router, prefix="/api/v1")
 app.include_router(storage_router, prefix="/api/v1")
+app.include_router(config_router, prefix="/api/v1")

--- a/src/course_supporter/api/routes/config.py
+++ b/src/course_supporter/api/routes/config.py
@@ -1,0 +1,47 @@
+"""Read-only lookup endpoints for client-side config (Task 2.4.13).
+
+Currently exposes:
+
+* ``GET /api/v1/config/languages`` — the allowed course-language
+  whitelist (single source of truth, mirrors ``config/languages.yaml``).
+  The UI consumes this to populate its language selector — no hardcoded
+  list on the client.
+
+Future home for similar lookup endpoints (e.g. DD-2.4-I —
+``allowed_extensions`` for the upload modal). Auth-protected so the
+contract matches the rest of the API surface even though the data is
+non-tenant-scoped.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import structlog
+from fastapi import APIRouter, Depends
+
+from course_supporter.api.schemas import AllowedLanguagesResponse
+from course_supporter.auth.context import TenantContext
+from course_supporter.auth.registry import AuthScope
+from course_supporter.auth.scopes import require_scope
+from course_supporter.language import list_allowed
+
+logger = structlog.get_logger()
+
+router = APIRouter(prefix="/config", tags=["config"])
+
+SharedDep = Annotated[
+    TenantContext, Depends(require_scope(AuthScope.PREP, AuthScope.CHECK))
+]
+
+
+@router.get("/languages")
+async def get_allowed_languages(_tenant: SharedDep) -> AllowedLanguagesResponse:
+    """Return the project-wide course-language whitelist.
+
+    Codes are canonical ISO 639-3; ``name_en`` is always populated
+    (via ``iso639``), ``name_native`` is best-effort (None when the
+    library does not carry a native-script name for that language).
+    """
+    items = list_allowed()
+    return AllowedLanguagesResponse(items=items, total=len(items))

--- a/src/course_supporter/api/routes/documents.py
+++ b/src/course_supporter/api/routes/documents.py
@@ -45,6 +45,11 @@ from course_supporter.auth.registry import AuthScope
 from course_supporter.auth.scopes import require_scope
 from course_supporter.enqueue import enqueue_ingestion
 from course_supporter.jobs.cancellation_service import JobCancellationService
+from course_supporter.language import (
+    InvalidLanguageError,
+    LanguageNotAllowedError,
+    normalize_and_validate,
+)
 from course_supporter.models.source import AssignmentType, MaterialRole, SourceType
 from course_supporter.security import AUTHORED_POLICY, run_stage1
 from course_supporter.security.exceptions import (
@@ -240,10 +245,11 @@ async def create_document(
         str | None,
         Form(
             description=(
-                "Optional ISO 639-1 language override. When empty, the course "
-                "default is used and STT falls back to auto-detection."
+                "Optional language override. Accepts ISO 639-1 / 639-3 / "
+                "English name; stored as canonical ISO 639-3. When empty, "
+                "the course default is used and STT falls back to "
+                "auto-detection."
             ),
-            pattern=r"^[a-z]{2}$",
         ),
     ] = None,
 ) -> AuthoredDocumentCreateResponse:
@@ -261,6 +267,16 @@ async def create_document(
             status_code=422,
             detail="Either source_url or file must be provided",
         )
+
+    # FastAPI ``Form()`` does not run Pydantic field validators, so the
+    # language helper is invoked explicitly here. Without the explicit
+    # ``HTTPException``, the helper's ``ValueError`` subclasses would
+    # bubble as a 500 instead of a 422 (Task 2.4.13 fix-1 ratify).
+    if language is not None:
+        try:
+            language = normalize_and_validate(language)
+        except (InvalidLanguageError, LanguageNotAllowedError) as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     if file is not None:
         if source_type == SourceType.WEB:

--- a/src/course_supporter/api/routes/nodes.py
+++ b/src/course_supporter/api/routes/nodes.py
@@ -31,7 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from course_supporter.api.deps import get_arq_redis, get_s3_client, get_session
 from course_supporter.api.schemas import (
-    NodeCreateRequest,
+    ChildNodeCreateRequest,
     NodeListResponse,
     NodeMoveRequest,
     NodeReorderRequest,
@@ -39,6 +39,7 @@ from course_supporter.api.schemas import (
     NodeTreeResponse,
     NodeUpdateRequest,
     NodeWithDocumentsResponse,
+    RootNodeCreateRequest,
 )
 from course_supporter.auth.context import TenantContext
 from course_supporter.auth.registry import AuthScope
@@ -113,7 +114,7 @@ async def _require_child_node(
 
 @router.post("/nodes", status_code=201)
 async def create_root_node(
-    body: NodeCreateRequest,
+    body: RootNodeCreateRequest,
     tenant: PrepDep,
     session: SessionDep,
 ) -> NodeResponse:
@@ -121,6 +122,10 @@ async def create_root_node(
 
     Root nodes have no parent and appear at the top level.
     The ``order`` is auto-assigned as the next available position.
+
+    ``default_language`` is required — see ``RootNodeCreateRequest``.
+    The validator normalizes any standard input form to canonical ISO 639-3
+    before the DB write.
     """
     repo = CourseNodeRepository(session)
     node = await repo.create(
@@ -176,7 +181,7 @@ async def list_root_nodes(
 @router.post("/nodes/{node_id}/children", status_code=201)
 async def create_child_node(
     node_id: uuid.UUID,
-    body: NodeCreateRequest,
+    body: ChildNodeCreateRequest,
     tenant: PrepDep,
     session: SessionDep,
 ) -> NodeResponse:
@@ -279,9 +284,11 @@ async def update_node(
     Only fields present in the request body are updated.
     To clear a field, send it as ``null``. Updating
     ``default_language`` is a pure DB write — it does not trigger
-    re-ingestion of existing materials.
+    re-ingestion of existing materials. **Root nodes** cannot have
+    ``default_language`` cleared — the request is rejected with 422
+    so the CHECK constraint never fires as a 500.
     """
-    await _require_node_for_tenant(session, tenant.tenant_id, node_id)
+    node = await _require_node_for_tenant(session, tenant.tenant_id, node_id)
     repo = CourseNodeRepository(session)
 
     # Distinguish "field omitted" from "field set to null"
@@ -291,6 +298,17 @@ async def update_node(
     if "description" in body.model_fields_set:
         update_kwargs["description"] = body.description
     if "default_language" in body.model_fields_set:
+        # Root nodes carry the course language; clearing it would violate
+        # ``course_nodes_root_language_required`` (a 500 from the DB).
+        # Reject at the route boundary with a clear 422 instead.
+        if body.default_language is None and getattr(node, "parent_id", None) is None:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "default_language cannot be cleared on a root node "
+                    "(course language is required)."
+                ),
+            )
         update_kwargs["default_language"] = body.default_language
 
     node = await repo.update(node_id, **update_kwargs)

--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -6,25 +6,89 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from course_supporter.language import (
+    InvalidLanguageError,
+    LanguageEntry,
+    LanguageNotAllowedError,
+    normalize_and_validate,
+)
 from course_supporter.models.source import AssignmentType, MaterialRole, SourceType
 
 # --- Material Tree Nodes ---
 
 
-class NodeCreateRequest(BaseModel):
-    """Request body for creating a material tree node.
+def _validate_language(raw: str) -> str:
+    """Pydantic-compatible wrapper around ``normalize_and_validate``.
 
-    Used by both root node creation (``POST /nodes``)
-    and child node creation (``POST /nodes/{node_id}/children``).
+    Turns the helper's typed exceptions into ``ValueError`` so FastAPI
+    renders them as 422 with the helper's message.
+    """
+    try:
+        return normalize_and_validate(raw)
+    except (InvalidLanguageError, LanguageNotAllowedError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+class RootNodeCreateRequest(BaseModel):
+    """Request body for creating a root node (= course).
+
+    ``default_language`` is **required** for root nodes (Task 2.4.13:
+    course language is the entry-gate for Pass 2a language pinning).
+    Accepts any standard language description — 639-1 (``"uk"``), 639-3
+    (``"ukr"``), or English name (``"Ukrainian"``) — and stores it as
+    canonical 639-3 after validation against ``config/languages.yaml``.
 
     Example::
 
         {
-            "title": "Module 1: Introduction",
-            "description": "Overview of core concepts"
+            "title": "Python for Beginners",
+            "description": "Foundational Python course",
+            "default_language": "uk"
         }
+    """
+
+    title: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="Node title displayed in the material tree.",
+        examples=["Python for Beginners"],
+    )
+    description: str | None = Field(
+        default=None,
+        max_length=5000,
+        description="Optional detailed description of the node's purpose.",
+        examples=["Foundational Python course."],
+    )
+    default_language: str = Field(
+        ...,
+        description=(
+            "Required language of instruction. Accepts ISO 639-1 / 639-3 / "
+            "English name; stored as canonical ISO 639-3. Must be in the "
+            "whitelist served by ``GET /api/v1/config/languages``."
+        ),
+        examples=["uk", "ukr", "Ukrainian"],
+    )
+
+    @field_validator("default_language")
+    @classmethod
+    def _check_language(cls, raw: str) -> str:
+        return _validate_language(raw)
+
+
+class ChildNodeCreateRequest(BaseModel):
+    """Request body for creating a non-root (child) node.
+
+    ``default_language`` is optional on children — language inheritance
+    is resolved at ingestion time against the root, and any value set on
+    a child is currently unused by the pipeline (KD-2.4-13 §1). Kept
+    here for forward-compat in case cascade overrides land later.
+
+    Example::
+
+        {"title": "Module 1: Intro"}
     """
 
     title: str = Field(
@@ -42,14 +106,20 @@ class NodeCreateRequest(BaseModel):
     )
     default_language: str | None = Field(
         default=None,
-        pattern=r"^[a-z]{2}$",
         description=(
-            "Optional ISO 639-1 language for materials under this node. "
-            "Usually set on the root/course node; inherited by materials "
-            "unless overridden. Leave empty to rely on STT auto-detection."
+            "Optional language override for this subtree. Stored as canonical "
+            "ISO 639-3 when set. Pipeline currently reads only the root "
+            "language; child overrides are forward-compat metadata."
         ),
-        examples=["uk", "en"],
+        examples=["uk", "ukr"],
     )
+
+    @field_validator("default_language")
+    @classmethod
+    def _check_language(cls, raw: str | None) -> str | None:
+        if raw is None:
+            return None
+        return _validate_language(raw)
 
 
 class NodeUpdateRequest(BaseModel):
@@ -57,6 +127,11 @@ class NodeUpdateRequest(BaseModel):
 
     All fields are optional — only provided fields are updated.
     To clear the description, send ``"description": null`` explicitly.
+
+    ``default_language`` membership against ``config/languages.yaml`` is
+    enforced here when present; the route additionally rejects
+    set-to-null on a *root* node (HTTP 422) so the CHECK constraint
+    ``course_nodes_root_language_required`` never has to fire as a 500.
 
     Example::
 
@@ -81,14 +156,37 @@ class NodeUpdateRequest(BaseModel):
     )
     default_language: str | None = Field(
         default=None,
-        pattern=r"^[a-z]{2}$",
         description=(
-            "New default ISO 639-1 language for this subtree. "
-            "Send ``null`` to clear, omit to keep unchanged. "
-            "Setting it is a pure DB write; does NOT trigger re-ingestion of "
-            "existing materials. New uploads and explicit retries will pick it up."
+            "New default language for this subtree (any standard form; stored "
+            "as canonical ISO 639-3). Send ``null`` to clear (children only — "
+            "root rejects null with 422). Setting it is a pure DB write; does "
+            "NOT trigger re-ingestion of existing materials."
         ),
-        examples=["uk", "en"],
+        examples=["uk", "ukr"],
+    )
+
+    @field_validator("default_language")
+    @classmethod
+    def _check_language(cls, raw: str | None) -> str | None:
+        if raw is None:
+            return None
+        return _validate_language(raw)
+
+
+class AllowedLanguagesResponse(BaseModel):
+    """Response shape for ``GET /api/v1/config/languages``.
+
+    Returns the project-wide course-language whitelist (canonical ISO 639-3
+    codes enriched with English names; native names when ``iso639`` carries
+    them). UI consumes this as the single source of truth for the language
+    selector — no hardcoded list on the client.
+    """
+
+    items: list[LanguageEntry] = Field(
+        description="Allowed languages — canonical 639-3 + display names."
+    )
+    total: int = Field(
+        description="Convenience count of ``items`` (always equals ``len(items)``)."
     )
 
 
@@ -153,7 +251,13 @@ class NodeResponse(BaseModel):
     description: str | None = Field(description="Optional node description.")
     default_language: str | None = Field(
         default=None,
-        description=("Default ISO 639-1 language for materials under this subtree."),
+        description=(
+            "Canonical ISO 639-3 language for materials under this subtree. "
+            "Root nodes (``parent_id`` is null) are guaranteed non-null by "
+            "the ``course_nodes_root_language_required`` CHECK constraint; "
+            "child nodes may be null (inheritance is resolved at ingestion "
+            "from the root, not stored)."
+        ),
     )
     order: int = Field(description="0-based position among siblings.")
     content_hash: str | None = Field(
@@ -279,58 +383,6 @@ class NodeWithDocumentsResponse(BaseModel):
     updated_at: datetime = Field(description="When this node was last modified.")
 
 
-class AuthoredDocumentCreateRequest(BaseModel):
-    """Request body for adding a material to a tree node."""
-
-    source_type: SourceType = Field(
-        ...,
-        description=(
-            "Type of the source material. "
-            "Must be one of: ``video``, ``presentation``, ``text``, ``web``."
-        ),
-        examples=["video", "presentation", "text", "web"],
-    )
-    material_role: MaterialRole = Field(
-        default=MaterialRole.EDUCATIONAL,
-        description=(
-            "Role of the material: ``educational`` (delivers content to students) "
-            "or ``methodological`` (declares course intent/goals)."
-        ),
-        examples=["educational", "methodological"],
-    )
-    task_type: AssignmentType | None = Field(
-        default=None,
-        description=(
-            "Mark the material as a concrete assignment of the given taxonomy "
-            "tier (``test``, ``short_task``, ``task``, ``project``). When set, "
-            "the Methodist agent preserves this material as a "
-            "recommended_assignment verbatim. ``null`` for regular materials."
-        ),
-        examples=[None, "test", "task"],
-    )
-    source_url: str = Field(
-        ...,
-        max_length=2000,
-        description="URL or S3 path to the raw material.",
-        examples=["https://example.com/slides.pdf", "s3://bucket/key"],
-    )
-    filename: str | None = Field(
-        default=None,
-        max_length=500,
-        description="Original filename for display purposes.",
-        examples=["slides.pdf", "lecture-01.mp4"],
-    )
-    language: str | None = Field(
-        default=None,
-        pattern=r"^[a-z]{2}$",
-        description=(
-            "Optional ISO 639-1 language override. When absent, the course "
-            "default is used, and STT auto-detection is the final fallback."
-        ),
-        examples=["uk", "en"],
-    )
-
-
 class AuthoredDocumentUpdateRequest(BaseModel):
     """Request body for PATCH /documents/{document_id}.
 
@@ -378,7 +430,8 @@ class AuthoredDocumentResponse(BaseModel):
     language: str | None = Field(
         default=None,
         description=(
-            "ISO 639-1 language. ``null`` when unset and not yet auto-detected."
+            "Canonical ISO 639-3 language. ``null`` when unset and not yet "
+            "auto-detected."
         ),
     )
     order: int = Field(description="0-based position among sibling materials.")
@@ -425,7 +478,8 @@ class AuthoredDocumentCreateResponse(BaseModel):
     language: str | None = Field(
         default=None,
         description=(
-            "ISO 639-1 language. ``null`` when unset and not yet auto-detected."
+            "Canonical ISO 639-3 language. ``null`` when unset and not yet "
+            "auto-detected."
         ),
     )
     order: int = Field(description="0-based position among sibling materials.")
@@ -564,13 +618,20 @@ class ConfirmUploadRequest(BaseModel):
     )
     language: str | None = Field(
         default=None,
-        pattern=r"^[a-z]{2}$",
         description=(
-            "Optional ISO 639-1 language override. When absent, the course "
+            "Optional language override. Accepts ISO 639-1 / 639-3 / English "
+            "name; stored as canonical ISO 639-3. When absent, the course "
             "default is used, and STT auto-detection is the final fallback."
         ),
-        examples=["uk", "en"],
+        examples=["uk", "ukr"],
     )
+
+    @field_validator("language")
+    @classmethod
+    def _check_language(cls, raw: str | None) -> str | None:
+        if raw is None:
+            return None
+        return _validate_language(raw)
 
 
 # --- Storage Management ---

--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -16,6 +16,11 @@ from course_supporter.ingestion.factory import (
     create_heavy_steps,
     create_processors,
 )
+from course_supporter.language import (
+    InvalidLanguageError,
+    LanguageNotAllowedError,
+    normalize_and_validate,
+)
 from course_supporter.models.source import SourceType
 from course_supporter.service_logging import (
     set_job_from_arq,
@@ -367,16 +372,31 @@ async def arq_ingest_material(
     # Cache auto-detected language back to the entry for future STT calls.
     # Uses an atomic UPDATE ... WHERE language IS NULL to avoid a race
     # where a concurrent PATCH may set language between our check and write.
+    #
+    # STT output is a black-box external signal — a provider may return a
+    # code outside the project whitelist (Task 2.4.13). Normalize through
+    # the helper; if it cannot be resolved or is not allowed, warn-log and
+    # skip the cache write (do NOT fail ingestion — language authority is
+    # the course root, not STT auto-detect).
     if detected_language:
-        async with session_factory() as session:
-            entry_repo = AuthoredDocumentRepository(session)
-            updated = await entry_repo.set_language_if_unset(mid, detected_language)
-            await session.commit()
-            if updated:
-                log.info(
-                    "language_auto_detected_cached",
-                    language=detected_language,
-                )
+        try:
+            normalized = normalize_and_validate(detected_language)
+        except (InvalidLanguageError, LanguageNotAllowedError) as exc:
+            log.warning(
+                "language_auto_detect_skipped",
+                raw=detected_language,
+                reason=str(exc),
+            )
+        else:
+            async with session_factory() as session:
+                entry_repo = AuthoredDocumentRepository(session)
+                updated = await entry_repo.set_language_if_unset(mid, normalized)
+                await session.commit()
+                if updated:
+                    log.info(
+                        "language_auto_detected_cached",
+                        language=normalized,
+                    )
 
     await callback.on_success(
         job_id=jid,

--- a/src/course_supporter/config.py
+++ b/src/course_supporter/config.py
@@ -241,6 +241,7 @@ class Settings(BaseSettings):
     external_services_path: Path = Path("config/external_services.yaml")
     auth_registry_path: Path = Path("config/auth.yaml")
     platform_registry_path: Path = Path("config/platforms.yaml")
+    language_registry_path: Path = Path("config/languages.yaml")
     ladders_dir: Path = Path("config")
 
     # --- Convenience properties ---

--- a/src/course_supporter/language.py
+++ b/src/course_supporter/language.py
@@ -1,0 +1,194 @@
+"""Language allowlist, normalization, and validation (Task 2.4.13).
+
+Single point of language logic for the backend. Three consumers today:
+
+* ``api.schemas`` — Pydantic field validators on ``RootNodeCreateRequest``
+  and ``NodeUpdateRequest`` accept any standard description (639-1,
+  639-3, or English name) and normalize to canonical 639-3.
+* ``api.tasks`` (STT auto-detect cache) — wraps ``detected_language``
+  before persisting via ``AuthoredDocumentRepository.set_language_if_unset``.
+* ``api.routes.config`` — ``GET /api/v1/config/languages`` returns the
+  allowed set enriched with English names (and native names where
+  ``iso639`` exposes them) for the UI selector.
+
+The whitelist lives in ``config/languages.yaml``. The path is injected
+from ``Settings.language_registry_path`` so tests can swap fixtures.
+
+Loader pattern mirrors :mod:`course_supporter.api.upload_validation`
+(Pydantic model + module-level cache + path-from-settings). Kept as a
+flat top-level module per the cross-cutting convention used by
+``config.py`` / ``errors.py`` / ``key_pool.py`` — promote to a package
+only when a second module joins it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+
+import iso639
+import yaml
+from pydantic import BaseModel, Field
+
+
+class LanguageEntry(BaseModel):
+    """One allowed language for the UI selector and validation."""
+
+    code: str = Field(description="Canonical ISO 639-3 three-letter code.")
+    name_en: str = Field(description="English name (from iso639 SIL table).")
+    name_native: str | None = Field(
+        default=None,
+        description=(
+            "Native-script name when iso639 carries one; None otherwise. "
+            "UI may fall back to ``name_en`` when missing."
+        ),
+    )
+
+
+class LanguageRegistryConfig(BaseModel):
+    """Top-level shape of ``config/languages.yaml``."""
+
+    languages: list[str] = Field(
+        description="Flat list of ISO 639-3 codes — the allowed whitelist."
+    )
+
+
+class InvalidLanguageError(ValueError):
+    """Raised when input cannot be resolved to any known ISO language."""
+
+
+class LanguageNotAllowedError(ValueError):
+    """Raised when input resolves to a valid ISO language not on the whitelist."""
+
+    def __init__(self, code: str, allowed_count: int) -> None:
+        super().__init__(
+            f"Language {code!r} is not in the allowed set "
+            f"({allowed_count} languages — see config/languages.yaml)."
+        )
+        self.code = code
+        self.allowed_count = allowed_count
+
+
+_registry: LanguageRegistryConfig | None = None
+_allowed_codes: frozenset[str] | None = None
+_allowed_entries: list[LanguageEntry] | None = None
+
+
+def load_language_registry(config_path: Path) -> LanguageRegistryConfig:
+    """Load and validate the language whitelist from YAML.
+
+    Raises:
+        FileNotFoundError: when ``config_path`` does not exist.
+        ValueError: when YAML parsing or Pydantic validation fails.
+    """
+    if not config_path.exists():
+        raise FileNotFoundError(f"Language config not found: {config_path}")
+    try:
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(
+            f"Failed to parse language config '{config_path}': {exc}"
+        ) from exc
+    return LanguageRegistryConfig.model_validate(raw)
+
+
+def _default_config_path() -> Path:
+    """Resolve the language config path from settings (lazy import).
+
+    Settings are imported lazily to avoid a circular import: ``config.py``
+    is loaded at app boot, before this module is needed.
+    """
+    from course_supporter.config import get_settings
+
+    return get_settings().language_registry_path
+
+
+def get_language_registry(config_path: Path | None = None) -> LanguageRegistryConfig:
+    """Return the cached registry; load on first call (or when path overridden)."""
+    global _registry, _allowed_codes, _allowed_entries
+    if _registry is None or config_path is not None:
+        path = config_path if config_path is not None else _default_config_path()
+        _registry = load_language_registry(path)
+        _allowed_codes = frozenset(_registry.languages)
+        _allowed_entries = None  # rebuilt on first list_allowed() call
+    return _registry
+
+
+def _get_allowed_codes() -> frozenset[str]:
+    if _allowed_codes is None:
+        get_language_registry()
+    assert _allowed_codes is not None  # populated by the loader above
+    return _allowed_codes
+
+
+def normalize_and_validate(raw: str) -> str:
+    """Resolve any standard language description to its canonical 639-3 code.
+
+    Accepts a 639-1 (two-letter) code, a 639-3 (three-letter) code, or an
+    English name (e.g. ``"Ukrainian"``). Returns the canonical 639-3 form.
+
+    Raises:
+        InvalidLanguageError: when the input cannot be resolved to any
+            known ISO language at all.
+        LanguageNotAllowedError: when the input resolves to a valid ISO
+            language that is not in the project's whitelist
+            (``config/languages.yaml``).
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        raise InvalidLanguageError(f"Empty or non-string language input: {raw!r}")
+
+    candidate = raw.strip()
+    lower = candidate.lower()
+    # iso639's resolvers are case-sensitive in different ways depending on
+    # the lookup (codes are lowercase, names are title-case) — try the
+    # likely shapes in order and stop at the first hit. The ``iso639``
+    # stubs are absent (see pyproject ``[tool.mypy.overrides]``), so
+    # ``Language`` calls return ``Any``; the explicit annotation pins it.
+    lang: iso639.Language | None = None
+    with contextlib.suppress(iso639.LanguageNotFoundError):
+        lang = iso639.Language.from_part3(lower)
+    if lang is None:
+        with contextlib.suppress(iso639.LanguageNotFoundError):
+            lang = iso639.Language.from_part1(lower)
+    if lang is None:
+        with contextlib.suppress(iso639.LanguageNotFoundError):
+            lang = iso639.Language.from_name(candidate)
+    if lang is None:
+        with contextlib.suppress(iso639.LanguageNotFoundError):
+            lang = iso639.Language.from_name(candidate.title())
+
+    if lang is None:
+        raise InvalidLanguageError(
+            f"Unknown ISO language: {raw!r} (not a 639-1 / 639-3 code or English name)"
+        )
+
+    # ``lang.part3`` is typed as ``Any`` (no iso639 stubs); SIL guarantees
+    # a 3-letter lowercase string. ``str(...)`` pins the type without a
+    # redundant cast and is a no-op on a real string.
+    canonical = str(lang.part3)
+    allowed = _get_allowed_codes()
+    if canonical not in allowed:
+        raise LanguageNotAllowedError(canonical, len(allowed))
+    return canonical
+
+
+def list_allowed() -> list[LanguageEntry]:
+    """Return the allowed languages enriched with English (and native) names.
+
+    The result is cached after the first call; reset by calling
+    ``get_language_registry(path=...)`` with an explicit path (used by
+    tests that swap fixtures).
+    """
+    global _allowed_entries
+    if _allowed_entries is not None:
+        return _allowed_entries
+    registry = get_language_registry()
+    entries: list[LanguageEntry] = []
+    for code in registry.languages:
+        lang = iso639.Language.from_part3(code)
+        # iso639 does not always expose a native-script name; fall back
+        # to None and let the UI render ``name_en``.
+        native = getattr(lang, "native", None) or None
+        entries.append(LanguageEntry(code=code, name_en=lang.name, name_native=native))
+    _allowed_entries = entries
+    return entries

--- a/tests/integration/test_nodes_serialization_regression.py
+++ b/tests/integration/test_nodes_serialization_regression.py
@@ -108,7 +108,7 @@ async def test_create_root_node_returns_serializable_response(
     """
     response = await node_client.post(
         "/api/v1/nodes",
-        json={"title": "Regression serialization probe"},
+        json={"title": "Regression serialization probe", "default_language": "uk"},
     )
     assert response.status_code == 201, response.text
 

--- a/tests/unit/test_api/test_authored_documents.py
+++ b/tests/unit/test_api/test_authored_documents.py
@@ -370,6 +370,83 @@ class TestCreateDocument:
         assert resp.status_code == 201
         assert resp.json()["filename"] == "notes.md"
 
+    async def test_language_639_1_normalized_to_639_3(
+        self, client: AsyncClient, node_id: uuid.UUID
+    ) -> None:
+        """Form-input 639-1 ``uk`` → canonical 639-3 ``ukr`` (Task 2.4.13)."""
+        captured: dict[str, object] = {}
+
+        async def fake_create(self: object, **kwargs: object) -> MagicMock:
+            captured.update(kwargs)
+            entry = _mock_entry(node_id=node_id)
+            entry.language = kwargs.get("language")
+            return entry
+
+        job = _mock_job()
+        with (
+            patch.object(
+                CourseNodeRepository,
+                "get_by_id",
+                return_value=_mock_node(node_id=node_id),
+            ),
+            patch.object(AuthoredDocumentRepository, "create", new=fake_create),
+            patch(ENQUEUE_FUNC, new_callable=AsyncMock, return_value=job),
+        ):
+            resp = await client.post(
+                f"/api/v1/nodes/{node_id}/documents",
+                data={
+                    "source_type": "text",
+                    "source_url": "https://example.com/doc.md",
+                    "language": "uk",
+                },
+            )
+        assert resp.status_code == 201
+        assert captured["language"] == "ukr"
+        assert resp.json()["language"] == "ukr"
+
+    async def test_language_invalid_returns_422(
+        self, client: AsyncClient, node_id: uuid.UUID
+    ) -> None:
+        """Form-input language not in the whitelist returns 422, not 500."""
+        with patch.object(
+            CourseNodeRepository,
+            "get_by_id",
+            return_value=_mock_node(node_id=node_id),
+        ):
+            resp = await client.post(
+                f"/api/v1/nodes/{node_id}/documents",
+                data={
+                    "source_type": "text",
+                    "source_url": "https://example.com/doc.md",
+                    "language": "xyz",
+                },
+            )
+        assert resp.status_code == 422
+
+    async def test_language_absent_succeeds(
+        self, client: AsyncClient, node_id: uuid.UUID
+    ) -> None:
+        """Optional ``language`` field — absence is accepted."""
+        entry = _mock_entry(node_id=node_id)
+        job = _mock_job()
+        with (
+            patch.object(
+                CourseNodeRepository,
+                "get_by_id",
+                return_value=_mock_node(node_id=node_id),
+            ),
+            patch.object(AuthoredDocumentRepository, "create", return_value=entry),
+            patch(ENQUEUE_FUNC, new_callable=AsyncMock, return_value=job),
+        ):
+            resp = await client.post(
+                f"/api/v1/nodes/{node_id}/documents",
+                data={
+                    "source_type": "text",
+                    "source_url": "https://example.com/doc.md",
+                },
+            )
+        assert resp.status_code == 201
+
 
 class TestPresentationSlideCountInspection:
     """KD-2.3-M -- _presentation_slide_count helper (HTTP-side, <=200 ms)."""

--- a/tests/unit/test_api/test_config.py
+++ b/tests/unit/test_api/test_config.py
@@ -1,0 +1,58 @@
+"""Tests for ``GET /api/v1/config/languages`` (Task 2.4.13)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from course_supporter.api.app import app
+from course_supporter.api.deps import get_current_tenant
+from course_supporter.auth.context import TenantContext
+
+STUB_TENANT = TenantContext(
+    tenant_id=uuid.uuid4(),
+    tenant_name="test-tenant",
+    scopes=["prep", "check"],
+    plan_id="basic",
+    key_prefix="cs_test",
+)
+
+
+@pytest.fixture()
+async def client() -> AsyncClient:
+    app.dependency_overrides[get_current_tenant] = lambda: STUB_TENANT
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac  # type: ignore[misc]
+    app.dependency_overrides.clear()
+
+
+class TestGetAllowedLanguages:
+    async def test_returns_57_items(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/v1/config/languages")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 57
+        assert len(body["items"]) == 57
+
+    async def test_each_item_has_iso_639_3_and_english_name(
+        self, client: AsyncClient
+    ) -> None:
+        resp = await client.get("/api/v1/config/languages")
+        for item in resp.json()["items"]:
+            assert isinstance(item["code"], str) and len(item["code"]) == 3
+            assert item["code"] == item["code"].lower()
+            assert isinstance(item["name_en"], str) and item["name_en"]
+            # name_native is optional (iso639 does not always carry it).
+            assert "name_native" in item
+
+    async def test_includes_ukrainian_and_cantonese(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/v1/config/languages")
+        codes = {item["code"]: item for item in resp.json()["items"]}
+        assert codes["ukr"]["name_en"] == "Ukrainian"
+        # Cantonese (yue) — only reachable via 639-3; sanity-check it is in.
+        assert "yue" in codes

--- a/tests/unit/test_api/test_nodes.py
+++ b/tests/unit/test_api/test_nodes.py
@@ -98,20 +98,26 @@ async def client(
 
 
 class TestCreateRootNode:
-    """POST /api/v1/nodes"""
+    """POST /api/v1/nodes — Task 2.4.13 makes ``default_language`` required."""
 
     async def test_returns_201(self, client: AsyncClient) -> None:
         """Successful root node creation returns 201."""
         node = _mock_node()
         with patch.object(CourseNodeRepository, "create", return_value=node):
-            resp = await client.post("/api/v1/nodes", json={"title": "Module 1"})
+            resp = await client.post(
+                "/api/v1/nodes",
+                json={"title": "Module 1", "default_language": "uk"},
+            )
         assert resp.status_code == 201
 
     async def test_returns_node_fields(self, client: AsyncClient) -> None:
         """Response contains all expected node fields."""
         node = _mock_node(title="Module 1")
         with patch.object(CourseNodeRepository, "create", return_value=node):
-            resp = await client.post("/api/v1/nodes", json={"title": "Module 1"})
+            resp = await client.post(
+                "/api/v1/nodes",
+                json={"title": "Module 1", "default_language": "uk"},
+            )
         data = resp.json()
         assert data["id"] == str(node.id)
         assert data["title"] == "Module 1"
@@ -125,20 +131,78 @@ class TestCreateRootNode:
         node = _mock_node(description="Details")
         with patch.object(CourseNodeRepository, "create", return_value=node):
             resp = await client.post(
-                "/api/v1/nodes", json={"title": "Mod", "description": "Details"}
+                "/api/v1/nodes",
+                json={
+                    "title": "Mod",
+                    "description": "Details",
+                    "default_language": "uk",
+                },
             )
         assert resp.status_code == 201
         assert resp.json()["description"] == "Details"
 
     async def test_empty_title_returns_422(self, client: AsyncClient) -> None:
         """Empty title is rejected with 422."""
-        resp = await client.post("/api/v1/nodes", json={"title": ""})
+        resp = await client.post(
+            "/api/v1/nodes", json={"title": "", "default_language": "uk"}
+        )
         assert resp.status_code == 422
 
     async def test_missing_title_returns_422(self, client: AsyncClient) -> None:
         """Missing title is rejected with 422."""
-        resp = await client.post("/api/v1/nodes", json={})
+        resp = await client.post("/api/v1/nodes", json={"default_language": "uk"})
         assert resp.status_code == 422
+
+    async def test_missing_default_language_returns_422(
+        self, client: AsyncClient
+    ) -> None:
+        """Root creation without ``default_language`` is rejected (Task 2.4.13)."""
+        resp = await client.post("/api/v1/nodes", json={"title": "Module 1"})
+        assert resp.status_code == 422
+        # Field-error must mention default_language somewhere.
+        body = resp.json()
+        assert any(
+            "default_language" in str(loc)
+            for err in body.get("detail", [])
+            for loc in err.get("loc", [])
+        )
+
+    async def test_invalid_default_language_returns_422(
+        self, client: AsyncClient
+    ) -> None:
+        """Unknown ISO code is rejected with 422."""
+        resp = await client.post(
+            "/api/v1/nodes",
+            json={"title": "Module 1", "default_language": "xyz"},
+        )
+        assert resp.status_code == 422
+
+    async def test_valid_iso_not_in_whitelist_returns_422(
+        self, client: AsyncClient
+    ) -> None:
+        """Valid ISO but not whitelisted (e.g. Latin ``lat``) returns 422."""
+        resp = await client.post(
+            "/api/v1/nodes",
+            json={"title": "Module 1", "default_language": "lat"},
+        )
+        assert resp.status_code == 422
+
+    async def test_normalizes_language_to_iso_639_3(self, client: AsyncClient) -> None:
+        """Helper converts 639-1 / English-name input to canonical 639-3."""
+        node = _mock_node()
+        captured: dict[str, str] = {}
+
+        async def fake_create(self: object, **kwargs: object) -> MagicMock:
+            captured.update({k: str(v) for k, v in kwargs.items()})
+            return node
+
+        with patch.object(CourseNodeRepository, "create", new=fake_create):
+            resp = await client.post(
+                "/api/v1/nodes",
+                json={"title": "Module 1", "default_language": "Ukrainian"},
+            )
+        assert resp.status_code == 201
+        assert captured["default_language"] == "ukr"
 
 
 class TestCreateChildNode:
@@ -281,6 +345,66 @@ class TestUpdateNode:
                 f"/api/v1/nodes/{uuid.uuid4()}", json={"title": "New"}
             )
         assert resp.status_code == 404
+
+    async def test_root_set_language_null_returns_422(
+        self, client: AsyncClient
+    ) -> None:
+        """Clearing ``default_language`` on a root node is rejected (Task 2.4.13)."""
+        root = _mock_node(parent_id=None)
+        with patch.object(CourseNodeRepository, "get_by_id", return_value=root):
+            resp = await client.patch(
+                f"/api/v1/nodes/{root.id}", json={"default_language": None}
+            )
+        assert resp.status_code == 422
+        assert "root" in resp.json()["detail"].lower()
+
+    async def test_child_set_language_null_returns_200(
+        self, client: AsyncClient
+    ) -> None:
+        """Clearing ``default_language`` on a child node is allowed."""
+        child = _mock_node(parent_id=uuid.uuid4())
+        updated = _mock_node(parent_id=child.parent_id)
+        with (
+            patch.object(CourseNodeRepository, "get_by_id", return_value=child),
+            patch.object(CourseNodeRepository, "update", return_value=updated),
+        ):
+            resp = await client.patch(
+                f"/api/v1/nodes/{child.id}", json={"default_language": None}
+            )
+        assert resp.status_code == 200
+
+    async def test_update_language_invalid_returns_422(
+        self, client: AsyncClient
+    ) -> None:
+        """Membership validator rejects unknown codes on update."""
+        node = _mock_node()
+        with patch.object(CourseNodeRepository, "get_by_id", return_value=node):
+            resp = await client.patch(
+                f"/api/v1/nodes/{node.id}", json={"default_language": "xyz"}
+            )
+        assert resp.status_code == 422
+
+    async def test_update_language_normalized(self, client: AsyncClient) -> None:
+        """Updating with a 639-1 code persists the 639-3 form."""
+        node = _mock_node(parent_id=uuid.uuid4())  # child — null allowed/needed-no
+        updated = _mock_node()
+        captured: dict[str, object] = {}
+
+        async def fake_update(
+            self: object, _nid: uuid.UUID, **kwargs: object
+        ) -> MagicMock:
+            captured.update(kwargs)
+            return updated
+
+        with (
+            patch.object(CourseNodeRepository, "get_by_id", return_value=node),
+            patch.object(CourseNodeRepository, "update", new=fake_update),
+        ):
+            resp = await client.patch(
+                f"/api/v1/nodes/{node.id}", json={"default_language": "en"}
+            )
+        assert resp.status_code == 200
+        assert captured["default_language"] == "eng"
 
 
 class TestMoveNode:

--- a/tests/unit/test_language.py
+++ b/tests/unit/test_language.py
@@ -1,0 +1,85 @@
+"""Tests for ``course_supporter.language`` (Task 2.4.13)."""
+
+from __future__ import annotations
+
+import pytest
+
+from course_supporter.language import (
+    InvalidLanguageError,
+    LanguageNotAllowedError,
+    list_allowed,
+    normalize_and_validate,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("uk", "ukr"),
+        ("UK", "ukr"),  # case-insensitive 639-1
+        ("ukr", "ukr"),  # already 639-3
+        ("UKR", "ukr"),
+        ("Ukrainian", "ukr"),  # English name
+        ("ukrainian", "ukr"),  # name, lowercased
+        ("en", "eng"),
+        ("eng", "eng"),
+        ("English", "eng"),
+        ("yue", "yue"),  # Cantonese — no 639-1; only 639-3 form exists
+    ],
+)
+def test_normalize_happy_path(raw: str, expected: str) -> None:
+    assert normalize_and_validate(raw) == expected
+
+
+@pytest.mark.parametrize("bad", ["xyz", "", "  ", "not-a-language", "12"])
+def test_normalize_invalid_raises_invalid_language_error(bad: str) -> None:
+    with pytest.raises(InvalidLanguageError):
+        normalize_and_validate(bad)
+
+
+def test_normalize_valid_iso_but_not_in_whitelist() -> None:
+    # Latin (lat) is a valid ISO 639-3 language not in our whitelist.
+    with pytest.raises(LanguageNotAllowedError) as exc_info:
+        normalize_and_validate("lat")
+    assert exc_info.value.code == "lat"
+    assert exc_info.value.allowed_count == 57
+
+
+def test_chinese_macrolanguage_zh_is_rejected() -> None:
+    # ``zh`` (Chinese macrolanguage) resolves to ``zho`` per iso639 — but
+    # the whitelist only carries the specific variant ``cmn`` (Mandarin).
+    # Authors must pick the variant explicitly; macrolanguage is not allowed.
+    with pytest.raises(LanguageNotAllowedError) as exc_info:
+        normalize_and_validate("zh")
+    assert exc_info.value.code == "zho"
+
+
+def test_list_allowed_returns_57_entries_with_english_names() -> None:
+    entries = list_allowed()
+    assert len(entries) == 57
+
+    codes = [e.code for e in entries]
+    # Every code must be unique 3-letter lowercase.
+    assert len(set(codes)) == 57
+    for code in codes:
+        assert len(code) == 3
+        assert code == code.lower()
+
+    # English names are always present (iso639 SIL table).
+    for entry in entries:
+        assert entry.name_en
+        assert isinstance(entry.name_en, str)
+
+    # Sanity: Ukrainian is in the list with the expected English name.
+    by_code = {e.code: e for e in entries}
+    assert by_code["ukr"].name_en == "Ukrainian"
+    assert by_code["eng"].name_en == "English"
+    # Cantonese is in (no 639-1 — only reachable via 639-3 form).
+    assert "yue" in by_code
+
+
+def test_list_allowed_is_cached_across_calls() -> None:
+    first = list_allowed()
+    second = list_allowed()
+    # Same Python object → cache hit.
+    assert first is second

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -164,20 +164,20 @@ class TestRateLimitAPI:
                         # First 2 requests should pass (limit=2)
                         r1 = await client.post(
                             "/api/v1/nodes",
-                            json={"title": "Node 1"},
+                            json={"title": "Node 1", "default_language": "uk"},
                         )
                         assert r1.status_code == 201
 
                         r2 = await client.post(
                             "/api/v1/nodes",
-                            json={"title": "Node 2"},
+                            json={"title": "Node 2", "default_language": "uk"},
                         )
                         assert r2.status_code == 201
 
                         # Third request should be rate limited
                         r3 = await client.post(
                             "/api/v1/nodes",
-                            json={"title": "Node 3"},
+                            json={"title": "Node 3", "default_language": "uk"},
                         )
                         assert r3.status_code == 429
                         assert r3.json()["detail"] == "Rate limit exceeded"

--- a/tests/unit/test_scope_enforcement.py
+++ b/tests/unit/test_scope_enforcement.py
@@ -71,7 +71,7 @@ class TestScopeEnforcement:
                 ):
                     response = await client.post(
                         "/api/v1/nodes",
-                        json={"title": "Test Node"},
+                        json={"title": "Test Node", "default_language": "uk"},
                     )
             assert response.status_code == 201
         finally:
@@ -92,7 +92,7 @@ class TestScopeEnforcement:
             ) as client:
                 response = await client.post(
                     "/api/v1/nodes",
-                    json={"title": "Test Node"},
+                    json={"title": "Test Node", "default_language": "uk"},
                 )
             assert response.status_code == 403
             assert "Requires scope: prep" in response.json()["detail"]
@@ -183,7 +183,7 @@ class TestScopeEnforcement:
                 ):
                     resp_prep = await client.post(
                         "/api/v1/nodes",
-                        json={"title": "Test"},
+                        json={"title": "Test", "default_language": "uk"},
                     )
                 assert resp_prep.status_code == 201
 


### PR DESCRIPTION
## Summary

Phase 2.4 RUN_SMOKE #2 prep, **task A** (entry-gate for Pass 2a language pinning in task-14). Backend half — UI PR ships separately after this merge + `refactoring-vision/api-contracts/` openapi sync.

**Behavior change:** course `default_language` is now **required** at creation (root nodes only); storage format becomes **ISO 639-3** (canonical); validation against the 57-language whitelist in `config/languages.yaml`.

## Architecture (ratified vision-side 2026-06-02)

1. **NOT NULL only on ROOT** via CHECK constraint `parent_id IS NOT NULL OR default_language IS NOT NULL`. Children remain nullable — their language is dead-data; runtime inheritance always reads `get_root_for` (`api/tasks.py:185`).
2. **Backfill silent `'ukr'`** for root NULLs (operator-ratified: all existing courses Ukrainian).
3. **ISO 639-3 storage** — represents languages without a 639-1 code (yue/fil/cmn). Migration converts existing 639-1 → 639-3 via inline map (no app-code import per corrective 2 — migration stays self-contained).
4. **Allowed set (57 codes)** in `config/languages.yaml` — ElevenLabs Scribe WER-tier Excellent + High (≤10% WER, verified 2026-06-02).
5. **Single helper** `src/course_supporter/language.py` (flat top-level module per cross-cutting convention with `config.py` / `errors.py` / `key_pool.py`) normalizes 639-1 / 639-3 / English name → canonical 639-3.
6. **`python-iso639`** (Apache-2.0, SIL-backed) already in `pyproject.toml` — zero dep change.
7. **Pydantic split:** `RootNodeCreateRequest` (required) / `ChildNodeCreateRequest` (optional). PATCH route-side rejects `default_language: null` on root with 422 (CHECK never surfaces as 500).
8. **`GET /api/v1/config/languages`** serves the whitelist as UI single source of truth.

## STT auto-detect cache

`api/tasks.py:370-389` wraps `detected_language` through `normalize_and_validate` with **warn-log + skip-cache on failure** (STT is a black-box external signal; ingestion authority is the root language). Inheritance write (`tasks.py:185-187`) copies root → entry without re-normalizing (root is already 639-3 after migration).

## Files (15)

**New:**
- `config/languages.yaml` (57-language whitelist + docstring shape mirroring `platforms.yaml`).
- `src/course_supporter/language.py` (helper + Pydantic registry + module-cache).
- `src/course_supporter/api/routes/config.py` (GET endpoint).
- `migrations/versions/phase24_root_lang_required.py` (Alembic).
- `tests/unit/test_language.py` (19 cases — happy path / invalid ISO / not-in-whitelist / cache).
- `tests/unit/test_api/test_config.py` (endpoint contract).

**Modified:**
- `src/course_supporter/config.py` — `language_registry_path` setting.
- `src/course_supporter/api/schemas.py` — split create-schemas + validator + `AllowedLanguagesResponse`.
- `src/course_supporter/api/routes/nodes.py` — split create handlers + PATCH route-side 422 for root null.
- `src/course_supporter/api/tasks.py` — STT cache normalization wrapper.
- `src/course_supporter/api/app.py` — config router registration.
- `tests/unit/test_api/test_nodes.py` — extended (4 existing + 4 new create tests + 4 new patch tests).
- `tests/unit/test_rate_limiter.py`, `tests/unit/test_scope_enforcement.py`, `tests/integration/test_nodes_serialization_regression.py` — payloads updated to send `default_language: "uk"`.

## Out of scope (NOT touched)

- Pass 2a render-context / prompts (task-14 / B).
- `PresentationSegment` concepts schema (task-15 / C).
- Cascade multi-language subtree — children stay dead-data nullable.
- Ladder configs, video_pipeline code paths, UI.

## Test plan

- [x] `ruff check` + `ruff format` clean (pre-commit + targeted).
- [x] `mypy --strict` clean (128 src files, 0 errors).
- [x] `pytest tests/unit/` — **1951 passed, 5 skipped** (zero regressions, +20 new assertions for new behaviour).
- [x] **Migration upgrade applied to local DB:** 1 NULL root → `'ukr'`, 1 `'uk'` root → `'ukr'`, 3 `'uk'` children → `'ukr'`; CHECK enforced (verified by direct NULL-root INSERT — rejected with constraint violation).
- [x] **Migration downgrade round-trip:** `'ukr'` → `'uk'` reverse-mapped; backfilled NULLs irreversible (documented).
- [x] **`GET /api/v1/config/languages`** returns 200 with 57 items, each `{code, name_en, name_native?}`.
- [ ] `--run-db` integration suite — NOT executed per task §Acceptance (config-only data changes for ingestion; targeted integration covered by `test_nodes_serialization_regression.py` adjustment).
- [ ] **Operator post-merge:** update `refactoring-vision/api-contracts/<phase>.openapi.yaml` with new schemas + endpoint, then UI PR `task-2-4-13-course-language-required-ui` proceeds.

## Coordination

UI PR (`course-supporter-ui`) is **held until this merges + openapi sync**. Per UI CLAUDE.md §"API contract is the integration point" — UI fetches `/api/v1/config/languages`, removes hardcoded 8-language list (`utils/languages.ts`), enforces submit-blocked-without-language. Short stale-endpoint window in UI dev between merges is non-blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)