### PR TITLE
task(2.4.13B): root-CourseNode test factory — hotfix for CHECK fallout

### DIFF
--- a/tests/_helpers/course_node_factory.py
+++ b/tests/_helpers/course_node_factory.py
@@ -57,6 +57,7 @@ sites pick up the new shape atomically.
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 from course_supporter.storage.orm import CourseNode
@@ -64,7 +65,7 @@ from course_supporter.storage.orm import CourseNode
 
 def make_root_course_node(
     *,
-    tenant_id: Any,
+    tenant_id: uuid.UUID,
     default_language: str = "ukr",
     **overrides: Any,
 ) -> CourseNode:

--- a/tests/_helpers/course_node_factory.py
+++ b/tests/_helpers/course_node_factory.py
@@ -1,0 +1,114 @@
+"""Root-CourseNode test factory (task 2.4.13B fixture-fallout hotfix).
+
+Single point of truth for the **root** branch of test
+``CourseNode`` setup. After task 2.4.13 landed CHECK constraint
+``course_nodes_root_language_required`` (``parent_id IS NOT NULL OR
+default_language IS NOT NULL``), any fixture or test setup that
+builds a root ``CourseNode`` (``parent_id=None``) without
+``default_language`` violates the CHECK on commit/flush. Per
+2.4.13 рішення 1, that is the intended behaviour — root without
+explicit language is data the system must reject.
+
+This factory exists so the dozen test-setup sites that need a
+root node express that intent uniformly (default canonical
+``"ukr"`` mirroring the migration backfill in
+``phase24_root_lang_required``) and so a future fourteenth test
+cannot quietly recreate the bug by forgetting the field. The
+factory mirrors task 2.4.13 рішення 5 («helper — єдина точка
+мовної логіки») at the test-fixture layer.
+
+Consumers:
+
+- ``tests/integration/conftest.py`` — central ``seed_root_node`` /
+  ``committed_seeds`` fixtures (high-leverage path: many failing
+  tests reach the CHECK through these fixtures, not through a
+  direct ``CourseNode()``).
+- ``tests/integration/test_content_hash_persistence.py``,
+  ``tests/integration/test_cost_endpoints_db.py``,
+  ``tests/integration/test_external_service_call_db.py``,
+  ``tests/integration/test_job_cancellation_service_db.py``,
+  ``tests/integration/test_job_redesign_db.py``,
+  ``tests/integration/test_material_node_repository_db.py``,
+  ``tests/storage/test_authored_document_repository.py``,
+  ``tests/storage/test_cascade_invalidation.py``,
+  ``tests/storage/test_cascade_kd_alpha.py``,
+  ``tests/storage/test_get_subtree_active_documents.py``,
+  ``tests/storage/test_get_subtree_tenant_isolation.py`` — files
+  with their own root-setup constructions.
+
+Scope discipline (task 2.4.13B рішення 2-3):
+
+- **ROOT ONLY.** Child nodes (``parent_id`` set) satisfy the
+  CHECK structurally and do not need a language — per task 2.4.13
+  child ``default_language`` is dead data. Callers that build
+  children keep using raw ``CourseNode(...)``; this factory does
+  not have a child counterpart on purpose (minimum surface).
+- **NOT for subject-under-test.** Unit tests that exercise the
+  ``CourseNode`` model itself (``tests/unit/test_material_node.py``,
+  ``tests/unit/test_tenant_isolation.py``) construct
+  ``CourseNode`` directly as the subject of the assertion, never
+  commit, and so never trip the CHECK. They stay raw — wrapping
+  them via this factory would obscure what they are testing.
+
+Update this module on contract changes (e.g. ``default_language``
+column rename or a different canonical default); all consumer
+sites pick up the new shape atomically.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from course_supporter.storage.orm import CourseNode
+
+
+def make_root_course_node(
+    *,
+    tenant_id: Any,
+    default_language: str = "ukr",
+    **overrides: Any,
+) -> CourseNode:
+    """Build a root ``CourseNode`` instance with ``default_language`` set.
+
+    Returns an unflushed, unattached SQLAlchemy instance — caller
+    decides session, ``session.add`` / ``session.flush`` / commit
+    discipline so this helper composes with both savepoint-only
+    (``db_session`` / ``seed_root_node``) and committed
+    (``committed_seeds``) fixture patterns.
+
+    Args:
+        tenant_id: Owning ``Tenant.id``. Required keyword.
+        default_language: Canonical ISO 639-3 code. Defaults to
+            ``"ukr"`` to match the migration backfill in
+            ``phase24_root_lang_required`` (the same default the
+            production whitelist treats as the canonical Ukrainian
+            form). Override per-call when the test needs a
+            specific language (e.g. ``default_language="eng"`` for
+            an English-course scenario).
+        **overrides: Any other ``CourseNode`` constructor kwarg
+            (``id``, ``title``, ``description``, ``order``,
+            ``content_hash``). ``parent_id`` is fixed to ``None``
+            — by construction this is a root factory; if a test
+            needs a child node it should use ``CourseNode(...)``
+            directly with the parent it cares about.
+
+    Raises:
+        TypeError: when ``overrides`` carries ``parent_id`` —
+            callers asking for a child have reached the wrong
+            factory and we surface that loudly rather than
+            silently flipping the node to a child.
+    """
+    if "parent_id" in overrides:
+        raise TypeError(
+            "make_root_course_node does not accept parent_id — this "
+            "factory is root-specific (task 2.4.13B рішення 2). For a "
+            "child node, construct CourseNode(...) directly with the "
+            "parent_id you need; the CHECK constraint does not apply "
+            "to child nodes."
+        )
+    return CourseNode(
+        tenant_id=tenant_id,
+        parent_id=None,
+        default_language=default_language,
+        **overrides,
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import (
 
 from course_supporter.config import get_settings
 from course_supporter.storage.orm import AuthoredDocument, CourseNode, Job, Tenant
+from tests._helpers.course_node_factory import make_root_course_node
 
 # ── Engine (module-scoped, shared across test module) ──────────────
 
@@ -88,7 +89,7 @@ async def seed_tenant(db_session: AsyncSession) -> Tenant:
 @pytest.fixture()
 async def seed_root_node(db_session: AsyncSession, seed_tenant: Tenant) -> CourseNode:
     """Create a root CourseNode linked to seed_tenant."""
-    node = CourseNode(
+    node = make_root_course_node(
         tenant_id=seed_tenant.id,
         title="Integration Test Course",
         order=0,
@@ -134,7 +135,7 @@ async def committed_seeds(
         session.add(tenant)
         await session.flush()
 
-        node = CourseNode(
+        node = make_root_course_node(
             tenant_id=tenant.id,
             title="E2E Test Course",
             order=0,

--- a/tests/integration/test_arq_task_e2e.py
+++ b/tests/integration/test_arq_task_e2e.py
@@ -173,22 +173,45 @@ class TestArqIngestMaterialE2E:
     @pytest.mark.parametrize(
         ("detected_language", "expected_language"),
         [
-            pytest.param(None, None, id="no_detection"),
-            pytest.param("uk", "uk", id="with_detection_cached"),
+            pytest.param(None, "ukr", id="no_detection"),
+            pytest.param("uk", "ukr", id="with_detection_cached"),
         ],
     )
-    async def test_success_full_lifecycle(
+    async def test_inheritance_dominates_over_stt_detection(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         committed_seeds: dict[str, uuid.UUID],
         detected_language: str | None,
         expected_language: str | None,
     ) -> None:
-        """Full success: queued->complete, pending->done, content set.
+        """In a rooted course STT-detected language does NOT override
+        the course language — the root is the authority (task 2.4.13).
 
-        Also covers the STT auto-detect language cache: when the
-        processor reports ``detected_language``, it is persisted to
-        ``AuthoredDocument.language`` (entries seeded with language=NULL).
+        Pre-task-2.4.13 this test exercised the STT auto-detect
+        cache-back path: an entry seeded with ``language=NULL`` would
+        inherit nothing from the root (root could have NULL language),
+        the STT call would surface a detection, and
+        ``set_language_if_unset`` would persist it. After task 2.4.13
+        landed the CHECK ``course_nodes_root_language_required`` and
+        the entry/root inheritance block in ``api/tasks.py``, the
+        cache-back path is unreachable on a rooted course:
+
+        * the root **always** has a ``default_language`` (CHECK
+          guaranteed), so inheritance fires before STT runs and the
+          entry is persisted with the root's language;
+        * ``set_language_if_unset`` then sees a non-NULL language and
+          is a no-op regardless of whether STT detected anything.
+
+        Both parametrisations therefore converge on the root's
+        language (``"ukr"`` per the ``committed_seeds`` fixture
+        default, mirroring the production CHECK-required value). The
+        test now locks the inheritance-dominates invariant from task
+        2.4.13 рішення 1.
+
+        The orchestrator still calls ``set_language_if_unset`` and
+        still reads ``detected_language`` — that code path is
+        vestigial post-2.4.13 (DD-2.4-N) and is left for a separate
+        cleanup task; this hotfix is tests-only.
         """
         mid = committed_seeds["material_id"]
         tid = committed_seeds["tenant_id"]

