### PR TITLE
task(2.4.16): DashScopeProvider text-generation branch (DD-2.4-O)

### DIFF
--- a/src/course_supporter/llm/providers/dashscope.py
+++ b/src/course_supporter/llm/providers/dashscope.py
@@ -1,10 +1,10 @@
-"""Alibaba DashScope provider for Qwen multimodal models.
+"""Alibaba DashScope provider for Qwen multimodal AND text models.
 
 Supports standard regions (Singapore via dashscope-intl, US, Beijing)
 and MaaS workspace endpoints (eu-central-1, etc.) via module-level
 ``dashscope.base_http_api_url`` configured at provider init time.
 
-KD-2.3-A: native client per multimodal provider — does NOT reuse
+KD-2.3-A: native client per provider — does NOT reuse
 ``openai_compat.py`` compatible-mode shim. Reasons:
 
 1. Silent reasoning-mode override drop risk. Compatible-mode strips
@@ -17,10 +17,29 @@ KD-2.3-A: native client per multimodal provider — does NOT reuse
    ``usage.image`` / ``usage.video`` fields for VL); compatible mode
    masks these.
 
+DD-2.4-O: ``complete`` routes between two distinct SDK endpoints by
+the presence of image bytes in ``request.contents``:
+
+* image bytes present → ``AioMultiModalConversation.call``
+  (``multimodal-generation`` task-group; VL models like
+  ``qwen3-vl-32b-instruct``).
+* no image bytes → ``AioGeneration.call`` (``text-generation``
+  task-group; text reasoning flagships like
+  ``qwen3.7-max-2026-05-20``).
+
+The split is required because the SDK 1.25.18 cannot serve a text
+model through the multimodal endpoint — the server returns a non-JSON
+4xx and the SDK's aiohttp branch fails to decode it
+(``StreamReader`` vs ``bytes`` mismatch in
+``dashscope/common/utils.py``), surfacing as
+``'StreamReader' object has no attribute 'decode'`` ~289 ms before
+inference.
+
 DashScope surfaces most errors as non-200 ``DashScopeAPIResponse``
 objects rather than exceptions. ``DashScopeResponseError`` wraps the
 status_code + code + message tuple so ``classify_error`` can map to
-``ErrorCategory`` consistently with other providers.
+``ErrorCategory`` consistently with other providers; the shape is
+identical across both endpoints.
 """
 
 from __future__ import annotations
@@ -33,6 +52,7 @@ from collections.abc import Iterator, Sequence
 from typing import Any
 
 import dashscope
+from dashscope.aigc.generation import AioGeneration
 from dashscope.aigc.multimodal_conversation import AioMultiModalConversation
 from dashscope.common.error import (
     AuthenticationError,
@@ -118,13 +138,15 @@ class DashScopeResponseError(Exception):
 
 
 class DashScopeProvider(LLMProvider):
-    """Alibaba DashScope provider for Qwen3-VL multimodal models.
+    """Alibaba DashScope provider for Qwen VL and text-reasoning models.
 
     The DashScope Python SDK uses module-level globals for
     ``api_key`` and ``base_http_api_url``. We set ``base_http_api_url``
     once at init time (binds all DashScope calls to one endpoint —
-    standard region or MaaS workspace), and pass ``api_key=`` per
-    call to support multi-key round-robin rotation across quotas.
+    standard region or MaaS workspace; applies uniformly to the
+    multimodal and text-generation task-groups), and pass
+    ``api_key=`` per call to support multi-key round-robin rotation
+    across quotas.
     """
 
     provider_name = "dashscope"
@@ -262,14 +284,94 @@ class DashScopeProvider(LLMProvider):
                 texts.append(elem["text"])
         return "".join(texts)
 
