### PR TITLE
task(2.4.17): DeepSeekThinkingProvider + video Pass 2a ladder rebalance

### DIFF
--- a/config/external_services.yaml
+++ b/config/external_services.yaml
@@ -147,13 +147,25 @@ providers:
         cost_per_1k_in: 0.00014
         cost_per_1k_out: 0.00028
       - id: deepseek-v4-pro
-        # "Smart" / deep-reasoning tier. Regular $1.74/$3.48 per 1M; a 75%
-        # promo runs to 2026-05-31 (~$0.435/$0.87). Registry uses the durable
-        # regular rate to avoid a silent post-promo jump. Reasoning output may
-        # warrant a per-rung max_output_tokens override above 8192.
+        # "Smart" / deep-reasoning tier. Durable regular rate $1.74/$3.48
+        # per 1M (this entry); the prior 75% promo expired 2026-05-31, and a
+        # rolling promo at $0.435/$0.87 was observed live 2026-06-05 — registry
+        # keeps the durable rate per the cross-vendor convention (avoid silent
+        # post-promo jumps; precedent: deepseek-v4-flash + qwen3.7-max). Context
+        # 1M / max output 384K per the official DeepSeek docs verified 2026-06-05;
+        # the conservative ``max_output_tokens`` here (65536) mirrors the video
+        # Pass 2a ladder pin — the model's true output ceiling is far higher,
+        # but the cap above which we have empirical evidence of clean emission
+        # is the spike's observed ~23k token thinking-on output (RUN_SMOKE #2,
+        # B-spike series). Raise as new stages exercise more output.
+        # Reasoning-mode behaviour: per KD-2.4-T this model is routed via the
+        # ``deepseek_thinking`` provider for reasoning-tier stages (video Pass
+        # 2a) so the thinking-on default is preserved; the ``deepseek`` provider
+        # (KD-2.4-S) still applies thinking-disabled for schema-bound consumers
+        # and can be used with this model when that contract is required.
         capabilities: [structured_output, long_context]
-        max_context: 131072
-        max_output_tokens: 8192
+        max_context: 1048576
+        max_output_tokens: 65536
         unit_type: tokens
         cost_per_1k_in: 0.00174
         cost_per_1k_out: 0.00348
@@ -207,17 +219,27 @@ providers:
     # qwen3-vl). Reasoning/"thinking" variants (qwen3-235b-a22b-thinking-2507,
     # qwen3-next-80b-a3b-thinking) are also workspace-available — add on demand.
     models:
-      - id: qwen3.7-max-2026-05-20
+      - id: qwen3.7-max
         # Latest Qwen flagship "Max" (text reasoning; released 2026-05-20).
+        # Registered under the canonical alias (NOT the date-pinned
+        # ``qwen3.7-max-2026-05-20`` variant) because curl-probe 2026-06-05
+        # confirmed the workspace (ws-kyxnm2ipitv2bwlr, eu-central-1) grants
+        # access only to the canonical alias; the date-pinned id returns 403
+        # Model.AccessDenied (separate unauthorized entity, lower limits).
+        # Mirrors the VL alias precedent (qwen3-vl-32b-instruct).
+        # NB: canonical alias currently resolves to the 2026-05-20 snapshot
+        # per the workspace console card ("functionally equivalent to
+        # qwen3.7-max-2026-05-20"); the alias may advance to newer snapshots
+        # without a config change — behavior may shift silently. Pin
+        # explicitly if a frozen snapshot is ever required.
         # Context 1M / output 65536 confirmed from OpenRouter listing
         # 2026-06-02. Pricing $2.50/$7.50 per 1M is the Alibaba direct
         # durable regular rate (cross-checked via artificialanalysis.ai).
-        # OpenRouter / pricepertoken list $1.25/$3.75 — an exact 2× delta
-        # against the Alibaba direct rate (a 50% promo signature); registry
-        # convention prefers the durable regular rate to avoid a silent
-        # post-promo jump (precedent: deepseek-v4-pro). The Alibaba Model
-        # Studio public pricing page did not yet list qwen3.7-max as of
-        # 2026-06-02 — refresh this entry once it does and reconcile.
+        # The current $1.65/$4.951 per 1M tier is a limited-time promo —
+        # registry keeps the durable rate to avoid a silent post-promo jump
+        # (precedent: deepseek-v4-pro). The Alibaba Model Studio public
+        # pricing page did not yet list qwen3.7-max as of 2026-06-02 —
+        # refresh this entry once it does and reconcile.
         capabilities: [structured_output, long_context]
         max_context: 1048576
         max_output_tokens: 65536

--- a/config/ladders_video.yaml
+++ b/config/ladders_video.yaml
@@ -68,10 +68,7 @@ stages:
         max_output_tokens: 8192
 
   # Pass 2a semantic mapping (KD-2.2-A/F/H word-idx contract; landed in task