--- a/tests/integration/test_content_hash_persistence.py
+++ b/tests/integration/test_content_hash_persistence.py
@@ -30,6 +30,7 @@ from course_supporter.storage.orm import (
     DocumentSummary,
     Tenant,
 )
+from tests._helpers.course_node_factory import make_root_course_node
 
 pytestmark = pytest.mark.requires_db
 
@@ -51,11 +52,18 @@ async def _make_node(
     parent_id: uuid.UUID | None = None,
     title: str = "node",
 ) -> CourseNode:
-    node = CourseNode(
-        tenant_id=tenant_id,
-        parent_id=parent_id,
-        title=title,
-    )
+    # Task 2.4.13B — route the root branch through ``make_root_course_node``
+    # so its CHECK-satisfying ``default_language`` default lands here too.
+    # Child branch stays raw (CHECK does not apply when parent_id is set;
+    # child language is dead data per task 2.4.13 рішення 1).
+    if parent_id is None:
+        node = make_root_course_node(tenant_id=tenant_id, title=title)
+    else:
+        node = CourseNode(
+            tenant_id=tenant_id,
+            parent_id=parent_id,
+            title=title,
+        )
     session.add(node)
     await session.flush()
     return node
@@ -371,7 +379,9 @@ class TestCreateMaterializesContentHash:
         """Brand-new CourseNode has empty-Merkle hash, not NULL."""
         tenant = await _make_tenant(db_session)
         repo = CourseNodeRepository(db_session)