+    def _build_messages_text(self, request: LLMRequest) -> list[dict[str, Any]]:
+        """Build DashScope text-generation messages from LLMRequest.
+
+        The ``text-generation`` task-group expects ``content`` as a
+        plain string per message (per
+        ``dashscope.aigc.generation.Generation._build_input_parameters``,
+        which assembles ``msgs.append({"role": Role.USER, "content": prompt})``).
+        This shape differs from the multimodal task-group, which
+        carries a ``list[dict]`` of ``{"image": ...}`` / ``{"text": ...}``
+        elements. ``request.contents`` is intentionally ignored on this
+        branch — callers must route bytes content through
+        ``_build_messages`` instead.
+        """
+        messages: list[dict[str, Any]] = []
+        if request.system_prompt:
+            messages.append({"role": "system", "content": request.system_prompt})
+        if request.prompt:
+            messages.append({"role": "user", "content": request.prompt})
+        return messages
+
+    def _extract_text_generation(self, response: Any) -> str:
+        """Extract assistant text from a DashScope ``Generation`` response.
+
+        The text-generation endpoint returns one of two shapes per the
+        SDK's ``result_format`` parameter
+        (``dashscope/aigc/generation.py`` docstring, line 362):
+
+        * default (``result_format="text"``) — ``output.text`` as a
+          plain string.
+        * ``result_format="message"`` —
+          ``output.choices[0].message.content`` as a plain string per
+          ``Message.from_generation_response``
+          (``dashscope/api_entities/dashscope_response.py:132``).
+
+        Both forms are handled here so future ladder rungs may pin
+        either without coupling the extractor to a single shape.
+        """
+        output = response.output
+        if not output:
+            return ""
+        text_field = output.get("text")
+        if text_field:
+            return str(text_field)
+        choices = output.get("choices")
+        if not choices:
+            return ""
+        message = choices[0].get("message")
+        if not message:
+            return ""
+        content = message.get("content")
+        if not content:
+            return ""
+        if isinstance(content, str):
+            return content
+        return ""
+
+    @staticmethod
+    def _has_image_bytes(request: LLMRequest) -> bool:
+        """Return True iff ``request.contents`` carries image bytes.
+
+        Routes ``complete`` between the multimodal and text-generation
+        SDK endpoints (DD-2.4-O). ``None`` and empty-list contents are
+        text-branch (no images); a contents list with at least one
+        ``bytes``/``bytearray`` element is VL-branch. Non-bytes elements
+        (e.g. plain text/URL items) do not by themselves switch the
+        branch — only raw image bytes do.
+        """
+        contents = request.contents
+        if not contents:
+            return False
+        return any(isinstance(item, (bytes, bytearray)) for item in contents)
+
     async def complete(self, request: LLMRequest) -> LLMResponse:
-        """Generate completion via DashScope MultiModalConversation."""
+        """Generate completion via the appropriate DashScope endpoint.
+
+        Routes between ``AioMultiModalConversation.call`` (VL models,
+        image bytes in ``request.contents``) and ``AioGeneration.call``
+        (text-only reasoning models). The two endpoints share
+        identical multi-key / base-URL plumbing, error taxonomy
+        (``DashScopeResponseError``), and usage shape
+        (``input_tokens`` / ``output_tokens``); only the message shape
+        and the extractor differ per task-group. DD-2.4-O.
+        """
         model = request.model or self._default_model
-        messages = self._build_messages(request)
+        has_images = self._has_image_bytes(request)
 
         kwargs: dict[str, Any] = {
             "model": model,
-            "messages": messages,
             "api_key": self._next_key(),
         }
         if request.temperature is not None:
@@ -278,13 +380,21 @@ class DashScopeProvider(LLMProvider):
             kwargs["max_tokens"] = request.max_tokens
         if request.reasoning is not None:
             # Per-rung reasoning override (e.g. ``{"exclude": True}``)
-            # propagated verbatim. DashScope SDK forwards the kwarg to
-            # the Qwen reasoning-mode control; omitting it preserves
-            # the model's default behaviour.
+            # propagated verbatim on both branches per KD-2.3-S — the
+            # SDK forwards the kwarg to the Qwen reasoning-mode control
+            # symmetrically for VL and text models; omitting it
+            # preserves each model's default behaviour. No live ladder
+            # rung currently sets this on the text branch; the
+            # passthrough is mechanism-only.
             kwargs["reasoning"] = request.reasoning
 
         with self._measure_latency() as timer:
