### PR TITLE
task(2.4.18): pass 2a infrastructure robustness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ dependencies = [
     # Security: magic-bytes file type detection (KD14)
     "python-magic>=0.4.27",
     "dashscope>=1.25.18",
+    # Direct httpx usage: STT providers (deepgram/elevenlabs) pass
+    # ``httpx.Timeout(...)``; LLM provider clients pin SDK timeout
+    # via ``httpx.Timeout`` (TASK-2.4.18). Was transitively pulled in
+    # by ``openai`` SDK; legalised as a first-class dependency.
+    "httpx>=0.28",
 ]
 
 [dependency-groups]
@@ -58,7 +63,6 @@ dev = [
     "ruff>=0.9",
     "mypy>=1.14",
     "pre-commit>=4.1",
-    "httpx>=0.28",
     "types-pyyaml>=6.0.12.20250915",
 ]
 docs = [

--- a/src/course_supporter/llm/providers/openai_compat.py
+++ b/src/course_supporter/llm/providers/openai_compat.py
@@ -16,6 +16,7 @@ import re
 from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 
+import httpx
 import openai
 from openai.types.chat import ChatCompletionMessageParam
 from pydantic import BaseModel
@@ -34,6 +35,12 @@ _OPENAI_OVERFLOW_PATTERN = re.compile(
     r"context length|too long|maximum context|tokens exceed",
     re.IGNORECASE,
 )
+
+# Explicit SDK timeout. Read budget covers reasoning-tier providers
+# (DeepSeek thinking-on observed 149-707s in TASK-2.4.17 live runs);
+# connect kept short so DNS / TLS hiccups fail fast and the ladder
+# escalates instead of hanging the ARQ event loop (TASK-2.4.18).
+_DEFAULT_HTTP_TIMEOUT = httpx.Timeout(900.0, connect=30.0)
 
 
 def _build_vision_content(
@@ -86,7 +93,10 @@ class OpenAICompatProvider(LLMProvider):
         self._api_keys = tuple(api_keys)
         self._base_url = base_url
         self._clients = tuple(
-            openai.AsyncOpenAI(api_key=k, base_url=base_url) for k in api_keys
+            openai.AsyncOpenAI(
+                api_key=k, base_url=base_url, timeout=_DEFAULT_HTTP_TIMEOUT
+            )
+            for k in api_keys
         )
         self._client_cycle: Iterator[openai.AsyncOpenAI] = itertools.cycle(
             self._clients
@@ -119,6 +129,11 @@ class OpenAICompatProvider(LLMProvider):
         Mapping:
         * RateLimitError / APITimeoutError / APIConnectionError /
           InternalServerError -> INFRASTRUCTURE.
+        * ``httpx.TimeoutException`` / builtin ``TimeoutError``
+          (alias of ``asyncio.TimeoutError`` since Py3.11) ->
+          INFRASTRUCTURE. Covers transport-level timeouts the OpenAI
+          SDK may surface unwrapped and outer ``asyncio.wait_for``
+          guards layered around the call.
         * BadRequestError with code ``context_length_exceeded``, or a
           message matching a known overflow pattern (DeepSeek /
           Mistral fallback) -> INPUT_OVERFLOW.
@@ -132,6 +147,8 @@ class OpenAICompatProvider(LLMProvider):
                 openai.APITimeoutError,
                 openai.APIConnectionError,
                 openai.InternalServerError,
+                httpx.TimeoutException,
+                TimeoutError,
             ),
         ):
             return ErrorCategory.INFRASTRUCTURE
@@ -154,7 +171,11 @@ class OpenAICompatProvider(LLMProvider):
 
         self._instructor_clients = tuple(
             _instructor.from_openai(
-                openai.AsyncOpenAI(api_key=k, base_url=self._base_url)
+                openai.AsyncOpenAI(
+                    api_key=k,
+                    base_url=self._base_url,
+                    timeout=_DEFAULT_HTTP_TIMEOUT,
+                )
             )
             for k in self._api_keys
         )

--- a/src/course_supporter/llm/stage_router.py
+++ b/src/course_supporter/llm/stage_router.py
@@ -391,7 +391,10 @@ class StageRouter:
                 response_validator(response.content)
             return response
         except Exception as exc:
-            error_message = str(exc)
+            # Guard against exception types whose ``str(exc)`` is empty
+            # (no args). Without this, ESC row degrades to "success=False,
+            # error_message=NULL" — zero diagnostic surface (TASK-2.4.18).
+            error_message = str(exc).strip() or f"{type(exc).__name__} (no message)"
             raise
         finally:
             if self._session_factory is not None:

--- a/src/course_supporter/storage/job_repository.py
+++ b/src/course_supporter/storage/job_repository.py
@@ -98,6 +98,14 @@ class JobRepository:
             msg = f"Job {job_id} not found"
             raise ValueError(msg)
 
+        # Idempotent no-op when target equals current. ARQ task replay
+        # (worker restart mid-await, ``max_tries`` retry, manual rerun)
+        # would otherwise raise on ``active → active`` and crash the
+        # second attempt before the real work runs (TASK-2.4.18).
+        # Mirrors ``update_stage`` idempotency.
+        if job.status == status:
+            return job
+
         allowed = JOB_TRANSITIONS.get(job.status, set())
         if status not in allowed:
             msg = (

--- a/src/course_supporter/worker.py
+++ b/src/course_supporter/worker.py
@@ -129,6 +129,13 @@ class WorkerSettings:
     keep_result: int = 3600
     poll_delay: float = 0.5
 
+    # ARQ defaults heartbeat to ``job_timeout`` (~6h here); explicit
+    # 120s makes the worker recoverable within reasonable bounds while
+    # comfortably exceeding a single reasoning-tier LLM await
+    # (TASK-2.4.17 observed 149-707s) when the loop is unblocked by
+    # the SDK timeout (openai_compat._DEFAULT_HTTP_TIMEOUT, TASK-2.4.18).
+    health_check_interval: int = 120
+
 
 class HomeworkWorkerSettings:
     """ARQ worker settings for the homework queue.
@@ -156,3 +163,4 @@ class HomeworkWorkerSettings:
 
     keep_result: int = 3600
     poll_delay: float = 0.5
+    health_check_interval: int = 120

--- a/tests/integration/test_job_repository.py
+++ b/tests/integration/test_job_repository.py
@@ -172,6 +172,33 @@ class TestJobTransitionValidation:
         with pytest.raises(ValueError, match="Invalid job status transition"):
             await repo.update_status(job.id, "complete")
 
+    async def test_update_status_idempotent_active_to_active(
+        self, db_session: AsyncSession, seed_root_node: CourseNode
+    ) -> None:
+        """Same-state transition is a no-op and preserves ``started_at``.
+
+        ARQ task replay (worker restart mid-await, ``max_tries`` retry,
+        manual rerun) would otherwise hit
+        ``Invalid job status transition: active → active`` and crash the
+        second attempt before the real work runs (TASK-2.4.18).
+        """
+        repo = JobRepository(db_session)
+        job = await repo.create(
+            tenant_id=seed_root_node.tenant_id,
+            course_node_id=seed_root_node.id,
+            job_type="ingest",
+        )
+
+        first = await repo.update_status(job.id, "active")
+        first_started_at = first.started_at
+        assert first.status == "active"
+        assert first_started_at is not None
+
+        # Replay: no exception, same row returned, ``started_at`` frozen.
+        second = await repo.update_status(job.id, "active")
+        assert second.status == "active"
+        assert second.started_at == first_started_at
+
 
 class TestJobQueries:
     """Query methods against real data."""

--- a/tests/unit/test_llm/test_provider_classifiers.py
+++ b/tests/unit/test_llm/test_provider_classifiers.py
@@ -280,6 +280,21 @@ def _openai_other_bad_request() -> Exception:
     )
 
 
+def _httpx_read_timeout() -> Exception:
+    # ``httpx.ReadTimeout`` is the concrete timeout the SDK surfaces
+    # when the explicit ``httpx.Timeout(read=...)`` budget is hit. We
+    # classify the base ``httpx.TimeoutException`` so any variant
+    # (read / write / connect / pool) escalates the same way.
+    return httpx.ReadTimeout("read timeout")
+
+
+def _builtin_timeout_error() -> Exception:
+    # In Py3.11+ ``asyncio.TimeoutError`` is an alias of builtin
+    # ``TimeoutError``; the classifier matches the latter to cover
+    # outer ``asyncio.wait_for`` guards layered around the SDK call.
+    return TimeoutError()
+
+
 class TestOpenAICompatClassifier:
     @pytest.mark.parametrize(
         ("factory", "expected"),
@@ -288,6 +303,8 @@ class TestOpenAICompatClassifier:
             (_openai_timeout, ErrorCategory.INFRASTRUCTURE),
             (_openai_connection_error, ErrorCategory.INFRASTRUCTURE),
             (_openai_internal_server, ErrorCategory.INFRASTRUCTURE),
+            (_httpx_read_timeout, ErrorCategory.INFRASTRUCTURE),
+            (_builtin_timeout_error, ErrorCategory.INFRASTRUCTURE),
             (_openai_overflow_by_code, ErrorCategory.INPUT_OVERFLOW),
             (_deepseek_overflow_by_message, ErrorCategory.INPUT_OVERFLOW),
             (_openai_other_bad_request, ErrorCategory.SEMANTIC),

--- a/uv.lock
+++ b/uv.lock
@@ -409,6 +409,7 @@ dependencies = [
     { name = "dashscope" },
     { name = "fastapi", extra = ["standard"] },
     { name = "google-genai" },
+    { name = "httpx" },
     { name = "imagehash" },
     { name = "instructor" },
     { name = "jinja2" },
@@ -435,7 +436,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -460,6 +460,7 @@ requires-dist = [
     { name = "dashscope", specifier = ">=1.25.18" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.128" },
     { name = "google-genai", specifier = ">=1.12" },
+    { name = "httpx", specifier = ">=0.28" },
     { name = "imagehash", specifier = ">=4.3" },
     { name = "instructor", specifier = ">=1.7" },
     { name = "jinja2", specifier = ">=3.1" },
@@ -486,7 +487,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.28" },
     { name = "mypy", specifier = ">=1.14" },
     { name = "pre-commit", specifier = ">=4.1" },
     { name = "pytest", specifier = ">=8.3" },


### PR DESCRIPTION
## Summary

Five-point infrastructure hardening triggered by TASK-2.4.17 live verification: a 707s reasoning-tier video Pass 2a call blocked the ARQ event loop, the implicit SDK timeout did not fire cleanly, ARQ heartbeat expired, the failed ESC row landed with `error_message=NULL` (zero diagnostic surface), and no ladder cascade to rung 2 was triggered.

- **SDK timeout** — `openai.AsyncOpenAI(..., timeout=httpx.Timeout(900.0, connect=30.0))` on both eager and lazy-instructor clients. Covers reasoning-tier latency band (149–707s observed in TASK-2.4.17) with margin; short connect fails fast. DeepSeek + DeepSeekThinking inherit.
- **Idempotent `JobRepository.update_status`** — same-state target is a no-op returning the existing row, preserving `started_at`. Closes the `active → active` ARQ replay race that crashed the second attempt before real work ran. Mirrors `update_stage`.
- **ESC `error_message` non-NULL guarantee** — `StageRouter._call_with_log` line 394 now uses `str(exc).strip() or f"{type(exc).__name__} (no message)"`. Defensive against parameter-less exceptions; the real-prod SIGKILL-mid-await scenario is removed primarily by SDK timeout + heartbeat.
- **ARQ `health_check_interval = 120`** on both `WorkerSettings` + `HomeworkWorkerSettings`. ARQ default heartbeat is `job_timeout`-derived (~6h here); 120s comfortably exceeds a single reasoning-tier await once the loop is unblocked.
- **`OpenAICompatProvider.classify_error`** += `httpx.TimeoutException` + builtin `TimeoutError` (alias of `asyncio.TimeoutError` since Py3.11) → INFRASTRUCTURE. Covers an unwrapped transport timeout and outer `asyncio.wait_for` guards layered around the SDK call.

Bonus: `httpx>=0.28` legalised from `dev` → main `dependencies`. Already directly imported by `webhook.py`, `stt/providers/deepgram.py`, `stt/providers/elevenlabs.py`; was working only via the openai SDK's transitive pull.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — 288 files unchanged
- [x] `mypy src/` — 129 source files, no issues
- [x] `pre-commit run --files <staged>` — 9/9 hooks pass (legacy ruff alias + format + mypy + EOL + trailing-ws + yaml + toml + large-file + debug-stmt)
- [x] `pytest --run-db --run-redis` — **2235 passed / 0 failed / 3 skipped** (baseline 2232/0/3 → +3 new)
  - `TestOpenAICompatClassifier`: 2 new parametrised cases (`_httpx_read_timeout`, `_builtin_timeout_error` → INFRASTRUCTURE)
  - `TestJobTransitionValidation::test_update_status_idempotent_active_to_active` — locks the replay-safe invariant
- [ ] Live verification (post-merge): re-run a long video, confirm that any Pass 2a failure produces ESC row with `error_message` non-NULL; that a timeout / connection error escalates the ladder to rung 2 instead of hanging the worker