-        node = await repo.create(tenant_id=tenant.id, title="freshly-created")
+        node = await repo.create(
+            tenant_id=tenant.id, title="freshly-created", default_language="ukr"
+        )
         await db_session.refresh(node)
 
         # New empty node = no AuthoredDocs + no child CourseNodes →
@@ -389,7 +399,9 @@ class TestCreateMaterializesContentHash:
         """Brand-new AuthoredDocument has materialised hash + parent hash recomputed."""
         tenant = await _make_tenant(db_session)
         node_repo = CourseNodeRepository(db_session)
-        node = await node_repo.create(tenant_id=tenant.id, title="parent")
+        node = await node_repo.create(
+            tenant_id=tenant.id, title="parent", default_language="ukr"
+        )
         await db_session.refresh(node)
         node_hash_before_doc = node.content_hash
 

--- a/tests/integration/test_cost_endpoints_db.py
+++ b/tests/integration/test_cost_endpoints_db.py
@@ -40,6 +40,7 @@ from course_supporter.storage.orm import (
     Tenant,
 )
 from course_supporter.storage.repositories import ExternalServiceCallRepository
+from tests._helpers.course_node_factory import make_root_course_node
 
 pytestmark = [pytest.mark.requires_db, pytest.mark.requires_redis]
 