-            response = await AioMultiModalConversation.call(**kwargs)
+            if has_images:
+                kwargs["messages"] = self._build_messages(request)
+                response = await AioMultiModalConversation.call(**kwargs)
+            else:
+                kwargs["messages"] = self._build_messages_text(request)
+                response = await AioGeneration.call(**kwargs)
 
         if response.status_code != 200:
             raise DashScopeResponseError(
@@ -293,7 +403,10 @@ class DashScopeProvider(LLMProvider):
                 message=response.message or "",
             )
 
-        content_text = self._extract_text(response)
+        if has_images:
+            content_text = self._extract_text(response)
+        else:
+            content_text = self._extract_text_generation(response)
         if request.expects_json:
             content_text = strip_markdown_json(content_text)
         usage = response.usage

--- a/tests/unit/test_llm/test_providers_dashscope.py
+++ b/tests/unit/test_llm/test_providers_dashscope.py
@@ -76,6 +76,13 @@ class _SchemaForTest(BaseModel):
     ok: bool
 
 
+# Minimal PNG magic header used to flip the ``_has_image_bytes`` detector
+# into the VL branch (DD-2.4-O). The byte sequence is what
+# ``_detect_image_mime`` recognises; the trailing zeros simply pad to a
+# realistic non-empty payload so the base64-encode path runs unchanged.
+_VL_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+
+
 # ── Pure helpers ────────────────────────────────────────────────
 
 
@@ -338,7 +345,14 @@ class TestClassifyError:
 
 
 class TestCompleteAsync:
-    """``complete`` end-to-end via mocked ``AioMultiModalConversation.call``."""
+    """``complete`` end-to-end via mocked ``AioMultiModalConversation.call``.
+
+    Each request carries ``contents=[_VL_PNG]`` so the
+    ``_has_image_bytes`` detector picks the multimodal branch
+    (DD-2.4-O). Without image bytes the same shape would route to the
+    text endpoint and the multimodal mock would never be hit — that
+    routing property is locked separately by ``TestCompleteRouting``.
+    """
 
     @pytest.mark.asyncio
     async def test_success_extracts_content_and_tokens(
@@ -353,7 +367,11 @@ class TestCompleteAsync:
         monkeypatch.setattr(ds_module.AioMultiModalConversation, "call", fake_call)
 
         request = LLMRequest(
-            prompt="hi", model="qwen3-vl-32b-instruct", temperature=0.0, max_tokens=64
+            prompt="hi",
+            model="qwen3-vl-32b-instruct",
+            temperature=0.0,
+            max_tokens=64,
+            contents=[_VL_PNG],
         )
         response = await provider.complete(request)
 
@@ -385,13 +403,18 @@ class TestCompleteAsync:
 
         # expects_json -> fence stripped to bare JSON
         stripped = await provider.complete(
-            LLMRequest(prompt="hi", model="qwen3-vl-32b-instruct", expects_json=True)
+            LLMRequest(
+                prompt="hi",
+                model="qwen3-vl-32b-instruct",
+                expects_json=True,
+                contents=[_VL_PNG],
+            )
         )
         assert stripped.content == '{"status": "ok"}'
 
         # default (plain text) -> raw passthrough
         raw = await provider.complete(
-            LLMRequest(prompt="hi", model="qwen3-vl-32b-instruct")
+            LLMRequest(prompt="hi", model="qwen3-vl-32b-instruct", contents=[_VL_PNG])
         )
         assert raw.content == fenced
 
@@ -411,7 +434,9 @@ class TestCompleteAsync:
         )
         monkeypatch.setattr(ds_module.AioMultiModalConversation, "call", fake_call)
 
-        request = LLMRequest(prompt="hi", model="qwen3-vl-32b-instruct")
+        request = LLMRequest(
+            prompt="hi", model="qwen3-vl-32b-instruct", contents=[_VL_PNG]
+        )
         with pytest.raises(DashScopeResponseError) as exc_info:
             await provider.complete(request)
         assert exc_info.value.status_code == 429