-  # 2.4.5, retuned for RUN_SMOKE #2 in task 2.4.12 after RUN_SMOKE #1 exposed
-  # the prior ladder as both ceiling- and reasoning-constrained on long video:
-  # the 8K output pin truncated 23-min transcripts and gemini-2.5-flash as R1
-  # was weak for single-shot structural segmentation at 265K input).
+  # 2.4.5, retuned across tasks 2.4.12 / 2.4.17 as live evidence accumulated).
   # Input: transcript word-stream (``words_json`` + ``words_count``) + a
   #   deterministic visual-overlay block (``visuals``) via Jinja render
   #   context; image bytes do NOT flow here (text-reasoning, not vision).
@@ -79,52 +76,81 @@ stages:
   #   word-idx schema) by the ``step_5_pass2a_mapping`` response_validator;
   #   a ``ValidationError`` → ``StructuralRetryError`` (Path 3, as audio).
   #
-  # Ladder rationale (text-reasoning; per-source_type calibration per
-  # KD-2.3-X — calibrated *within* the registered text pool, NOT a unique
-  # per-source model; ranking observed in RUN_SMOKE #2):
-  #   1. gemini/gemini-3.1-flash-lite — cost-first preview-tier primary.
-  #      Single-shot reasoning is sharper than gemini-2.5-flash on long
-  #      context, at comparable cost ($0.25/$1.50 vs $0.30/$2.50 per 1M).
-  #      Preview-tier status is an accepted trade-off.
-  #   2. dashscope/qwen3.7-max-2026-05-20 — diverse-provider rescue (NOT
-  #      Gemini, guards against a Gemini-API common issue). Reasoning-tier
-  #      flagship with 1M context and 65536 output (92.4% GPQA Diamond,
-  #      80.4% SWE-Verified). 1M context covers the longest video
-  #      transcripts (RUN_SMOKE #1 hit ~265K input). NOT calibrated on
-  #      video Pass 2a yet — performance observed in RUN_SMOKE #2.
-  #   3. gemini/gemini-2.5-flash — stable Gemini fallback (the proven
-  #      baseline; passed text / presentation Pass 2a in RUN_SMOKE #1).
-  #   4. gemini/gemini-2.5-pro — reasoning escalation on the hardest
-  #      materials ($1.25/$10 per 1M; the priciest rung, last resort).
+  # Ladder rationale — 5-way spike 2026-06-05 (task-2.4.17).
+  # ----------------------------------------------------------------------
+  # The same single video matter (0I8S6diyDjw, ~10:48 English lecture,
+  # 2653 STT words, 241 visual scenes) was Pass 2a'd through five models
+  # using a byte-identical reconstructed prompt. The decisive metric was
+  # the size of the largest segment (``%`` of duration AND chars); a
+  # well-balanced split keeps it below ~30%.
   #
-  # Anthropic/Sonnet R3 rung removed — no Anthropic credits make the rung a
-  # dead tier (separate operator concern). Promote back as a fifth tier
-  # once credits are restored.
-  # DeepSeek V4 Pro intentionally NOT added here — its reasoning mode needs
-  # a dedicated ``DeepSeekThinkingProvider`` (future work, separate task).
+  #   | model                          | mode        | largest dur% | result   |
+  #   | gemini-3.1-flash-lite          | cheap-tier  | 75.3%        | collapse |
+  #   | qwen3.7-plus                   | cheap-tier  | 79.3%        | collapse |
+  #   | deepseek-v4-pro (NON-thinking) | cheap-tier  | 66.8%        | collapse |
+  #   | qwen3.7-max                    | reasoning   | 25.9%        | balanced |
+  #   | deepseek-v4-pro (thinking ON)  | reasoning   | 23.5%        | balanced |
   #
