### PR TITLE
task(2.4.17-followup): collapse redundant deepseek_thinking_base_url

### DIFF
--- a/src/course_supporter/config.py
+++ b/src/course_supporter/config.py
@@ -241,10 +241,12 @@ class Settings(BaseSettings):
     # --- DeepSeek ---
     # DeepSeek uses OpenAI-compatible API via OpenAI SDK with custom base_url.
     # Other providers have their own SDKs with built-in endpoints.
+    # Both ``deepseek`` and ``deepseek_thinking`` providers share this single
+    # field — the thinking-on sibling differs only in the omitted thinking-
+    # disable hook (provider-side), not the endpoint. Factory wires both
+    # providers from ``s.deepseek_base_url``; collapsing to one field removes
+    # the drift-via-ENV-override risk that ReviewBot flagged on PR #458.
     deepseek_base_url: str = "https://api.deepseek.com"
-    # Same endpoint as deepseek_base_url — the thinking-on sibling only differs
-    # in the omitted thinking-disable hook (provider-side), not the endpoint.
-    deepseek_thinking_base_url: str = "https://api.deepseek.com"
 
     # --- Mistral ---
     # Mistral uses OpenAI-compatible API via OpenAI SDK with custom base_url.

--- a/src/course_supporter/llm/factory.py
+++ b/src/course_supporter/llm/factory.py
@@ -44,7 +44,11 @@ PROVIDER_CONFIGS: dict[str, ProviderFactoryConfig] = {
     ),
     "deepseek_thinking": ProviderFactoryConfig(
         get_default_model=lambda s: s.deepseek_thinking_default_model,
-        get_base_url=lambda s: s.deepseek_thinking_base_url,
+        # Shares the single ``deepseek_base_url`` Settings field with
+        # ``deepseek`` — the two providers diverge only in the thinking-mode
+        # hook (provider-side), not the endpoint. One source of truth removes
+        # the drift-via-ENV-override risk.
+        get_base_url=lambda s: s.deepseek_base_url,
         extra_kwargs={"provider_name": "deepseek_thinking"},
     ),
     "mistral": ProviderFactoryConfig(


### PR DESCRIPTION
## Summary

Addresses ReviewBot 💡 from #458 on `src/course_supporter/config.py` — `deepseek_base_url` / `deepseek_thinking_base_url` identical-default redundancy.

**Going deeper than the bot's as-written fix.** The bot suggested `deepseek_thinking_base_url: str = deepseek_base_url` — that only saves a string literal; the two fields would remain independently overridable via separate ENV vars (`DEEPSEEK_BASE_URL` vs `DEEPSEEK_THINKING_BASE_URL`), so the drift potential the bot itself flagged stays open.

This PR drops the `deepseek_thinking_base_url` field entirely and points the factory's `get_base_url=` at `s.deepseek_base_url` for the thinking sibling. One field, one source of truth, drift impossible by construction.

## What stays independent

`deepseek_thinking_default_model` — different semantic default from `deepseek_default_model`:

| field | default | rationale |
|---|---|---|
| `deepseek_default_model` | `deepseek-chat` | legacy convention |
| `deepseek_thinking_default_model` | `deepseek-v4-pro` | single reasoning-tier flagship per KD-2.4-T |

Those are NOT redundancy — different defaults serve different consumers.

## What this loses

Operator can no longer override the thinking sibling's endpoint independently via a separate ENV var. YAGNI: they hit the same `api.deepseek.com`; if a future split (e.g. dedicated V4 Pro staging) appears, restore the field then.

## Acceptance

- [x] `ruff check` + `ruff format --check`
- [x] `mypy --strict` (129 src files, 0 issues)
- [x] `pre-commit run` on changed files (2): all hooks Passed
- [x] `pytest tests/unit/test_llm/test_providers_deepseek*.py`: 15/15 PASSED
- [x] Full `pytest --run-db --run-redis`: 2232 passed / 0 failed / 3 skipped

## Background

Originally stacked off #458 as PR #459; GitHub auto-closed #459 when #458 merged with `--delete-branch` (stacked-PR base disappeared). Rebased onto post-merge main, identical commit content (`acb5819`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)