@@ -428,7 +453,9 @@ class TestCompleteAsync:
         fake_call = AsyncMock(return_value=_success_response())
         monkeypatch.setattr(ds_module.AioMultiModalConversation, "call", fake_call)
 
-        request = LLMRequest(prompt="hi", model="qwen3-vl-32b-instruct")
+        request = LLMRequest(
+            prompt="hi", model="qwen3-vl-32b-instruct", contents=[_VL_PNG]
+        )
         await provider.complete(request)
         await provider.complete(request)
 
@@ -483,6 +510,7 @@ class TestCompleteAsync:
             prompt="hi",
             model="qwen3-vl-32b-instruct",
             reasoning={"exclude": True},
+            contents=[_VL_PNG],
         )
         await provider.complete(request)
 
@@ -503,11 +531,393 @@ class TestCompleteAsync:
         fake_call = AsyncMock(return_value=_success_response())
         monkeypatch.setattr(ds_module.AioMultiModalConversation, "call", fake_call)
 
-        request = LLMRequest(prompt="hi", model="qwen3-vl-32b-instruct")
+        request = LLMRequest(
+            prompt="hi", model="qwen3-vl-32b-instruct", contents=[_VL_PNG]
+        )
         await provider.complete(request)
 
         kwargs = fake_call.await_args.kwargs
         assert "reasoning" not in kwargs