-  # Output-pin policy (DD-2.4-H): per-rung ``max_output_tokens: 65536``
-  # lifts the budget from the sprint-wide 8192 baseline to the per-rung
-  # model ceiling — the 8K pin actively truncated long-video transcripts
-  # in RUN_SMOKE #1 (the Gemini 65K model ceiling was artificially
-  # constrained by the pin). All four rungs share the same 65536 cap
-  # (Gemini 3.1-flash-lite / 2.5-flash / 2.5-pro registry-confirmed 65536;
-  # Qwen 3.7-Max confirmed 65536 from OpenRouter listing 2026-06-02), so
-  # intra-ladder rung-uniformity still holds at the new, higher pin. Other
-  # Pass 2a stages (audio / presentation / text) keep the 8192 pin →
-  # DD-2.4-H stays live sprint-wide; for video Pass 2a it is lifted "as a
-  # class" per the ratified optional clause in task 2.4.12.
+  # The collapse pattern is a "catch-all tail" — the model bundles the last
+  # half-plus of the transcript into one segment regardless of label
+  # (gemini calls it "Closing Credits", plus calls it "Future of Science
+  # Photography", non-think Pro calls it "The Future Role of Science
+  # Photographers"). The empirical boundary is the reasoning budget:
+  # 0 reasoning_tokens (non-think Pro, gemini-flash-lite) → collapse;
+  # 5.5k reasoning_tokens (plus, cheap-tier) → still collapse; 21k
+  # reasoning_tokens (Pro thinking on) → balanced. The two reasoning-tier
+  # rungs (Pro thinking on, qwen3.7-max) both hold balance and emit
+  # semantically equivalent segmentations.
+  #
+  # KD-2.4-T (Phase 2.4 task-2.4.17) ratified the per-stage thinking opt-in:
+  # video Pass 2a goes through the new ``deepseek_thinking`` provider so the
+  # DeepSeek default-on thinking is preserved (the standard ``deepseek``
+  # provider keeps KD-2.4-S thinking-disabled for schema-bound stages).
+  #
+  # Rungs (post-task-2.4.17 — cost-first within reasoning-tier; flash-tier
+  # is excluded as proven-collapsing on this workload):
+  #   1. deepseek_thinking/deepseek-v4-pro — cheapest reasoning-tier
+  #      ($1.74/$3.48 per 1M durable, 28% cheaper than qwen3.7-max). Highest
+  #      latency (~7 min) is acceptable for background ingestion; tradeoff
+  #      ratified per Q3 ratify 2026-06-05.
+  #   2. dashscope/qwen3.7-max — diverse-provider rescue (different vendor /
+  #      data-centre / billing surface from DeepSeek). Reasoning-tier
+  #      flagship with 1M context and 65k output; ~4× faster than Pro.
+  #   3. gemini/gemini-2.5-pro — last-resort escalation ($1.25/$10 per 1M);
+  #      reasoning-tier baseline at Google; survives outages where both
+  #      DeepSeek and DashScope MaaS surfaces would be down.
+  #
+  # Dropped in task-2.4.17: gemini-3.1-flash-lite and gemini-2.5-flash.
+  # Both are flash-tier and the 5-way spike empirically demonstrated they
+  # collapse the long video Pass 2a workload (75% and unconfirmed-but-
+  # presumed-similar; the registry-confirmed cheap-tier behaviour at 5.5k
+  # reasoning_tokens is the supporting evidence).
+  #
+  # Anthropic / Sonnet R4 rung remains unavailable (operator credits
+  # concern; restoration would slot it after gemini-2.5-pro).
+  #
+  # n=1 caveat (KD-2.4-T). Rung order is calibrated against a single
+  # English mid-length lecture (~10:48). Other languages, very short
+  # videos, very long videos warrant their own calibration cycle on live
+  # operations per KD-2.3-X (per-source-type ladder calibration).
+  #
+  # Output-pin policy (DD-2.4-H). Per-rung ``max_output_tokens: 65536`` is
+  # the sprint-wide video Pass 2a value lifted from the 8192 baseline (the
+  # 8K pin truncated 23-min transcripts in RUN_SMOKE #1). All three rungs'
+  # underlying models support 65k+ output (DeepSeek V4 Pro 384k per the
+  # official docs verified 2026-06-05; Qwen 3.7-Max 65k from OpenRouter;
+  # Gemini 2.5 Pro 65k registered). Other Pass 2a stages (audio /
+  # presentation / text) keep the 8192 pin — DD-2.4-H stays live sprint-
+  # wide; video Pass 2a is lifted "as a class" per the optional clause
+  # ratified in task-2.4.12 and preserved here.
   video_pass_2a_mapping:
     prompt_ref: "prompts/video_pass_2a_mapping/v1.md"
     ladder:
-      - provider: gemini
-        model: gemini-3.1-flash-lite
+      - provider: deepseek_thinking
+        model: deepseek-v4-pro
         max_output_tokens: 65536
       - provider: dashscope
-        model: qwen3.7-max-2026-05-20
-        max_output_tokens: 65536
-      - provider: gemini
-        model: gemini-2.5-flash
+        model: qwen3.7-max
         max_output_tokens: 65536
       - provider: gemini
         model: gemini-2.5-pro

--- a/src/course_supporter/config.py
+++ b/src/course_supporter/config.py
@@ -25,6 +25,7 @@ _LLM_PROVIDER_KEYS = (
     "anthropic",
     "openai",
     "deepseek",
+    "deepseek_thinking",
     "mistral",
     "dashscope",
 )
@@ -136,6 +137,14 @@ class Settings(BaseSettings):
     deepseek_api_key_raw: SecretStr | None = Field(
         None, validation_alias="deepseek_api_key"
     )