@@ -94,7 +95,9 @@ async def cost_seed(
         session.add(tenant)
         await session.flush()
 
-        root = CourseNode(tenant_id=tenant.id, title="Python Basics", order=0)
+        root = make_root_course_node(
+            tenant_id=tenant.id, title="Python Basics", order=0
+        )
         session.add(root)
         await session.flush()
         lesson = CourseNode(
@@ -447,7 +450,9 @@ class TestCostCourseE2E:
             other = Tenant(name=f"other-{uuid.uuid4().hex[:6]}")
             session.add(other)
             await session.flush()
-            other_node = CourseNode(tenant_id=other.id, title="Other Course", order=0)
+            other_node = make_root_course_node(
+                tenant_id=other.id, title="Other Course", order=0
+            )
             session.add(other_node)
             await session.commit()
             other_node_id = other_node.id

--- a/tests/integration/test_external_service_call_db.py
+++ b/tests/integration/test_external_service_call_db.py
@@ -19,11 +19,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from course_supporter.config import get_settings
 from course_supporter.storage.orm import (
-    CourseNode,
     ExternalServiceCall,
     Job,
     Tenant,
 )
+from tests._helpers.course_node_factory import make_root_course_node
 
 pytestmark = pytest.mark.requires_db
 
@@ -101,7 +101,7 @@ class TestForeignKeyEnforcement:
         tenant = Tenant(name=f"esc-{uuid.uuid4().hex[:6]}")
         db_session.add(tenant)
         await db_session.flush()
-        node = CourseNode(tenant_id=tenant.id, title="course", order=0)
+        node = make_root_course_node(tenant_id=tenant.id, title="course", order=0)
         db_session.add(node)
         await db_session.flush()
         job = Job(tenant_id=tenant.id, course_node_id=node.id, job_type="ingest")

--- a/tests/integration/test_job_cancellation_service_db.py
+++ b/tests/integration/test_job_cancellation_service_db.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from course_supporter.jobs.cancellation_service import JobCancellationService
 from course_supporter.storage.orm import CourseNode, Job, Tenant
+from tests._helpers.course_node_factory import make_root_course_node
 
 pytestmark = pytest.mark.requires_db
 
@@ -34,8 +35,8 @@ async def _seed_two_tenants_two_nodes(
     t2 = Tenant(name=f"jcs-t2-{uuid.uuid4().hex[:6]}")
     session.add_all([t1, t2])
     await session.flush()
-    n1 = CourseNode(tenant_id=t1.id, title="n1", order=0)
-    n2 = CourseNode(tenant_id=t2.id, title="n2", order=0)
+    n1 = make_root_course_node(tenant_id=t1.id, title="n1", order=0)
+    n2 = make_root_course_node(tenant_id=t2.id, title="n2", order=0)
     session.add_all([n1, n2])
     await session.flush()
     return t1, t2, n1, n2

--- a/tests/integration/test_job_redesign_db.py
+++ b/tests/integration/test_job_redesign_db.py
@@ -29,7 +29,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from course_supporter.config import get_settings
-from course_supporter.storage.orm import CourseNode, Job, Tenant
+from course_supporter.storage.orm import Job, Tenant
+from tests._helpers.course_node_factory import make_root_course_node
 
 pytestmark = pytest.mark.requires_db
 
@@ -177,7 +178,7 @@ class TestForeignKeyEnforcement:
         tenant = Tenant(name=f"jrd-{uuid.uuid4().hex[:6]}")
         db_session.add(tenant)
         await db_session.flush()
-        node = CourseNode(tenant_id=tenant.id, title="n", order=0)
+        node = make_root_course_node(tenant_id=tenant.id, title="n", order=0)
         db_session.add(node)
         await db_session.flush()
         job = Job(

--- a/tests/integration/test_material_node_repository_db.py
+++ b/tests/integration/test_material_node_repository_db.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -43,13 +44,13 @@ class TestSortOrder:
         """
         base = datetime.now(UTC) - timedelta(hours=1)
 
-        def _make(**kwargs: object) -> CourseNode:
+        def _make(**kwargs: Any) -> CourseNode:
             # Task 2.4.13B — route root siblings through the factory
             # (CHECK ``default_language`` lands here); children stay raw
             # (task 2.4.13 рішення 1 — child language is dead data).
             if parent_id is None:
-                return make_root_course_node(tenant_id=tenant_id, **kwargs)  # type: ignore[arg-type]
-            return CourseNode(tenant_id=tenant_id, parent_id=parent_id, **kwargs)  # type: ignore[arg-type]
+                return make_root_course_node(tenant_id=tenant_id, **kwargs)
+            return CourseNode(tenant_id=tenant_id, parent_id=parent_id, **kwargs)
 
         siblings = {
             "ordered_first": _make(

--- a/tests/integration/test_material_node_repository_db.py
+++ b/tests/integration/test_material_node_repository_db.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from course_supporter.storage.course_node_repository import CourseNodeRepository
 from course_supporter.storage.orm import CourseNode, Tenant
+from tests._helpers.course_node_factory import make_root_course_node
 
 pytestmark = pytest.mark.requires_db
 
@@ -41,31 +42,32 @@ class TestSortOrder:
             4. NULL order, created latest
         """
         base = datetime.now(UTC) - timedelta(hours=1)
+
+        def _make(**kwargs: object) -> CourseNode:
+            # Task 2.4.13B — route root siblings through the factory
+            # (CHECK ``default_language`` lands here); children stay raw
+            # (task 2.4.13 рішення 1 — child language is dead data).
+            if parent_id is None:
+                return make_root_course_node(tenant_id=tenant_id, **kwargs)  # type: ignore[arg-type]
+            return CourseNode(tenant_id=tenant_id, parent_id=parent_id, **kwargs)  # type: ignore[arg-type]
+
         siblings = {
-            "ordered_first": CourseNode(
-                tenant_id=tenant_id,
-                parent_id=parent_id,
+            "ordered_first": _make(
                 title="ordered_first",
                 order=0,
                 created_at=base,
             ),
-            "ordered_second": CourseNode(
-                tenant_id=tenant_id,
-                parent_id=parent_id,
+            "ordered_second": _make(
                 title="ordered_second",
                 order=2,
                 created_at=base + timedelta(minutes=20),
             ),
-            "null_old": CourseNode(
-                tenant_id=tenant_id,
-                parent_id=parent_id,
+            "null_old": _make(
                 title="null_old",
                 order=None,
                 created_at=base + timedelta(minutes=5),
             ),
-            "null_new": CourseNode(
-                tenant_id=tenant_id,
-                parent_id=parent_id,
+            "null_new": _make(
                 title="null_new",
                 order=None,
                 created_at=base + timedelta(minutes=40),

--- a/tests/storage/test_authored_document_repository.py
+++ b/tests/storage/test_authored_document_repository.py
@@ -41,6 +41,7 @@ from course_supporter.storage.authored_document_repository import (
     AuthoredDocumentRepository,
 )
 from course_supporter.storage.orm import AuthoredDocument, CourseNode, Job, Tenant
+from tests._helpers.course_node_factory import make_root_course_node
 
 
 @pytest.fixture(scope="module")
@@ -89,13 +90,24 @@ async def _make_node(
     parent_id: uuid.UUID | None,
     title: str,
 ) -> CourseNode:
-    node = CourseNode(
-        id=uuid.uuid4(),
-        tenant_id=tenant_id,
-        parent_id=parent_id,
-        title=title,
-        order=0,
-    )
+    # Task 2.4.13B — root branch routes through the factory so the
+    # CHECK-satisfying ``default_language`` lands here. Child branch
+    # stays raw (task 2.4.13 рішення 1 — child language is dead data).
+    if parent_id is None:
+        node = make_root_course_node(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            title=title,
+            order=0,
+        )
+    else:
+        node = CourseNode(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            parent_id=parent_id,
+            title=title,
+            order=0,
+        )
     session.add(node)
     await session.flush()
     return node

--- a/tests/storage/test_cascade_invalidation.py
+++ b/tests/storage/test_cascade_invalidation.py
@@ -61,6 +61,7 @@ from course_supporter.storage.orm import (
     Job,
     Tenant,
 )
+from tests._helpers.course_node_factory import make_root_course_node
 from tests._helpers.kd3_marker import assert_marker_recent
 
 # ── Unit-level: scrub_authored_document field semantics ───────────
@@ -246,13 +247,24 @@ async def _make_node(
     parent_id: uuid.UUID | None,
     title: str,
 ) -> CourseNode:
-    node = CourseNode(
-        id=uuid.uuid4(),
-        tenant_id=tenant_id,
-        parent_id=parent_id,
-        title=title,
-        order=0,
-    )
+    # Task 2.4.13B — root branch routes through the factory so the
+    # CHECK-satisfying ``default_language`` lands here. Child branch
+    # stays raw (task 2.4.13 рішення 1 — child language is dead data).
+    if parent_id is None:
+        node = make_root_course_node(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            title=title,
+            order=0,
+        )
+    else:
+        node = CourseNode(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            parent_id=parent_id,
+            title=title,
+            order=0,
+        )
     session.add(node)
     await session.flush()
     return node

--- a/tests/storage/test_cascade_kd_alpha.py
+++ b/tests/storage/test_cascade_kd_alpha.py
@@ -56,6 +56,7 @@ from course_supporter.storage.orm import (
     Student,
     Tenant,
 )
+from tests._helpers.course_node_factory import make_root_course_node
 
 # ── Invariant 1: Survival (mapper inspection — no DB) ─────────────
 
@@ -167,10 +168,9 @@ class TestGetSubtreeDecoupling:
             session.add(tenant)
             await session.flush()
 
-            root = CourseNode(
+            root = make_root_course_node(
                 id=uuid.uuid4(),
                 tenant_id=tenant.id,
-                parent_id=None,
                 title="root",
                 order=0,
             )

--- a/tests/storage/test_get_subtree_active_documents.py
+++ b/tests/storage/test_get_subtree_active_documents.py
@@ -58,6 +58,7 @@ from course_supporter.storage.orm import (
     CourseNode,
     Tenant,
 )
+from tests._helpers.course_node_factory import make_root_course_node
 
 
 @pytest.fixture(scope="module")
@@ -101,13 +102,24 @@ async def _make_node(
     parent_id: uuid.UUID | None,
     title: str,
 ) -> CourseNode:
-    node = CourseNode(
-        id=uuid.uuid4(),
-        tenant_id=tenant_id,
-        parent_id=parent_id,
-        title=title,
-        order=0,
-    )
+    # Task 2.4.13B — root branch routes through the factory so the
+    # CHECK-satisfying ``default_language`` lands here. Child branch
+    # stays raw (task 2.4.13 рішення 1 — child language is dead data).
+    if parent_id is None:
+        node = make_root_course_node(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            title=title,
+            order=0,
+        )
+    else:
+        node = CourseNode(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            parent_id=parent_id,
+            title=title,
+            order=0,
+        )
     session.add(node)
     await session.flush()
     return node

--- a/tests/storage/test_get_subtree_tenant_isolation.py
+++ b/tests/storage/test_get_subtree_tenant_isolation.py
@@ -36,6 +36,7 @@ from sqlalchemy.ext.asyncio import (
 from course_supporter.config import get_settings
 from course_supporter.storage.course_node_repository import CourseNodeRepository
 from course_supporter.storage.orm import CourseNode, Tenant
+from tests._helpers.course_node_factory import make_root_course_node
 
 
 @pytest.fixture(scope="module")
@@ -84,13 +85,24 @@ async def _make_node(
     parent_id: uuid.UUID | None,
     title: str,
 ) -> CourseNode:
-    node = CourseNode(
-        id=uuid.uuid4(),
-        tenant_id=tenant_id,
-        parent_id=parent_id,
-        title=title,
-        order=0,
-    )
+    # Task 2.4.13B — root branch routes through the factory so the
+    # CHECK-satisfying ``default_language`` lands here. Child branch
+    # stays raw (task 2.4.13 рішення 1 — child language is dead data).
+    if parent_id is None:
+        node = make_root_course_node(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            title=title,
+            order=0,
+        )
+    else:
+        node = CourseNode(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            parent_id=parent_id,
+            title=title,
+            order=0,
+        )
     session.add(node)
     await session.flush()
     return node


### PR DESCRIPTION
## Summary

Pre-existing test-fixture regression from task 2.4.13: the CHECK constraint `course_nodes_root_language_required` (migration `phase24_root_lang_required`) broke any test fixture that built a root `CourseNode` without `default_language`. 2.4.13 closure only ran unit + migration round-trip, so 44 failed / 78 errors across 23 files slipped through. Discovered on task-2.4.14 branch during full `--run-db --run-redis`; canary fails identically on baseline `21c9fed`, confirming pre-existing.

**Hotfix scope (tests-only, zero `src/`, zero migration):**
- New `tests/_helpers/course_node_factory.py` — `make_root_course_node(*, tenant_id, default_language=\"ukr\", **overrides)`. Mirrors task-2.4.13 рішення 5 («helper = single source of language logic») at the fixture layer.
- Central `tests/integration/conftest.py` (`seed_root_node` + `committed_seeds`) routed through the factory — high-leverage, closes 12 file clusters via this alone (`test_job_repository.py` 21→0, `test_stage2_safety_check.py` 9→0, …).
- 11 test files with direct root-setup constructions rewired; 5 `_make_node` helpers in storage/integration suites branch on `parent_id is None` (root → factory, child → raw).
- One semantic rewrite (operator decision C): `test_arq_task_e2e.py::test_success_full_lifecycle` → `test_inheritance_dominates_over_stt_detection`, both parametrisations expect `\"ukr\"`. Locks the task-2.4.13 рішення 1 invariant: in a rooted course STT-detect does NOT override the course language. `set_language_if_unset` + `if detected_language` block are now vestigial — DD-2.4-N (separate cleanup, not this PR).

**Scope discipline:**
- ROOT-specific. Child nodes (`parent_id` set) satisfy the CHECK structurally and stay raw — per task-2.4.13 child language is dead data. No blanket `default_language` on every `CourseNode()`.
- Subject-under-test unit tests (`test_material_node.py`, `test_tenant_isolation.py`) stay raw — they construct `CourseNode` as the assertion subject without commit, never trip the CHECK.
- ORM default rejected (would mask exactly the class of error the CHECK exists to catch).

**Merge order:** this hotfix merges **first**; `task-2-4-14-…` then rebases on the updated main and its `--run-db` runs clean. Task-doc: `refactoring-vision/sprint/phases/phase-2-4/PHASE-2-4-task-13B-fixture-fallout.md` (operator-owned).

## Acceptance — full `--run-db --run-redis`

| Metric | Baseline `21c9fed` | Final `6c8cf79` |
|---|---|---|
| passed | 2047 | **2169** (+122) |
| skipped | 3 | 3 |
| failed | **44** | **0** |
| errors | **78** | **0** |
| files with failures | **23** | **0** |

`ruff check src/ tests/` ✅ · `ruff format --check` ✅ · `mypy --strict src/` ✅ (128 src) · pre-commit hooks ✅.

## Test plan

- [ ] Reviewer: confirm factory refuses `parent_id` with TypeError (root-specific by design).
- [ ] Reviewer: confirm no child-construction or subject-under-test site was wrapped through the factory (rule #16 — empirical per-file).
- [ ] Reviewer: confirm `test_inheritance_dominates_over_stt_detection` docstring correctly describes the post-2.4.13 reality (inheritance fires before STT → cache-back unreachable on rooted course).
- [ ] CI green on the PR.
- [ ] After merge: operator rebases `task-2-4-14-…` on updated main; that branch's `--run-db --run-redis` should land green (~2173, +4 from 2.4.14's new tests on top of 2169 baseline).

## Carry-forward

**DD-2.4-N** (record in `active-debt.md`): `set_language_if_unset` + `if detected_language` block in `api/tasks.py` are vestigial post-2.4.13. Inheritance always fires before STT on a rooted course; cache-back can never update a NULL language. Cut on next torch of `api/tasks.py` or as a small dedicated cleanup. Before removing: probe other consumers of `set_language_if_unset`; verify `detected_language` has no log/observability consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)