+
+
+# ── complete() async — text-generation branch (DD-2.4-O) ────────
+
+
+def _success_response_text(
+    text: str = "Hello.",
+    tokens_in: int = 42,
+    tokens_out: int = 7,
+) -> MagicMock:
+    """Mock for the ``AioGeneration`` default ``result_format='text'`` shape.
+
+    DashScope text endpoint returns ``output.text`` as a plain string
+    (see ``dashscope/aigc/generation.py`` line 362 — default
+    ``result_format`` is ``text``).
+    """
+    response = MagicMock()
+    response.status_code = 200
+    response.code = ""
+    response.message = ""
+    response.output = {"text": text}
+    response.usage = {"input_tokens": tokens_in, "output_tokens": tokens_out}
+    return response
+
+
+def _success_response_text_message_shape(
+    text: str = "Hello.",
+    tokens_in: int = 42,
+    tokens_out: int = 7,
+) -> MagicMock:
+    """Mock for ``AioGeneration`` with ``result_format='message'`` shape.
+
+    Per ``Message.from_generation_response`` (``dashscope_response.py:132``)
+    the message-format response carries ``content`` as a plain string,
+    not a list-of-dicts (the multimodal-only shape).
+    """
+    response = MagicMock()
+    response.status_code = 200
+    response.code = ""
+    response.message = ""
+    response.output = {"choices": [{"message": {"content": text}}]}
+    response.usage = {"input_tokens": tokens_in, "output_tokens": tokens_out}
+    return response
+
+
+class TestCompleteAsyncText:
+    """``complete`` end-to-end via mocked ``AioGeneration.call`` (DD-2.4-O).
+
+    Covers the text-generation branch — the SDK endpoint Qwen text
+    reasoning flagships (``qwen3.7-max-2026-05-20``,
+    ``qwen3-max-2026-01-23``) belong to. Image bytes intentionally
+    absent on every test in this class so the detector picks this
+    branch; the asymmetric routing proof (each branch picks its own
+    SDK class) lives in ``TestCompleteRouting``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_success_extracts_output_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fake_call = AsyncMock(
+            return_value=_success_response_text(text="ok", tokens_in=10, tokens_out=3)
+        )
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_call)
+
+        request = LLMRequest(
+            prompt="hi", model="qwen3.7-max-2026-05-20", temperature=0.0, max_tokens=64
+        )
+        response = await provider.complete(request)
+
+        fake_call.assert_awaited_once()
+        assert response.content == "ok"
+        assert response.tokens_in == 10
+        assert response.tokens_out == 3
+        assert response.provider == "dashscope"
+        assert response.model_id == "qwen3.7-max-2026-05-20"
+
+    @pytest.mark.asyncio
+    async def test_success_extracts_choices_message_content(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Forward compatibility: a future ladder rung may pin
+        # ``result_format="message"`` for a structural reason; the
+        # extractor must keep working without code change.
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fake_call = AsyncMock(
+            return_value=_success_response_text_message_shape(text="ok")
+        )
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_call)
+
+        response = await provider.complete(
+            LLMRequest(prompt="hi", model="qwen3.7-max-2026-05-20")
+        )
+        assert response.content == "ok"
+
+    @pytest.mark.asyncio
+    async def test_messages_shape_plain_string_with_system(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Text endpoint requires ``content`` as a plain string per role
+        # (NOT a list-of-dicts as multimodal). System prompt arrives as
+        # a separate, first-position message — not merged into the user
+        # turn the way some providers expect.
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fake_call = AsyncMock(return_value=_success_response_text())
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_call)
+
+        await provider.complete(
+            LLMRequest(
+                prompt="map this transcript",
+                system_prompt="you are a methodist",
+                model="qwen3.7-max-2026-05-20",
+            )
+        )
+
+        msgs = fake_call.await_args.kwargs["messages"]
+        assert msgs == [
+            {"role": "system", "content": "you are a methodist"},
+            {"role": "user", "content": "map this transcript"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_expects_json_strips_fence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fenced = '```json\n{"status": "ok"}\n```'
+        monkeypatch.setattr(
+            ds_module.AioGeneration,
+            "call",
+            AsyncMock(return_value=_success_response_text(text=fenced)),
+        )
+
+        # expects_json -> fence stripped to bare JSON
+        stripped = await provider.complete(
+            LLMRequest(prompt="hi", model="qwen3.7-max-2026-05-20", expects_json=True)
+        )
+        assert stripped.content == '{"status": "ok"}'
+
+        # default (plain text) -> raw passthrough
+        raw = await provider.complete(
+            LLMRequest(prompt="hi", model="qwen3.7-max-2026-05-20")
+        )
+        assert raw.content == fenced
+
+    @pytest.mark.asyncio
+    async def test_non_200_raises_response_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Text endpoint surfaces non-200 through the same
+        # ``DashScopeAPIResponse`` shape as the multimodal one
+        # (status_code / code / message), so the classifier mapping
+        # is shared without provider-level branching.
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fake_call = AsyncMock(
+            return_value=_error_response(
+                status_code=429,
+                code="Throttling.RateQuota",
+                message="rate limit exceeded",
+            )
+        )
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_call)
+
+        request = LLMRequest(prompt="hi", model="qwen3.7-max-2026-05-20")
+        with pytest.raises(DashScopeResponseError) as exc_info:
+            await provider.complete(request)
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.code == "Throttling.RateQuota"
+        assert provider.classify_error(exc_info.value) == ErrorCategory.INFRASTRUCTURE
+
+    @pytest.mark.asyncio
+    async def test_multi_key_round_robin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Two API keys → two text calls visit each key once via ``api_key`` kwarg."""
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider(api_keys=("key-A", "key-B"))
+        fake_call = AsyncMock(return_value=_success_response_text())
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_call)
+
+        request = LLMRequest(prompt="hi", model="qwen3.7-max-2026-05-20")
+        await provider.complete(request)
+        await provider.complete(request)
+
+        keys_used = [c.kwargs["api_key"] for c in fake_call.await_args_list]
+        assert keys_used == ["key-A", "key-B"]
+
+    @pytest.mark.asyncio
+    async def test_reasoning_kwarg_omitted_when_request_field_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Parity guard with VL — when ``LLMRequest.reasoning`` is None,
+        # the provider must NOT surface a ``reasoning`` kwarg to the
+        # text endpoint either. No live text-branch ladder rung sets
+        # this today; the guard locks the symmetry per KD-2.3-S so
+        # adding a rung later cannot regress the default.
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fake_call = AsyncMock(return_value=_success_response_text())
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_call)
+
+        request = LLMRequest(prompt="hi", model="qwen3.7-max-2026-05-20")
+        await provider.complete(request)
+
+        kwargs = fake_call.await_args.kwargs
+        assert "reasoning" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_reasoning_kwarg_propagates_to_sdk_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Mechanism-only: prove the override path reaches the SDK when
+        # set on the request. No live ladder rung activates this on
+        # text models today (the rationale lives in DD-2.4-O ratify
+        # notes — passthrough, NOT activation).
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fake_call = AsyncMock(return_value=_success_response_text())
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_call)
+
+        request = LLMRequest(
+            prompt="hi",
+            model="qwen3.7-max-2026-05-20",
+            reasoning={"exclude": True},
+        )
+        await provider.complete(request)
+
+        kwargs = fake_call.await_args.kwargs
+        assert kwargs["reasoning"] == {"exclude": True}
+
+    @pytest.mark.asyncio
+    async def test_usage_input_output_tokens_extracted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``GenerationUsage`` shape is identical to
+        # ``MultiModalConversationUsage`` for ``input_tokens`` /
+        # ``output_tokens`` (per ``dashscope_response.py:217-231``).
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fake_call = AsyncMock(
+            return_value=_success_response_text(tokens_in=80_000, tokens_out=1_200)
+        )
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_call)
+
+        response = await provider.complete(
+            LLMRequest(prompt="hi", model="qwen3.7-max-2026-05-20")
+        )
+        assert response.tokens_in == 80_000
+        assert response.tokens_out == 1_200
+
+    @pytest.mark.asyncio
+    async def test_max_tokens_and_temperature_forwarded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fake_call = AsyncMock(return_value=_success_response_text())
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_call)
+
+        await provider.complete(
+            LLMRequest(
+                prompt="hi",
+                model="qwen3.7-max-2026-05-20",
+                temperature=0.3,
+                max_tokens=65_536,
+            )
+        )
+
+        kwargs = fake_call.await_args.kwargs
+        assert kwargs["temperature"] == 0.3
+        assert kwargs["max_tokens"] == 65_536
+
+
+# ── complete() async — branch detector (DD-2.4-O) ───────────────
+
+
+class TestCompleteRouting:
+    """Detector ``_has_image_bytes`` — picks the SDK endpoint per contents.
+
+    Asymmetric proof: in each scenario exactly one of
+    ``AioMultiModalConversation.call`` / ``AioGeneration.call`` is
+    awaited; the other is verified untouched. Covers the four
+    boundaries of the detector — ``contents=None``, ``contents=[]``,
+    ``contents=[<non-bytes>]``, ``contents=[<bytes>]``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_contents_none_routes_to_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fake_text = AsyncMock(return_value=_success_response_text())
+        fake_vl = AsyncMock(return_value=_success_response())
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_text)
+        monkeypatch.setattr(ds_module.AioMultiModalConversation, "call", fake_vl)
+
+        await provider.complete(
+            LLMRequest(prompt="hi", model="qwen3.7-max-2026-05-20", contents=None)
+        )
+        fake_text.assert_awaited_once()
+        fake_vl.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_contents_empty_list_routes_to_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fake_text = AsyncMock(return_value=_success_response_text())
+        fake_vl = AsyncMock(return_value=_success_response())
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_text)
+        monkeypatch.setattr(ds_module.AioMultiModalConversation, "call", fake_vl)
+
+        await provider.complete(
+            LLMRequest(prompt="hi", model="qwen3.7-max-2026-05-20", contents=[])
+        )
+        fake_text.assert_awaited_once()
+        fake_vl.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_contents_non_bytes_routes_to_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A contents list of non-bytes elements (e.g. plain strings or
+        # URL refs) is text-branch — only raw image bytes flip the
+        # router. Locks the detector against accidental flips by
+        # future contents shapes (e.g. a Gemini-style ``Part``).
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fake_text = AsyncMock(return_value=_success_response_text())
+        fake_vl = AsyncMock(return_value=_success_response())
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_text)
+        monkeypatch.setattr(ds_module.AioMultiModalConversation, "call", fake_vl)
+
+        await provider.complete(
+            LLMRequest(
+                prompt="hi",
+                model="qwen3.7-max-2026-05-20",
+                contents=["https://example.com/frame.jpg", {"text": "context"}],
+            )
+        )
+        fake_text.assert_awaited_once()
+        fake_vl.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_contents_png_bytes_routes_to_vl(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from course_supporter.llm.providers import dashscope as ds_module
+
+        provider = _make_provider()
+        fake_text = AsyncMock(return_value=_success_response_text())
+        fake_vl = AsyncMock(return_value=_success_response())
+        monkeypatch.setattr(ds_module.AioGeneration, "call", fake_text)
+        monkeypatch.setattr(ds_module.AioMultiModalConversation, "call", fake_vl)
+
+        png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+        await provider.complete(
+            LLMRequest(prompt="describe", model="qwen3-vl-32b-instruct", contents=[png])
+        )
+        fake_vl.assert_awaited_once()
+        fake_text.assert_not_awaited()
 
 
 # ── complete_structured() async ─────────────────────────────────
@@ -527,7 +937,7 @@ class TestCompleteStructuredAsync:
         fake_call = AsyncMock(return_value=_success_response(text=fenced))
         monkeypatch.setattr(ds_module.AioMultiModalConversation, "call", fake_call)
 
-        request = LLMRequest(prompt="ask", system_prompt="be terse")
+        request = LLMRequest(prompt="ask", system_prompt="be terse", contents=[_VL_PNG])
         parsed, raw = await provider.complete_structured(request, _SchemaForTest)
         assert isinstance(parsed, _SchemaForTest)
         assert parsed.ok is True


### PR DESCRIPTION
## Summary

- Adds a text-generation routing branch in `DashScopeProvider.complete()` so non-VL Qwen models (`qwen3.7-max-2026-05-20`, `qwen3-max-2026-01-23`) call the correct SDK endpoint (`AioGeneration.call`). Until now any text-only model silently failed ~289 ms before inference with `'StreamReader' object has no attribute 'decode'` (SDK 1.25.18 bug in `dashscope/common/utils.py:362` — the multimodal endpoint returns non-JSON 4xx for text models and the aiohttp branch can't decode it). The `video_pass_2a_mapping` rescue rung from task 2.4.12 was never actually executed because of this; the fix is also forward-cover for future text-Qwen rungs.
- VL branch (`AioMultiModalConversation.call`) preserved byte-identical for production callsites (video Pass 1 / presentation Pass 1, both VL) — the existing `TestCompleteAsync` cluster keeps green-keep as zero-regression proof, now with explicit `contents=[_VL_PNG]` to make the routing assumption part of the test contract. New `TestCompleteRouting` locks all four detector boundaries (`None` / `[]` / non-bytes / bytes) with asymmetric proof. Closes DD-2.4-O.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy src/` strict — 128 source files, 0 issues
- [x] `pre-commit run --files <changed>` — all hooks pass
- [x] `uv run pytest --run-db --run-redis` — **2225 passed / 0 failed / 3 skipped** (+14 vs 2.4.15 baseline 2211; 10 `TestCompleteAsyncText` + 4 `TestCompleteRouting`)
- [x] VL regression — existing `TestCompleteAsync` + `TestCompleteStructuredAsync` green-keep
- [ ] Live (post-merge, operator-run): upload yt `0I8S6diyDjw` as new material → ESC for `video_pass_2a_mapping` shows `provider=dashscope`, `model_id=qwen3.7-max-2026-05-20`, `success=t`, `latency_ms > 5000` (real inference, not 289 ms fail), `unit_in ~ 80k`, `unit_out` non-null — first honest empirical point on qwen3.7-max segmentation
- [ ] Operator decision after live run: revert TEMP swap in `config/ladders_video.yaml` (kept out of this PR per ratify — diagnostic-only, not a permanent rung order)

## Out of scope

- `config/ladders_video.yaml` TEMP swap (qwen rung 1) — operator-driven revert decision after post-merge RUN_SMOKE #2
- Registry / `external_services.yaml` — both text-Qwen models already registered
- SDK upstream bug at `dashscope/common/utils.py:362` — branching naturally avoids the failing aiohttp path; not patched here
- DD-2.4-F (`cost_usd` registry→ESC bridge) — separate sprint-closure work
- Other providers (gemini / anthropic / elevenlabs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)