+    # Same ENV var (DEEPSEEK_API_KEY) powers both DeepSeek providers — the
+    # thinking-on sibling lives in its own key pool so factory.create_providers
+    # instantiates a distinct provider class while sharing the operator's
+    # single DeepSeek quota. Precedent: alibaba_api_key drives both the
+    # DashScope-native pool and (if added) any sibling. (KD-2.4-T wiring.)
+    deepseek_thinking_api_key_raw: SecretStr | None = Field(
+        None, validation_alias="deepseek_api_key"
+    )
     mistral_api_key_raw: SecretStr | None = Field(
         None, validation_alias="mistral_api_key"
     )
@@ -183,6 +192,11 @@ class Settings(BaseSettings):
         return pool.next_key() if pool else None
 
     @property
+    def deepseek_thinking_api_key(self) -> SecretStr | None:
+        pool = self._key_pools.get("deepseek_thinking")
+        return pool.next_key() if pool else None
+
+    @property
     def mistral_api_key(self) -> SecretStr | None:
         pool = self._key_pools.get("mistral")
         return pool.next_key() if pool else None
@@ -213,6 +227,9 @@ class Settings(BaseSettings):
     anthropic_default_model: str = "claude-sonnet-4-20250514"
     openai_default_model: str = "gpt-4o-mini"
     deepseek_default_model: str = "deepseek-chat"
+    # Thinking-on sibling defaults to V4 Pro (reasoning-tier flagship; the only
+    # current consumer is video Pass 2a rung 1 per KD-2.4-T).
+    deepseek_thinking_default_model: str = "deepseek-v4-pro"
     mistral_default_model: str = "mistral-large-2512"
     dashscope_default_model: str = "qwen3-vl-32b-instruct"
 
@@ -225,6 +242,9 @@ class Settings(BaseSettings):
     # DeepSeek uses OpenAI-compatible API via OpenAI SDK with custom base_url.
     # Other providers have their own SDKs with built-in endpoints.
     deepseek_base_url: str = "https://api.deepseek.com"
+    # Same endpoint as deepseek_base_url — the thinking-on sibling only differs
+    # in the omitted thinking-disable hook (provider-side), not the endpoint.
+    deepseek_thinking_base_url: str = "https://api.deepseek.com"
 
     # --- Mistral ---
     # Mistral uses OpenAI-compatible API via OpenAI SDK with custom base_url.

--- a/src/course_supporter/llm/factory.py
+++ b/src/course_supporter/llm/factory.py
@@ -42,6 +42,11 @@ PROVIDER_CONFIGS: dict[str, ProviderFactoryConfig] = {
         get_base_url=lambda s: s.deepseek_base_url,
         extra_kwargs={"provider_name": "deepseek"},
     ),
