### PR TITLE
task(2.4.19): balance validator for video Pass 2a (anti-dominant quality gate)

### DIFF
--- a/src/course_supporter/ingestion/video_pipeline/steps.py
+++ b/src/course_supporter/ingestion/video_pipeline/steps.py
@@ -28,8 +28,9 @@ import asyncio
 import bisect
 import itertools
 import json
+from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import structlog
 from pydantic import ValidationError
@@ -39,6 +40,7 @@ from course_supporter.ingestion.base import ProcessingError, UnsupportedFormatEr
 from course_supporter.ingestion.schemas import (
     AudioPass2aResult,
     AudioPass2cResult,
+    AudioSegmentDraft,
     DocumentSegmentDraft,
     DocumentSummaryDraft,
     VisualSceneRef,
@@ -54,7 +56,10 @@ from course_supporter.ingestion.video_pipeline.schemas import (
     VideoFileMetadata,
 )
 from course_supporter.language import display_name
-from course_supporter.llm.error_categories import StructuralRetryError
+from course_supporter.llm.error_categories import (
+    LadderExhaustedError,
+    StructuralRetryError,
+)
 from course_supporter.models.source import ChunkType
 from course_supporter.service_logging import get_current_job_id
 
@@ -87,6 +92,34 @@ _MAX_DURATION_MS = 150 * 60 * 1000
 # rationale: starting default; calibrated in 2.4.5 (the real consumer of
 # pauses — Pass 2a segment boundaries, KD2c).
 _PAUSE_THRESHOLD_MS = 700
+
+# Pass 2a balance gate threshold (TASK-2.4.19). The largest top-level
+# segment must cover no more than this fraction of the transcript — a
+# deterministic anti-dominant guard above the LLM's own reasoning. Live
+# calibration n=4 (1 EN spike + 3 UKR jobs, 10:48-90 min): healthy band
+# 23-35 %; the single historical 55 % outlier (EN spike `0I8S6diyDjw`)
+# motivates the gate. 0.45 leaves a clean margin above the healthy band
+# without forcing over-segmentation. Semantically ≈ "must have at least
+# 3 top-level segments with the dominant one bounded".
+_BALANCE_THRESHOLD: Final = 0.45
+
+
+def largest_segment_share(segments: Sequence[AudioSegmentDraft]) -> float:
+    """Return ``max(span) / sum(spans)`` over top-level word-idx ranges.
+
+    Used by the Pass 2a balance gate (TASK-2.4.19) to detect
+    anti-dominant collapse — a single top-level segment swallowing
+    most of the transcript. Past the schema validator empty input is
+    a programming bug (``AudioPass2aResult._full_cover`` already
+    rejects empty ``segments`` whenever ``total_word_count > 0``);
+    raises ``ValueError`` to surface it instead of silently
+    short-circuiting the gate.
+    """
+    if not segments:
+        msg = "largest_segment_share: empty segments"
+        raise ValueError(msg)
+    spans = [seg.end_word_idx - seg.start_word_idx for seg in segments]
+    return max(spans) / sum(spans)
 
 
 # ── Krok 1-4 — invoked from process_raw ────────────────────────────
@@ -274,8 +307,22 @@ async def step_5_pass2a_mapping(
     anchoring each visual to a transcript word so the LLM segments the clean
     word-stream while seeing a deterministic visual-overlay block.
 
-    Failures (carrier cache miss, ladder exhausted, persistent JSON
-    validation fail, word-idx out of range) → ``ProcessingError`` (R1).
+    Pass 2a balance gate (TASK-2.4.19): the in-closure ``_validator``
+    rejects parses whose largest top-level segment exceeds
+    ``_BALANCE_THRESHOLD`` of the transcript via ``StructuralRetryError``
+    — the ladder runs its standard one-retry-per-rung + cascade with a
+    self-contained feedback string. If every rung collapses on balance
+    (``parsed["fallback"]`` populated), the last valid parse is accepted
+    as degraded, a ``video.pass2a.degraded_segmentation_accepted``
+    warning is emitted, the job does NOT fail. Schema / infra
+    exhaustion without any valid parse (``parsed["fallback"]`` empty)
+    re-raises ``LadderExhaustedError`` so the orchestrator's failure
+    path treats it as a real provider outage — the degraded-catch
+    deliberately does not mask a real failure.
+
+    Failures: carrier cache miss / word-idx out of range →
+    ``ProcessingError`` (R1); schema validation fail on every rung →
+    ``LadderExhaustedError``.
     """
     job_id = get_current_job_id()
     if job_id is None:
@@ -312,6 +359,13 @@ async def step_5_pass2a_mapping(
         Reuses ``AudioPass2aResult`` (same word-idx schema) — the contiguity /
         full-cover / subsegment-cover validators apply unchanged, with
         ``total_word_count`` carried via the Pydantic context.
+
+        After a valid parse, runs the Pass 2a balance gate (TASK-2.4.19):
+        if the largest top-level segment exceeds ``_BALANCE_THRESHOLD``,
+        stores ``local`` in ``parsed["fallback"]`` for the degraded-catch
+        path in the caller and raises ``StructuralRetryError`` with a
+        self-contained feedback identifying the dominant segment and the
+        word-range to split.
         """
         try:
             local = AudioPass2aResult.model_validate_json(
@@ -333,17 +387,61 @@ async def step_5_pass2a_mapping(
                 "Regenerate the response with valid output."
             )
             raise StructuralRetryError(feedback) from exc
+
+        share = largest_segment_share(local.segments)
+        if share > _BALANCE_THRESHOLD:
+            spans = [s.end_word_idx - s.start_word_idx for s in local.segments]
+            max_idx = spans.index(max(spans))
+            dom = local.segments[max_idx]
+            pct = round(share * 100, 1)
+            balance_feedback = (
+                f'Segmentation imbalance: segment #{max_idx} ("{dom.title}") '
+                f"covers {pct}% of the transcript (words "
+                f"{dom.start_word_idx}-{dom.end_word_idx} of "
+                f"{total_word_count}). Top-level segments must each cover "
+                f"at most {int(_BALANCE_THRESHOLD * 100)}%. Split this range "
+                f"into multiple top-level segments around distinct subtopics "
+                f"within words {dom.start_word_idx}-{dom.end_word_idx}, "
+                f"keeping the rest of the segmentation intact."
+            )
+            parsed["fallback"] = local
+            logger.warning(
+                "video_pass2a.balance.threshold_exceeded",
+                job_id=str(job_id),
+                dominant_idx=max_idx,
+                share=share,
+                dominant_words=(dom.start_word_idx, dom.end_word_idx),
+                total_word_count=total_word_count,
+            )
+            raise StructuralRetryError(balance_feedback)
         parsed["result"] = local
 
-    await stage_router.execute_for_stage(
-        _PASS_2A_STAGE_NAME,
-        response_validator=_validator,
-        expects_json=True,
-        words_count=total_word_count,
-        words_json=words_json,
-        visuals=visuals,
-        language=display_name(doc.language) if doc.language else None,
-    )
+    try:
+        await stage_router.execute_for_stage(
+            _PASS_2A_STAGE_NAME,
+            response_validator=_validator,
+            expects_json=True,
+            words_count=total_word_count,
+            words_json=words_json,
+            visuals=visuals,
+            language=display_name(doc.language) if doc.language else None,
+        )
+    except LadderExhaustedError:
+        # Distinguish balance-exhaustion (fallback populated by the
+        # validator's accept-then-flag-as-degraded path) from schema /
+        # infra exhaustion (no rung ever produced a valid parse). The
+        # latter is a real provider outage and must not be masked.
+        if parsed.get("fallback") is None:
+            raise
+        fallback = parsed["fallback"]
+        logger.warning(
+            "video.pass2a.degraded_segmentation_accepted",
+            job_id=str(job_id),
+            share=largest_segment_share(fallback.segments),
+            segments=len(fallback.segments),
+            total_word_count=total_word_count,
+        )
+        parsed["result"] = fallback
     result = parsed["result"]
 
     cumsum = chars_per_word_cumsum(words)

--- a/tests/unit/test_ingestion/test_pass_2a_language_kwarg.py
+++ b/tests/unit/test_ingestion/test_pass_2a_language_kwarg.py
@@ -289,8 +289,14 @@ class TestVideoStep5LanguageKwarg:
 
     @pytest.mark.asyncio
     async def test_pinned_language_resolves_to_english_display_name(self) -> None:
-        words = [SttWord(text="alpha", start_ms=0, end_ms=500)]
+        words = [
+            SttWord(text="alpha", start_ms=0, end_ms=500),
+            SttWord(text="beta", start_ms=600, end_ms=1100),
+            SttWord(text="gamma", start_ms=1200, end_ms=1800),
+        ]
         doc = _video_doc(words, language="ukr")
+        # 3 balanced segments so the Pass 2a balance gate (TASK-2.4.19)
+        # passes; this test only inspects the render_context language kwarg.
         router = _CapturingStageRouter(
             json.dumps(
                 {
@@ -298,15 +304,16 @@ class TestVideoStep5LanguageKwarg:
                     "description": "D.",
                     "segments": [
                         {
-                            "start_word_idx": 0,
-                            "end_word_idx": 1,
-                            "title": "Seg",
-                            "description": "Segment description.",
+                            "start_word_idx": i,
+                            "end_word_idx": i + 1,
+                            "title": f"Seg-{i}",
+                            "description": f"Segment {i} description.",
                             "main_concepts": [],
                             "secondary_concepts": [],
                             "noisy": False,
                             "subsegments": [],
                         }
+                        for i in range(3)
                     ],
                 }
             )
@@ -325,8 +332,14 @@ class TestVideoStep5LanguageKwarg:
 
     @pytest.mark.asyncio
     async def test_unset_language_forwards_none(self) -> None:
-        words = [SttWord(text="alpha", start_ms=0, end_ms=500)]
+        words = [
+            SttWord(text="alpha", start_ms=0, end_ms=500),
+            SttWord(text="beta", start_ms=600, end_ms=1100),
+            SttWord(text="gamma", start_ms=1200, end_ms=1800),
+        ]
         doc = _video_doc(words, language=None)
+        # 3 balanced segments so the Pass 2a balance gate (TASK-2.4.19)
+        # passes; this test only inspects the render_context language kwarg.
         router = _CapturingStageRouter(
             json.dumps(
                 {
@@ -334,15 +347,16 @@ class TestVideoStep5LanguageKwarg:
                     "description": "D.",
                     "segments": [
                         {
-                            "start_word_idx": 0,
-                            "end_word_idx": 1,
-                            "title": "Seg",
-                            "description": "Segment description.",
+                            "start_word_idx": i,
+                            "end_word_idx": i + 1,
+                            "title": f"Seg-{i}",
+                            "description": f"Segment {i} description.",
                             "main_concepts": [],
                             "secondary_concepts": [],
                             "noisy": False,
                             "subsegments": [],
                         }
+                        for i in range(3)
                     ],
                 }
             )

--- a/tests/unit/test_ingestion/test_video_pass2a.py
+++ b/tests/unit/test_ingestion/test_video_pass2a.py
@@ -69,23 +69,31 @@ def _video_doc(words: list[SttWord], visuals: list[tuple[int, str]]) -> SourceDo
 
 
 def _one_segment_json(render_context: dict[str, Any]) -> str:
-    """A valid AudioPass2aResult JSON covering the whole word stream."""
+    """A balanced AudioPass2aResult JSON covering the whole word stream.
+
+    Splits the word stream evenly across the available words so the
+    Pass 2a balance gate (TASK-2.4.19) passes — single-segment output
+    is rejected by the validator. Concepts and ``noisy`` are concentrated
+    on the first segment so existing aggregation assertions stay valid.
+    """
     n = render_context["words_count"]
+    boundaries = [round(i * n / 3) for i in range(4)]
     return json.dumps(
         {
             "title": "Theme",
             "description": "Doc-level description.",
             "segments": [
                 {
-                    "start_word_idx": 0,
-                    "end_word_idx": n,
-                    "title": "Seg",
-                    "description": "Segment description.",
-                    "main_concepts": ["concept-a"],
-                    "secondary_concepts": ["concept-b"],
-                    "noisy": True,
+                    "start_word_idx": boundaries[i],
+                    "end_word_idx": boundaries[i + 1],
+                    "title": f"Seg-{i}",
+                    "description": f"Segment {i} description.",
+                    "main_concepts": ["concept-a"] if i == 0 else [],
+                    "secondary_concepts": ["concept-b"] if i == 0 else [],
+                    "noisy": i == 0,
                     "subsegments": [],
                 }
+                for i in range(3)
             ],
         }
     )
@@ -211,14 +219,17 @@ class TestStep5:
             )
 
         assert isinstance(summary, DocumentSummaryDraft)
-        seg = summary.segments[0]
-        # bridge: word-idx [0, 3) → char offsets [0, len(assemble_text)].
-        assert seg.start_pos == 0
-        assert seg.end_pos == len(doc.assemble_text()) == 16  # "alpha beta gamma"
+        # Balanced 3-segment fixture: first segment starts at 0, last ends at
+        # end of the transcript — covers the word-idx → char-offset bridge.
+        first = summary.segments[0]
+        last = summary.segments[-1]
+        assert first.start_pos == 0
+        assert last.end_pos == len(doc.assemble_text()) == 16  # "alpha beta gamma"
         # timestamps adapted ms → sec (the single audio→video difference).
-        assert seg.start_time_sec == 0.0
-        assert seg.end_time_sec == 1.8
-        assert seg.noisy is True
+        assert first.start_time_sec == 0.0
+        assert last.end_time_sec == 1.8
+        # noisy concentrated on the first segment in the fixture.
+        assert first.noisy is True
         # concept union+dedup (secondary minus main).
         assert summary.main_concepts == ["concept-a"]
         assert summary.secondary_concepts == ["concept-b"]

--- a/tests/unit/test_ingestion/test_video_pass2a_balance.py
+++ b/tests/unit/test_ingestion/test_video_pass2a_balance.py
@@ -1,0 +1,321 @@
+"""Tests for the Pass 2a balance gate (TASK-2.4.19).
+
+CI-level: pure helper (boundary cases) + ``step_5_pass2a_mapping``
+integration scenarios exercising the validator's anti-dominant guard and
+the degraded-catch fork in the caller. The fake router walks a flat
+content sequence as one attempt per slot so retry + cascade reduce to a
+linear list — sufficient to verify validator path (raise vs accept) and
+the caller's ``LadderExhaustedError`` handling.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from course_supporter.ingestion.schemas import AudioSegmentDraft, DocumentSummaryDraft
+from course_supporter.ingestion.video_pipeline import steps
+from course_supporter.ingestion.video_pipeline.schemas import SttResult, SttWord
+from course_supporter.ingestion.video_pipeline.steps import (
+    _BALANCE_THRESHOLD,
+    largest_segment_share,
+)
+from course_supporter.llm.error_categories import (
+    LadderExhaustedError,
+    StructuralRetryError,
+)
+from course_supporter.llm.stage_router import StageResult
+from course_supporter.models.source import (
+    ChunkType,
+    ContentChunk,
+    SourceDocument,
+    SourceType,
+)
+
+_GET_JOB_ID = "course_supporter.ingestion.video_pipeline.steps.get_current_job_id"
+_JOB_ID = uuid.UUID("00000000-0000-0000-0000-000000000019")
+
+
+def _seg(start: int, end: int, title: str = "t") -> AudioSegmentDraft:
+    return AudioSegmentDraft(
+        start_word_idx=start,
+        end_word_idx=end,
+        title=title,
+        description="d",
+        main_concepts=[],
+        secondary_concepts=[],
+        noisy=False,
+        subsegments=[],
+    )
+
+
+class TestLargestSegmentShare:
+    """Pure helper — Pass 2a balance metric."""
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(ValueError, match="empty segments"):
+            largest_segment_share([])
+
+    def test_single_segment(self) -> None:
+        # max == sum → 1.0
+        assert largest_segment_share([_seg(0, 10)]) == 1.0
+
+    def test_balanced_well_below_threshold(self) -> None:
+        # spans 40 / 35 / 25 → max 40, sum 100 → 0.40
+        segs = [_seg(0, 40), _seg(40, 75), _seg(75, 100)]
+        assert largest_segment_share(segs) == pytest.approx(0.40)
+
+    def test_exact_threshold_boundary_does_not_trigger(self) -> None:
+        # spans 45 / 45 / 10 → max 45, sum 100 → 0.45 exactly.
+        # Gate uses strict ``>`` — 0.45 must not trigger.
+        segs = [_seg(0, 45), _seg(45, 90), _seg(90, 100)]
+        result = largest_segment_share(segs)
+        assert result == pytest.approx(0.45)
+        assert result <= _BALANCE_THRESHOLD
+
+    def test_just_above_threshold_triggers(self) -> None:
+        # spans 46 / 45 / 9 → max 46, sum 100 → 0.46
+        segs = [_seg(0, 46), _seg(46, 91), _seg(91, 100)]
+        result = largest_segment_share(segs)
+        assert result == pytest.approx(0.46)
+        assert result > _BALANCE_THRESHOLD
+
+    def test_just_below_threshold_does_not_trigger(self) -> None:
+        # spans 35 / 35 / 30 → max 35, sum 100 → 0.35
+        segs = [_seg(0, 35), _seg(35, 70), _seg(70, 100)]
+        result = largest_segment_share(segs)
+        assert result == pytest.approx(0.35)
+        assert result < _BALANCE_THRESHOLD
+
+
+# ── Step 5 integration ───────────────────────────────────────────────────
+
+
+def _words(*specs: tuple[str, int, int]) -> list[SttWord]:
+    return [SttWord(text=t, start_ms=s, end_ms=e) for t, s, e in specs]
+
+
+def _video_doc(words: list[SttWord]) -> SourceDocument:
+    return SourceDocument(
+        source_type=SourceType.VIDEO,
+        source_url="s3://b/v.mp4",
+        title="v",
+        chunks=[
+            ContentChunk(
+                chunk_type=ChunkType.TRANSCRIPT,
+                text=" ".join(w.text for w in words),
+                index=0,
+            )
+        ],
+    )
+
+
+def _redis_with(stt: SttResult) -> AsyncMock:
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=stt.model_dump_json())
+    return redis
+
+
+def _result_json(spans: list[tuple[int, int]], title: str = "Doc") -> str:
+    """Build a valid ``AudioPass2aResult`` JSON with the given word ranges."""
+    return json.dumps(
+        {
+            "title": title,
+            "description": "Doc-level description.",
+            "segments": [
+                {
+                    "start_word_idx": s,
+                    "end_word_idx": e,
+                    "title": f"Seg-{i}",
+                    "description": f"Description of segment {i}.",
+                    "main_concepts": [],
+                    "secondary_concepts": [],
+                    "noisy": False,
+                    "subsegments": [],
+                }
+                for i, (s, e) in enumerate(spans)
+            ],
+        }
+    )
+
+
+class _LadderFakeRouter:
+    """Walks a content sequence and mirrors ``StageRouter`` validator semantics.
+
+    Each item is one attempt slot. If the validator raises
+    ``StructuralRetryError`` — that slot is exhausted and we advance. If
+    it returns cleanly — we return ``StageResult``. After all items are
+    exhausted — we raise ``LadderExhaustedError``. Models retry +
+    cascade as a flat list; sufficient for verifying the validator
+    path (raise vs accept) and the caller's exhaustion handling.
+    """
+
+    def __init__(self, contents: list[str]) -> None:
+        self.contents = contents
+        self.calls: list[str] = []
+
+    async def execute_for_stage(
+        self,
+        stage_name: str,
+        *,
+        response_validator: Any = None,
+        contents: Any = None,
+        **render_context: Any,
+    ) -> StageResult:
+        last_exc: StructuralRetryError | None = None
+        for content in self.contents:
+            self.calls.append(content)
+            try:
+                if response_validator is not None:
+                    response_validator(content)
+            except StructuralRetryError as exc:
+                last_exc = exc
+                continue
+            return StageResult(
+                content=content,
+                provider_used="p",
+                model_used="m",
+                attempt_count=1,
+            )
+        raise LadderExhaustedError(
+            stage_name,
+            [("p", "m", str(last_exc) if last_exc else "no reason")],
+        )
+
+
+class TestStep5BalanceGate:
+    """Validator + caller integration via a sequence-walking fake router."""
+
+    async def test_balanced_parse_passes_through(self) -> None:
+        """share ≤ 0.45 → normal flow, single validator call."""
+        words = _words(*[(f"w{i}", i * 100, i * 100 + 50) for i in range(10)])
+        stt = SttResult(language="en", duration_ms=1000, words=words, pauses=[])
+        doc = _video_doc(words)
+        # spans 4 / 3 / 3 → max 4/10 = 0.40 (≤ 0.45)
+        balanced = _result_json([(0, 4), (4, 7), (7, 10)])
+        router = _LadderFakeRouter([balanced])
+
+        with patch(_GET_JOB_ID, return_value=_JOB_ID):
+            summary = await steps.step_5_pass2a_mapping(
+                doc, redis=_redis_with(stt), stage_router=router
+            )
+
+        assert isinstance(summary, DocumentSummaryDraft)
+        assert len(summary.segments) == 3
+        # Only one attempt — no retry on a balanced parse.
+        assert len(router.calls) == 1
+
+    async def test_balance_retry_followed_by_balanced_succeeds(self) -> None:
+        """Imbalanced rung 1 → balanced rung 2 succeeds; no degraded path."""
+        words = _words(*[(f"w{i}", i * 100, i * 100 + 50) for i in range(10)])
+        stt = SttResult(language="en", duration_ms=1000, words=words, pauses=[])
+        doc = _video_doc(words)
+        imbalanced = _result_json([(0, 8), (8, 10)])  # max 8/10 = 0.80
+        balanced = _result_json([(0, 4), (4, 7), (7, 10)])  # max 4/10 = 0.40
+        router = _LadderFakeRouter([imbalanced, balanced])
+
+        with patch(_GET_JOB_ID, return_value=_JOB_ID):
+            summary = await steps.step_5_pass2a_mapping(
+                doc, redis=_redis_with(stt), stage_router=router
+            )
+
+        assert isinstance(summary, DocumentSummaryDraft)
+        assert len(summary.segments) == 3
+        # Two attempts: imbalanced rejected (retry), balanced accepted.
+        assert len(router.calls) == 2
+
+    async def test_degraded_acceptance_when_all_rungs_imbalanced(self) -> None:
+        """Every rung produces valid-but-imbalanced parse → degraded fallback."""
+        words = _words(*[(f"w{i}", i * 100, i * 100 + 50) for i in range(10)])
+        stt = SttResult(language="en", duration_ms=1000, words=words, pauses=[])
+        doc = _video_doc(words)
+        # spans 8 / 2 → max 8/10 = 0.80 (> 0.45), sustained over all attempts.
+        imbalanced = _result_json([(0, 8), (8, 10)])
+        # Two rungs x one structural retry each -> 4 attempts, all imbalanced.
+        router = _LadderFakeRouter([imbalanced] * 4)
+
+        with patch(_GET_JOB_ID, return_value=_JOB_ID):
+            summary = await steps.step_5_pass2a_mapping(
+                doc, redis=_redis_with(stt), stage_router=router
+            )
+
+        # Degraded path: last valid parse promoted to result.
+        assert isinstance(summary, DocumentSummaryDraft)
+        assert len(summary.segments) == 2
+        # Every imbalanced attempt invoked the validator.
+        assert len(router.calls) == 4
+
+    async def test_schema_exhaustion_without_fallback_re_raises(self) -> None:
+        """All rungs return schema-invalid JSON → no fallback → propagation."""
+        words = _words(*[(f"w{i}", i * 100, i * 100 + 50) for i in range(10)])
+        stt = SttResult(language="en", duration_ms=1000, words=words, pauses=[])
+        doc = _video_doc(words)
+        # Invalid JSON triggers ValidationError → StructuralRetryError on the
+        # schema path (NOT the balance path); parsed["fallback"] never set.
+        bogus = json.dumps({"not": "a valid result"})
+        router = _LadderFakeRouter([bogus] * 4)
+
+        with (
+            patch(_GET_JOB_ID, return_value=_JOB_ID),
+            pytest.raises(LadderExhaustedError),
+        ):
+            await steps.step_5_pass2a_mapping(
+                doc, redis=_redis_with(stt), stage_router=router
+            )
+
+    async def test_balance_feedback_text_is_self_contained(self) -> None:
+        """Balance feedback names dominant segment + word range + threshold."""
+        words = _words(*[(f"w{i}", i * 100, i * 100 + 50) for i in range(10)])
+        stt = SttResult(language="en", duration_ms=1000, words=words, pauses=[])
+        doc = _video_doc(words)
+        # spans 0..7 / 7..10 → max 7/10 = 0.70 — dominant idx 0, range 0-7.
+        imbalanced = _result_json([(0, 7), (7, 10)], title="Doc")
+
+        captured: list[str] = []
+
+        class _CaptureRouter:
+            async def execute_for_stage(
+                self,
+                stage_name: str,
+                *,
+                response_validator: Any = None,
+                contents: Any = None,
+                **render_context: Any,
+            ) -> StageResult:
+                assert response_validator is not None
+                try:
+                    response_validator(imbalanced)
+                except StructuralRetryError as exc:
+                    captured.append(exc.feedback)
+                    raise LadderExhaustedError(
+                        "video_pass_2a_mapping",
+                        [("p", "m", exc.feedback)],
+                    ) from None
+                msg = "unreachable: balance gate should fire"
+                raise AssertionError(msg)
+
+        with patch(_GET_JOB_ID, return_value=_JOB_ID):
+            # Expect degraded acceptance after the single-attempt exhaustion.
+            await steps.step_5_pass2a_mapping(
+                doc, redis=_redis_with(stt), stage_router=_CaptureRouter()
+            )
+
+        assert len(captured) == 1
+        feedback = captured[0]
+        # Dominant segment idx + title.
+        assert "segment #0" in feedback
+        assert '"Seg-0"' in feedback
+        # Concrete word range of the dominant segment.
+        assert "words 0-7" in feedback
+        # Total word count for context.
+        assert "of 10" in feedback
+        # Threshold percentage as a hard constraint, not a generic retry plea.
+        assert "at most 45%" in feedback
+        # Explicit instruction to split that range, not generic "retry".
+        assert "Split this range" in feedback
+        # Must NOT collapse to the generic _structural_retry suffix.
+        assert "Please retry with a valid response" not in feedback


### PR DESCRIPTION
## Summary

Anti-dominant quality gate over the existing 0.5 validator machinery in `StageRouter`. Live-calibration n=4 (1 EN spike + 3 UKR jobs, 10:48-90 min) showed a healthy `largest_segment_share` band of **23-35%** on DeepSeek V4 Pro thinking-on; the historical EN-spike outlier (55%, 5 segments, multi-topic fusion) motivates a deterministic guard so a single rung's recency-bias collapse cannot ship. The production-thinking wrapper-as-root hypothesis was disproved on n=4 — this is an episodic-imbalance backstop, not a wrapper fix.

### Mechanism

- **`_BALANCE_THRESHOLD: Final = 0.45`** — named module constant; clean margin above the healthy band, semantically "at least 3 top-level segments with the dominant one bounded".
- **`largest_segment_share(segments) -> float`** — pure helper returning `max(span) / sum(spans)`. Empty input is a programming bug past the schema validator → `ValueError`.
- **`_validator` extension** — after a successful schema parse, computes the share. If `> threshold`, stashes the last valid parse in `parsed["fallback"]` and raises `StructuralRetryError` with a **self-contained** feedback identifying the dominant segment (idx, title, word range, transcript total, threshold percent, "split this range" instruction). Does not collapse to the generic retry-plea — the parse is valid, the imbalance is policy-rejected.
- **Caller side** — `execute_for_stage` wrapped in `try / except LadderExhaustedError`. With `parsed["fallback"]` populated → degraded acceptance + `video.pass2a.degraded_segmentation_accepted` warning, job does NOT fail. Empty → re-raise (schema/infra exhaustion is a real provider outage and must not be masked).

### Reuses unchanged
`execute_for_stage` validator plumbing; `_structural_retry` feedback channel (KD7 + KD16); `StructuralRetryError` / `LadderExhaustedError` carrier classes; ESC `success=True, error_message=feedback` row pattern.

### Explicit non-touches
- **`audio.py`** — threshold 0.45 calibrated on video; cross-source-type reuse opportunistic per KD-2.3-X. DD-candidate after audio calibration.
- **`_structural_retry` shared template** — schema + balance + Pass 2c share it; feedback is made self-sufficient instead.
- **presentation/text/web Pass 2a** + schemas (`AudioPass2aResult` / `AudioSegmentDraft`).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — unchanged
- [x] `mypy src/` — 129 source files, no issues
- [x] `pre-commit run --files <staged>` — 9/9 hooks pass
- [x] `pytest --run-db --run-redis` — **2246 passed / 0 failed / 3 skipped** (baseline 2235/0/3 → **+11 new**)
  - `TestLargestSegmentShare` (6): empty → ValueError, single → 1.0, balanced well-below, exact 0.45 boundary does NOT trigger (strict `>`), just-above triggers, just-below does not.
  - `TestStep5BalanceGate` (5): balanced passthrough (1 attempt); imbalanced rung 1 → balanced rung 2 succeeds (2 attempts, no degraded path); all-rungs-imbalanced → degraded acceptance + last fallback promoted (4 attempts); all-rungs-schema-invalid → `LadderExhaustedError` propagates (no fallback); feedback text self-contained (no generic-plea collapse).
  - Existing `_one_segment_json` fixture in `test_video_pass2a.py` → 3-balanced-segment (single-segment is invalid under the new invariant; bridge assertions adapted to first/last segment perspective).
  - 2 video tests in `test_pass_2a_language_kwarg.py`: 1-word → 3-word + 3-balanced-segment payloads so the language forwarding contract still verifies through the gate.
- [ ] Live verification (post-merge): re-ingest the 90-min UKR doctest webinar (job `019e9ca7-efa3-...`) and a 15-min Python hash-functions video; expect ESC trail to remain a single Pass 2a row with `success=True` (healthy 23-35% share never triggers a retry); also re-ingest the historical EN spike (`0I8S6diyDjw`) and confirm at least one balance-retry ESC row with `success=True, error_message=<balance feedback>` precedes the degraded or balanced result.