### PR TITLE
task(2.4.20): sprint-closure hygiene — make doctor + .reviewbot.md + docstring sweep

### DIFF
--- a/.reviewbot.md
+++ b/.reviewbot.md
@@ -1,0 +1,108 @@
+# Reviewer-bot config
+
+Repo-level guidance for the GitHub AI ReviewBot. Codifies disposition
+archetypes observed across phase-2.4 PRs (RR #445 … #463) so the bot's
+suggestions stay actionable and the team's responses stay consistent.
+
+This document lists only **archetypes that have actually fired more than
+once** in this repo's PR history; it is not a speculative style guide.
+New archetypes are added reactively, when a decline-pattern repeats.
+
+---
+
+## Archetype 1 — Import-relocation on test files
+
+**Pattern.** The bot proposes hoisting per-method local imports inside a
+test file to module-top or class-level. Trigger is usually a diff that
+adds N new sites of the same `import` while the bot's window does not
+include the M existing sites in unchanged classes elsewhere in the file.
+
+**Example (PR #457, task-2.4.16).** Bot flagged 14 new
+`from course_supporter.llm.providers import dashscope as ds_module` sites
+as "Repeated Module Imports within Test Methods". The unchanged
+`TestCompleteAsync` (8 methods) and `TestCompleteStructuredAsync` already
+followed the exact same per-method local-import convention. POST-MERGE
+note codified the rule:
+
+> «import-relocation suggestions on test files should be cross-checked
+> against pre-existing sibling-test convention before applying — bot's
+> window is shorter than the file»
+> — POST-MERGE-NOTES-2-4-16 §3
+
+**Disposition.** **DECLINE** with explicit citation of pre-existing
+sibling-test line numbers. Note that a separate dedicated refactor
+sub-task (hoist all sites at once, or extract a fixture) is the right
+vehicle if the convention itself needs revisiting — but a single PR
+that follows the existing convention is not that vehicle.
+
+---
+
+## Archetype 2 — Correct signal, wrong fix
+
+**Pattern.** The bot names a real architectural smell (redundancy, hidden
+coupling, drift surface) but proposes a fix that does not address the
+named concern at its root. Common shape: half-solution that saves a
+string literal but leaves the underlying drift potential open.
+
+**Example (PR #458, task-2.4.17).** Bot suggested
+`deepseek_thinking_base_url: str = deepseek_base_url` to deduplicate a
+literal. Real concern (operator could drift `DEEPSEEK_BASE_URL` vs
+`DEEPSEEK_THINKING_BASE_URL`) was correctly named; the suggested code
+left both fields and their env overrides intact. Follow-up PR #460
+dropped the field entirely: factory points at `s.deepseek_base_url` for
+both providers, drift impossible by construction. POST-MERGE note
+codified the rule:
+
+> «when a 💡 names a real concern but proposes the wrong fix, action it
+> deeper; when it proposes a stylistic preference without naming a
+> concrete concern, decline with mirror-sibling citation»
+> — POST-MERGE-NOTES-2-4-17 §3
+
+**Disposition.** **ACTION DEEPER** in a follow-up PR. Do not decline a
+bot suggestion when the underlying concern is real, even if the
+as-written fix is wrong-direction. Take the signal, design the fix
+independently, ship it as a separate atomic PR.
+
+---
+
+## Archetype 3 — Stylistic abstraction without a concrete concern
+
+**Pattern.** The bot proposes extracting a single-callsite block into a
+helper, splitting a closure, or otherwise restructuring code for
+"cleanliness" without naming a concrete concern (testability gap,
+duplication, performance, correctness). Common shape: premature
+abstraction (single callsite, zero reuse) or one-source-type refactor
+that diverges from sibling source-type conventions.
+
+**Example (PR #463, task-2.4.19).** Bot suggested extracting the video
+Pass 2a balance check into
+`_validate_segment_balance(local, total_word_count, job_id, parsed)`.
+Signal (closure growing in responsibilities) was correct; as-written fix
+leaked the same coupling via explicit parameters without improving
+testability, abstracted a single-callsite block (zero reuse), and
+diverged from sibling `_audio_pass_2a_validator` which uses the same
+closure pattern. POST-MERGE note codified the rule:
+
+> «abstracts a single-callsite block (zero reuse, premature
+> abstraction). Memory [[mirror-sibling-before-innovating-at-review-time]]
+> applies … extracting only video diverges sibling-mirror without
+> addressing the structural concern»
+> — POST-MERGE-NOTES-2-4-19 §3
+
+**Disposition.** **DECLINE** with mirror-sibling citation. The right
+vehicle for cross-source-type refactors (e.g. all Pass 2a validator
+closures across audio + video + presentation + text) is a dedicated
+refactor sub-task, not an inline patch on a feature PR. Single-callsite
+helpers without a named concern stay inline.
+
+---
+
+## How to use
+
+When a bot suggestion arrives:
+
+1. Identify the archetype (1, 2, or 3 above; or "none of these").
+2. Apply the disposition template.
+3. If the archetype is new (does not fit any of the three), do not
+   pre-emptively add it here — wait until the same pattern fires on a
+   second PR, then codify with the second citation included.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install lint format typecheck test test-cov check all run-api up down reset logs ps migrate db-upgrade db-downgrade db-reset
+.PHONY: help install lint format typecheck test test-cov check all run-api up down reset logs ps doctor migrate db-upgrade db-downgrade db-reset
 
 help:  ## Показати цю довідку
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
@@ -68,6 +68,24 @@ logs:  ## Показати логи сервісів
 
 ps:  ## Статус сервісів
 	docker compose ps
+
+doctor:  ## Pre-flight infra check (postgres/redis/minio up + alembic at head + pings)
+	@fail=0; \
+	running=$$(docker compose ps --status=running --services 2>/dev/null); \
+	for svc in postgres redis minio; do \
+		if echo "$$running" | grep -qw $$svc; then echo "$$svc: up"; \
+		else echo "$$svc: DOWN"; fail=1; fi; \
+	done; \
+	head=$$(uv run alembic heads 2>/dev/null | head -1 | awk '{print $$1}'); \
+	cur=$$(uv run alembic current 2>/dev/null | head -1 | awk '{print $$1}'); \
+	if [ -n "$$head" ] && [ "$$cur" = "$$head" ]; then echo "alembic: $$cur (head)"; \
+	else echo "alembic: MISMATCH cur='$$cur' head='$$head'"; fail=1; fi; \
+	if docker compose exec -T redis redis-cli ping 2>/dev/null | grep -q PONG; then echo "redis ping: PONG"; \
+	else echo "redis ping: FAIL"; fail=1; fi; \
+	if curl -fs http://localhost:9000/minio/health/live >/dev/null 2>&1; then echo "minio health: ok"; \
+	else echo "minio health: FAIL"; fail=1; fi; \
+	if [ $$fail -eq 0 ]; then echo "doctor: PASS"; else echo "doctor: FAIL"; fi; \
+	exit $$fail
 
 psql:  ## Відкрити psql shell у postgres контейнері
 	docker compose exec postgres psql -U $${POSTGRES_USER:-course_supporter} -d $${POSTGRES_DB:-course_supporter}

--- a/src/course_supporter/ingestion/audio.py
+++ b/src/course_supporter/ingestion/audio.py
@@ -19,7 +19,7 @@ stages mirror ``VideoProcessor``:
   ``audio_pass_2c_denoise`` stage (``asyncio.gather`` over the
   filtered subset).
 
-Factory dispatch invariant (sub-area #6 ``create_processors``):
+Factory dispatch invariant (``create_processors``):
 the factory routes by ``source_type`` so AudioProcessor only ever
 receives ``SourceType.AUDIO`` inputs. Entry guard intentionally
 absent — the belt-and-suspenders pattern in TextProcessor /
@@ -68,14 +68,11 @@ cache write.
 Critical invariant (KD-2.2-E line 333): ``process_raw`` asserts
 ``assemble_text(doc) == " ".join(w.text for w in result.words)``
 as a runtime precondition for Pass 2b correctness. The assertion
-references audio's source_type-conditional separator that lands
-in sub-area #6 (``models/source.py`` per the v0.3 ``5b7fc67``
-consolidation); the activation gap is non-functional because no
-caller invokes ``process_raw`` until sub-area #7 wires the arq
-task entry. The assert serves as a cross-sub-area dependency
-tripwire — it fails fast if sub-area #6 reverts the separator
-branch or if chunk construction here violates segment-ordering
-invariants.
+references audio's source_type-conditional separator in
+``models/source.py`` (v0.3 ``5b7fc67`` consolidation). The assert
+serves as a production runtime tripwire — it fails fast if
+``models/source.py`` reverts the separator branch or if chunk
+construction here violates segment-ordering invariants.
 """
 
 from __future__ import annotations

--- a/src/course_supporter/ingestion/presentation.py
+++ b/src/course_supporter/ingestion/presentation.py
@@ -38,7 +38,7 @@ PyMuPDF.
 
 LibreOffice 26.2.x is a worker-image system dependency (``soffice`` on
 PATH) required only for the PPTX/PPT normalize path; the PDF path uses
-PyMuPDF alone. The Dockerfile install lands in sub-area #7.
+PyMuPDF alone.
 """
 
 from __future__ import annotations

--- a/src/course_supporter/ingestion/video_pipeline/steps.py
+++ b/src/course_supporter/ingestion/video_pipeline/steps.py
@@ -1,25 +1,18 @@
 """Seven pipeline gnízda (steps) of the canonical 7-step video flow.
 
-Each function is one gnízdo of ``PHASE-2-4.md`` §1. Krok 1-2 are real
-as of task 2.4.2 (ingestion via S3/yt-dlp + ffprobe; STT via ffmpeg
-audio extraction → ElevenLabs Scribe core); Krok 3-7 remain offline
-stubs returning mock §1 structures (tasks 2.4.3-2.4.7 fill them).
+Each function is one gnízdo of ``PHASE-2-4.md`` §1. Steps 1-4 are
+invoked from ``VideoProcessor.process_raw``; step 5 from
+``process_macro``; steps 6-7 from ``process_detail``.
 
 Data flows in-memory between steps (return values / arguments). The
-real STT carrier is *additionally* written to Redis by the processor
-(``video_stt_result:{job_id}``) for the future Pass 2a consumer — that
+STT carrier is *additionally* written to Redis by the processor
+(``video_stt_result:{job_id}``) for the Pass 2a consumer — that
 producer write lives in ``processor.py``, not here.
 
-Filling order (per ``PHASE-2-4.md`` §3): each task replaces one or two
-step bodies, leaving neighbours and the ``VideoProcessor`` orchestration
-untouched. Real steps raise
-:class:`~course_supporter.ingestion.base.UnsupportedFormatError`
+Steps raise :class:`~course_supporter.ingestion.base.UnsupportedFormatError`
 (constraint) or :class:`~course_supporter.ingestion.base.ProcessingError`
-(operational) per the per-task taxonomy (D3); the failure-injection seam
-is to patch any step (or ``media.*``) to raise (see the tests).
-
-Steps 1-4 are invoked from ``VideoProcessor.process_raw``; step 5 from
-``process_macro``; steps 6-7 from ``process_detail``.
+(operational); the failure-injection seam is to patch any step (or
+``media.*``) to raise (see the tests).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Three independent edits in one atomic commit (rule #13), zero logic risk:

- **`make doctor`** — new Makefile target. Pre-pytest infra diagnostic: postgres / redis / minio running, alembic `current` == `head`, redis PING, minio `/health/live`. Closes the false-47-failed-runs failure mode that bit phase-2.4 sessions when a container silently died between runs.
- **`.reviewbot.md`** — repo-level config for the AI ReviewBot. Codifies three decline archetypes observed across phase-2.4 PRs (import-relocation on test files, correct-signal-wrong-fix, stylistic-without-concern), each with a cited example from POST-MERGE-NOTES. No speculative archetypes — additions are reactive.
- **Docstring sweep** — drop stale mid-implementation framing from `video_pipeline/steps.py` (no longer "offline stubs"), `audio.py` (sub-area #6/#7 labels — Phase 2.2 internal labels — replaced by "production runtime tripwire"), and `presentation.py` ("lands in sub-area #7" — landed long ago). Architectural facts preserved.

Spec: `refactoring-vision/sprint/phases/phase-2-4/PHASE-2-4-task-20.md`.
Branch: `task-A-sprint-closure-hygiene` off `main` (`4acb598`).

## Test plan

- [x] `make doctor` → exit 0 on healthy stack (postgres/redis/minio up + alembic at head + redis PONG + minio health ok).
- [x] `make doctor` → exit ≠0 + "redis: DOWN" / "redis ping: FAIL" / "doctor: FAIL" after `docker compose stop redis`; PASS restored after restart.
- [x] `uv run ruff check src/ tests/` — All checks passed.
- [x] `uv run ruff format --check src/ tests/` — 289 files already formatted.
- [x] `uv run mypy src/` strict — Success: no issues found in 129 source files.
- [x] `uv run pre-commit run --files <staged>` — all hooks Passed.
- [x] `uv run pytest --run-db --run-redis` — **2246 passed / 0 failed / 3 skipped** (matches 2.4.19 baseline).
- [x] No `sub-area #6` / `sub-area #7` strings remain in the three module-docstrings; no `remain offline stubs` in `steps.py`; no `lands in sub-area #7` in `presentation.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)