+    "deepseek_thinking": ProviderFactoryConfig(
+        get_default_model=lambda s: s.deepseek_thinking_default_model,
+        get_base_url=lambda s: s.deepseek_thinking_base_url,
+        extra_kwargs={"provider_name": "deepseek_thinking"},
+    ),
     "mistral": ProviderFactoryConfig(
         get_default_model=lambda s: s.mistral_default_model,
         get_base_url=lambda s: s.mistral_base_url,

--- a/src/course_supporter/llm/providers/__init__.py
+++ b/src/course_supporter/llm/providers/__init__.py
@@ -14,6 +14,7 @@ from course_supporter.llm.providers.anthropic import AnthropicProvider
 from course_supporter.llm.providers.base import LLMProvider, StructuredOutputError
 from course_supporter.llm.providers.dashscope import DashScopeProvider
 from course_supporter.llm.providers.deepseek import DeepSeekProvider
+from course_supporter.llm.providers.deepseek_thinking import DeepSeekThinkingProvider
 from course_supporter.llm.providers.gemini import GeminiProvider
 from course_supporter.llm.providers.openai_compat import OpenAICompatProvider
 
@@ -22,6 +23,7 @@ PROVIDER_REGISTRY: dict[str, type[LLMProvider]] = {
     "anthropic": AnthropicProvider,
     "openai": OpenAICompatProvider,
     "deepseek": DeepSeekProvider,
+    "deepseek_thinking": DeepSeekThinkingProvider,
     "mistral": OpenAICompatProvider,
     "dashscope": DashScopeProvider,
 }
@@ -31,6 +33,7 @@ __all__ = [
     "AnthropicProvider",
     "DashScopeProvider",
     "DeepSeekProvider",
+    "DeepSeekThinkingProvider",
     "GeminiProvider",
     "LLMProvider",
     "OpenAICompatProvider",

--- a/src/course_supporter/llm/providers/deepseek.py
+++ b/src/course_supporter/llm/providers/deepseek.py
@@ -3,19 +3,24 @@
 DeepSeek V4 (Flash / Pro) exposes a dual-mode API: thinking-on (default,
 returns ``reasoning_content`` and inflates output/latency by an order
 of magnitude) and thinking-off (non-think, ``content``-only, fast). For
-the Pass 2a structured JSON workload (vision §2.2, KD-2.1-O) we want
-non-think — the task is schema-bound mapping, not chain-of-thought
-reasoning.
+schema-bound structured-JSON workloads (safety_check, Pass 2c denoise)
+we want non-think — the task is schema-bound mapping, not chain-of-
+thought reasoning. This contract is now ratified as KD-2.4-S (Phase
+2.4, 2026-06-05); prior to that it lived as an orphan decision from
+the Phase 2.1 C5 commit ``bf54b30`` and code-comments mis-attributed
+it to KD-2.1-O — that mis-attribution is corrected here. KD-2.1-O
+remains a separate concern (per-source-type Pass 2a structure,
+content vs no-content).
 
 DeepSeek's OpenAI-compatible REST surface accepts the toggle as a
 top-level body field; the OpenAI SDK exposes it via ``extra_body``.
 This subclass forces ``extra_body={"thinking": {"type": "disabled"}}``
-on every call, regardless of which stage routes through it. If a
-future stage needs thinking-on (heavy reasoning), it should not route
-through this provider — a separate ``DeepSeekThinkingProvider`` (or
-per-stage override) would be the right surface.
+on every call routed through it. Stages that need thinking-on (heavy
+reasoning, e.g. video Pass 2a per KD-2.4-T) route through the sibling
+:class:`DeepSeekThinkingProvider` instead — its base-class default
+``{}`` hook lets the DeepSeek API apply its V4 thinking-on default.
 
-Spike validation (2026-05-12):
+Spike validation (2026-05-12, DeepSeek V4 Flash):
 
 * Thinking ON (default):  mean latency 140 s, output ~11 k tokens,
   cost ~$0.004 / call.
@@ -34,7 +39,7 @@ class DeepSeekProvider(OpenAICompatProvider):
     """OpenAI-compatible provider with DeepSeek thinking mode forced off."""
 
     def _extra_create_kwargs(self) -> dict[str, Any]:
-        """Inject ``extra_body={"thinking": {"type": "disabled"}}`` (KD-2.1-O).
+        """Inject ``extra_body={"thinking": {"type": "disabled"}}`` (KD-2.4-S).
 
         Returned dict is spread into both
         :meth:`openai.AsyncOpenAI.chat.completions.create` (via

--- a/src/course_supporter/llm/providers/deepseek_thinking.py
+++ b/src/course_supporter/llm/providers/deepseek_thinking.py
@@ -1,0 +1,31 @@
+"""DeepSeek thinking-on provider — OpenAI-compatible without the disable hook.
+
+Sibling of :class:`DeepSeekProvider`. Same base_url, same SDK, same key pool
+(``DEEPSEEK_API_KEY``), BUT no ``_extra_create_kwargs`` override — the
+base-class default returns ``{}``, so the call body omits the ``thinking``
+field and the DeepSeek API falls back to its default thinking-on behaviour.
+
+Per KD-2.4-T (Phase 2.4 task-2.4.17): thinking-on is opt-in for
+reasoning-tier stages (video Pass 2a) where the full chain-of-thought
+empirically holds segmentation balance on long contexts (5-way spike
+2026-06-05 — DeepSeek V4 Pro with thinking on emitted 21k reasoning
+tokens and balanced 7 segments with largest 23.5% of duration; the same
+model with thinking forced off via DeepSeekProvider collapsed into a
+67% catch-all tail). DeepSeekProvider (KD-2.4-S) stays the default for
+schema-bound workloads (safety_check, Pass 2c denoise) where the
+deterministic non-think mode is desirable.
+"""
+
+from __future__ import annotations
+
+from course_supporter.llm.providers.openai_compat import OpenAICompatProvider
+
+
+class DeepSeekThinkingProvider(OpenAICompatProvider):
+    """OpenAI-compatible provider that lets DeepSeek thinking-mode default on.
+
+    No ``_extra_create_kwargs`` override — the base-class neutral ``{}`` hook
+    is exactly what we want: the request body omits ``thinking`` and the
+    DeepSeek API applies its V4 default (thinking on, ``reasoning_content``
+    surfaced alongside ``content``).
+    """

--- a/tests/unit/test_llm/test_providers_deepseek_thinking.py
+++ b/tests/unit/test_llm/test_providers_deepseek_thinking.py
@@ -1,24 +1,19 @@
-"""Unit tests for :class:`DeepSeekProvider` thinking-mode override.
+"""Unit tests for :class:`DeepSeekThinkingProvider` (KD-2.4-T).
 
-Verifies the KD-2.4-S contract (legalised in Phase 2.4 task-2.4.17,
-2026-06-05; prior to that it lived as an orphan decision in the
-Phase 2.1 C5 commit ``bf54b30`` and was mis-attributed to KD-2.1-O):
-DeepSeek production calls for schema-bound workloads always spread
-``extra_body={"thinking": {"type": "disabled"}}`` into the underlying
-OpenAI-compatible client. Without this override the default thinking-on
-behaviour inflates output ~6x and latency ~7x (measured during Phase A
-spike, 2026-05-12).
+Mirror of :mod:`tests.unit.test_llm.test_providers_deepseek` for the
+thinking-on sibling. Verifies that:
 
-KD-2.4-T (the per-stage thinking opt-in for reasoning-tier work) is
-verified separately in :mod:`tests.unit.test_llm.test_providers_deepseek_thinking`.
-The two test modules together pin the contract: schema-bound stays on
-:class:`DeepSeekProvider` (thinking off), reasoning-tier stays on
-:class:`DeepSeekThinkingProvider` (thinking on).
-
-The tests use light fakes for the OpenAI client cycle and the
-instructor cycle so we can capture the kwargs passed into
-``chat.completions.create`` / ``create_with_completion`` without
-hitting the real DeepSeek API.
+* the subclass inherits :class:`OpenAICompatProvider` cleanly,
+* :meth:`_extra_create_kwargs` returns the empty base-class default
+  (NOT the thinking-disabled override from KD-2.4-S),
+* both call paths (``chat.completions.create`` and instructor's
+  ``create_with_completion``) reach the SDK with no ``extra_body``
+  injected, so the DeepSeek API applies its default thinking-on V4
+  behaviour,
+* the provider registry exposes the new class under
+  ``"deepseek_thinking"`` and the factory wires it from the shared
+  ``DEEPSEEK_API_KEY`` pool, returning a working instance alongside the
+  non-thinking :class:`DeepSeekProvider`.
 """
 
 from __future__ import annotations
@@ -31,6 +26,7 @@ import pytest
 from pydantic import BaseModel
 
 from course_supporter.llm.providers.deepseek import DeepSeekProvider
+from course_supporter.llm.providers.deepseek_thinking import DeepSeekThinkingProvider
 from course_supporter.llm.providers.openai_compat import OpenAICompatProvider
 from course_supporter.llm.schemas import LLMRequest
 
@@ -38,12 +34,12 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-def _make_provider() -> DeepSeekProvider:
-    """Construct a DeepSeekProvider with a single fake API key."""
-    return DeepSeekProvider(
+def _make_provider() -> DeepSeekThinkingProvider:
+    """Construct a DeepSeekThinkingProvider with a single fake API key."""
+    return DeepSeekThinkingProvider(
         api_keys=("test-key",),
-        default_model="deepseek-v4-flash",
-        provider_name="deepseek",
+        default_model="deepseek-v4-pro",
+        provider_name="deepseek_thinking",
         base_url="https://api.deepseek.com/v1",
     )
 
@@ -74,31 +70,36 @@ class _SchemaForTest(BaseModel):
     ok: bool
 
 
-class TestDeepSeekProviderExtraBody:
-    """KD-2.4-S: thinking-disabled forced on every DeepSeek call."""
+class TestDeepSeekThinkingProviderHook:
+    """KD-2.4-T: thinking-on default kept by omitting the disable override."""
 
     def test_inherits_from_openai_compat(self) -> None:
         provider = _make_provider()
         assert isinstance(provider, OpenAICompatProvider)
 
-    def test_extra_create_kwargs_returns_thinking_disabled(self) -> None:
-        """Hook returns exactly the body fragment the SDK expects."""
+    def test_extra_create_kwargs_returns_empty(self) -> None:
+        """The base-class neutral hook is exactly what we want here."""
         provider = _make_provider()
-        kwargs = provider._extra_create_kwargs()
-        assert kwargs == {"extra_body": {"thinking": {"type": "disabled"}}}
+        assert provider._extra_create_kwargs() == {}
 
-    def test_base_class_extra_kwargs_remains_empty(self) -> None:
-        """Sanity check: parent (openai / mistral) path is unaffected."""
-        base = OpenAICompatProvider(
+    def test_distinct_from_non_thinking_provider(self) -> None:
+        """The two DeepSeek classes are NOT the same — non-think keeps disable."""
+        thinking = _make_provider()
+        non_thinking = DeepSeekProvider(
             api_keys=("test-key",),
-            default_model="gpt-test",
-            provider_name="openai",
+            default_model="deepseek-v4-flash",
+            provider_name="deepseek",
+            base_url="https://api.deepseek.com/v1",
         )
-        assert base._extra_create_kwargs() == {}
+        assert type(thinking) is not type(non_thinking)
+        assert thinking._extra_create_kwargs() == {}
+        assert non_thinking._extra_create_kwargs() == {
+            "extra_body": {"thinking": {"type": "disabled"}}
+        }
 
     @pytest.mark.asyncio
-    async def test_complete_passes_thinking_disabled_in_extra_body(self) -> None:
-        """``complete`` spreads ``extra_body`` into ``chat.completions.create``."""
+    async def test_complete_omits_extra_body(self) -> None:
+        """``complete`` does NOT inject ``extra_body`` — thinking stays default-on."""
         provider = _make_provider()
         fake_client = MagicMock()
         fake_client.chat.completions.create = AsyncMock(
@@ -112,7 +113,7 @@ class TestDeepSeekProviderExtraBody:
         request = LLMRequest(
             prompt="hello",
             system_prompt="sys",
-            model="deepseek-v4-flash",
+            model="deepseek-v4-pro",
             temperature=0.0,
             max_tokens=1024,
         )
@@ -121,9 +122,10 @@ class TestDeepSeekProviderExtraBody:
 
         fake_client.chat.completions.create.assert_awaited_once()
         kwargs = fake_client.chat.completions.create.await_args.kwargs
-        assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+        # KD-2.4-T contract: NO extra_body, so DeepSeek defaults to thinking-on.
+        assert "extra_body" not in kwargs
         # Sanity: base kwargs still pass through unchanged.
-        assert kwargs["model"] == "deepseek-v4-flash"
+        assert kwargs["model"] == "deepseek-v4-pro"
         assert kwargs["temperature"] == 0.0
         assert kwargs["max_tokens"] == 1024
         assert kwargs["messages"] == [
@@ -132,8 +134,8 @@ class TestDeepSeekProviderExtraBody:
         ]
 
     @pytest.mark.asyncio
-    async def test_complete_structured_passes_thinking_disabled(self) -> None:
-        """instructor's ``create_with_completion`` also receives ``extra_body``."""
+    async def test_complete_structured_omits_extra_body(self) -> None:
+        """instructor's ``create_with_completion`` also runs without ``extra_body``."""
         provider = _make_provider()
 
         fake_instructor = MagicMock()
@@ -148,7 +150,7 @@ class TestDeepSeekProviderExtraBody:
         request = LLMRequest(
             prompt="hello",
             system_prompt=None,
-            model="deepseek-v4-flash",
+            model="deepseek-v4-pro",
             temperature=0.0,
             max_tokens=256,
         )
@@ -158,49 +160,24 @@ class TestDeepSeekProviderExtraBody:
         instructor_create = fake_instructor.chat.completions.create_with_completion
         instructor_create.assert_awaited_once()
         kwargs = instructor_create.await_args.kwargs
-        assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
-        assert kwargs["model"] == "deepseek-v4-flash"
+        assert "extra_body" not in kwargs
+        assert kwargs["model"] == "deepseek-v4-pro"
         assert kwargs["max_retries"] == 2
         assert kwargs["response_model"] is _SchemaForTest
 
-    @pytest.mark.asyncio
-    async def test_openai_compat_complete_omits_extra_body(self) -> None:
-        """Non-DeepSeek providers must NOT inject ``extra_body``."""
-        base = OpenAICompatProvider(
-            api_keys=("test-key",),
-            default_model="gpt-test",
-            provider_name="openai",
-        )
-        fake_client = MagicMock()
-        fake_client.chat.completions.create = AsyncMock(
-            return_value=_stub_completion_response()
-        )
-        base._client_cycle = itertools.cycle([fake_client])  # type: ignore[assignment]
 
-        request = LLMRequest(
-            prompt="hi",
-            model="gpt-test",
-            temperature=0.0,
-        )
+class TestProviderRegistryDeepSeekThinking:
+    """Registry exposes the new class alongside the non-thinking default."""
 
-        await base.complete(request)
-
-        fake_client.chat.completions.create.assert_awaited_once()
-        kwargs = fake_client.chat.completions.create.await_args.kwargs
-        # Base class returns ``{}`` from the hook, so ``extra_body`` must
-        # not appear at all in the call kwargs.
-        assert "extra_body" not in kwargs
-
-
-class TestProviderRegistryDeepSeek:
-    """Registry now maps ``deepseek`` to the specialised subclass."""
-
-    def test_registry_uses_deepseek_subclass(self) -> None:
+    def test_registry_maps_deepseek_thinking_to_subclass(self) -> None:
         from course_supporter.llm.providers import PROVIDER_REGISTRY
 
+        assert PROVIDER_REGISTRY["deepseek_thinking"] is DeepSeekThinkingProvider
+        # Non-think mapping must stay untouched (KD-2.4-S contract preserved).
         assert PROVIDER_REGISTRY["deepseek"] is DeepSeekProvider
 
-    def test_factory_creates_deepseek_provider_instance(self) -> None:
+    def test_factory_shares_deepseek_key_pool(self) -> None:
+        """``DEEPSEEK_API_KEY`` ENV powers both providers via aliased Settings field."""
         from course_supporter.config import Settings
         from course_supporter.llm.factory import create_providers
 
@@ -210,6 +187,6 @@ class TestProviderRegistryDeepSeek:
         )
         providers = create_providers(s)
         assert isinstance(providers["deepseek"], DeepSeekProvider)
-        # Subclass relationship preserved for any downstream isinstance
-        # checks against the parent class.
-        assert isinstance(providers["deepseek"], OpenAICompatProvider)
+        assert isinstance(providers["deepseek_thinking"], DeepSeekThinkingProvider)
+        # Subclass relationship preserved for any downstream isinstance checks.
+        assert isinstance(providers["deepseek_thinking"], OpenAICompatProvider)


### PR DESCRIPTION
## Summary

- New `DeepSeekThinkingProvider` (sibling of `DeepSeekProvider` without the thinking-disabled override) lets video Pass 2a route through reasoning-on DeepSeek V4 Pro while keeping schema-bound stages (safety_check, Pass 2c) on the non-think default.
- `video_pass_2a_mapping` ladder rebalanced: rung 1 `deepseek_thinking/deepseek-v4-pro` → rung 2 `dashscope/qwen3.7-max` → rung 3 `gemini/gemini-2.5-pro`. Dropped both flash-tier rungs (5-way spike proved they collapse 67-79%).
- Ratifies KD-2.4-S (legalises Phase 2.1 C5 orphan thinking-disabled decision; corrects historical "KD-2.1-O" misnaming) and KD-2.4-T (per-stage thinking opt-in; supersedes KD-2.4-S in the reasoning-tier corner). Vision side landed in `refactoring-vision@5a9b1b1`.
- Registry refresh: `deepseek-v4-pro` context 131072 → 1048576, max_output_tokens 8192 → 65536 per the official DeepSeek docs verified 2026-06-05.

## Background — 5-way spike (2026-06-05)

Same input video (`0I8S6diyDjw`, English, ~10:48), byte-identical reconstructed Pass 2a prompt, only the model changed:

| model | mode | largest dur% | result |
|---|---|---:|---|
| gemini-3.1-flash-lite | cheap-tier | 75.3% | catch-all collapse |
| qwen3.7-plus | cheap-tier (5.5k reasoning_tokens) | 79.3% | catch-all collapse |
| deepseek-v4-pro NON-thinking | cheap-tier (0 reasoning_tokens) | 66.8% | catch-all collapse |
| dashscope/qwen3.7-max | reasoning | 25.9% | balanced |
| deepseek-v4-pro thinking ON | reasoning (21k reasoning_tokens) | 23.5% | balanced |

Empirical reasoning_tokens boundary ≈ 10k separates the two regimes. Plus and non-think Pro produced the same patological catch-all collapse as gemini-3.1-flash-lite — re-labelled but unchanged. The video Pass 2a workload needs a model that emits a full chain-of-thought, not just any "reasoning-tier" badge.

## n=1 caveat

Rung order is calibrated against a single English mid-length lecture. Other languages, very short or very long videos warrant their own calibration cycle on live operations per KD-2.3-X (per-source-type ladder calibration). Recorded in `phase-2-4/PHASE-2-4.md §K`.

## Acceptance

- [x] `ruff check` + `ruff format --check`
- [x] `mypy --strict` (129 src files, 0 issues)
- [x] `pre-commit run` on changed files (9): all hooks Passed
- [x] New tests `test_providers_deepseek_thinking.py` (6 tests, green)
- [x] Existing tests `test_providers_deepseek.py` (8 tests, green WITHOUT changes — proves KD-2.4-S contract preserved)
- [x] Full `pytest --run-db --run-redis`: 2232 passed / 0 failed / 3 skipped
- [x] Manual ladder ↔ registry membership (DD-2.4-K): all three rung IDs ∈ registry

## Test plan

- [ ] Live post-merge: upload another video → ESC `video_pass_2a_mapping` shows `provider=deepseek_thinking, model=deepseek-v4-pro, success=t, latency ~7 min (reasoning-tier), finish=stop`, segmentation balanced (largest <30%).
- [ ] Live sanity: existing `deepseek` consumers (`safety_check`, Pass 2c denoise) still call with `extra_body={"thinking":{"type":"disabled"}}` — verifiable via per-call ESC absence of `reasoning_content` proxy (latency in the ~10-20s band, not minutes).

## Vision-side reference

`refactoring-vision@5a9b1b1` (`task(2.4.17): KD-2.4-S + KD-2.4-T — DeepSeek thinking-mode policy`) — full KD text + vision.md status v0.20.11 + changelog. Held locally (vision repo has no GitHub remote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)