### PR TITLE
task(2.4.21): remove vestigial STT cache-back (DD-2.4-N)

### DIFF
--- a/src/course_supporter/api/tasks.py
+++ b/src/course_supporter/api/tasks.py
@@ -16,11 +16,6 @@ from course_supporter.ingestion.factory import (
     create_heavy_steps,
     create_processors,
 )
-from course_supporter.language import (
-    InvalidLanguageError,
-    LanguageNotAllowedError,
-    normalize_and_validate,
-)
 from course_supporter.models.source import SourceType
 from course_supporter.service_logging import (
     set_job_from_arq,
@@ -171,8 +166,6 @@ async def arq_ingest_material(
     )
     s3: S3Client | None = ctx.get("s3_client")
 
-    detected_language: str | None = None
-
     async with session_factory() as session:
         job_repo = JobRepository(session)
         entry_repo = AuthoredDocumentRepository(session)
@@ -184,8 +177,10 @@ async def arq_ingest_material(
             return
 
         # Resolve effective language: entry override → course default → None.
-        # When None, STT will auto-detect and return detected_language which
-        # we persist back to the entry after successful ingestion.
+        # Under the 2.4.13 invariant (CHECK ``course_nodes_root_language_required``)
+        # the root always has ``default_language``, so inheritance fires before
+        # STT runs and the entry is persisted with the root's language; STT
+        # auto-detect is observational only (no cache-back since 2.4.21).
         if entry.language is None:
             root = await node_repo.get_root_for(entry.course_node_id)
             if root is not None and root.default_language:
@@ -346,7 +341,6 @@ async def arq_ingest_material(
             # ── /Pass 2b ──
 
             content = doc.model_dump_json()
-            detected_language = doc.metadata.get("detected_language")
 
         except SecurityRejectedError as exc:
             # Stage 2 reject branch (KD-2.1-P, Phase 2.1 C6). The
@@ -376,35 +370,6 @@ async def arq_ingest_material(
             )
             log.error("ingestion_failed", error=str(exc))
             return
-
-    # Cache auto-detected language back to the entry for future STT calls.
-    # Uses an atomic UPDATE ... WHERE language IS NULL to avoid a race
-    # where a concurrent PATCH may set language between our check and write.
-    #
-    # STT output is a black-box external signal — a provider may return a
-    # code outside the project whitelist (Task 2.4.13). Normalize through
-    # the helper; if it cannot be resolved or is not allowed, warn-log and
-    # skip the cache write (do NOT fail ingestion — language authority is
-    # the course root, not STT auto-detect).
-    if detected_language:
-        try:
-            normalized = normalize_and_validate(detected_language)
-        except (InvalidLanguageError, LanguageNotAllowedError) as exc:
-            log.warning(
-                "language_auto_detect_skipped",
-                raw=detected_language,
-                reason=str(exc),
-            )
-        else:
-            async with session_factory() as session:
-                entry_repo = AuthoredDocumentRepository(session)
-                updated = await entry_repo.set_language_if_unset(mid, normalized)
-                await session.commit()
-                if updated:
-                    log.info(
-                        "language_auto_detected_cached",
-                        language=normalized,
-                    )
 
     await callback.on_success(
         job_id=jid,

--- a/src/course_supporter/language.py
+++ b/src/course_supporter/language.py
@@ -1,12 +1,10 @@
 """Language allowlist, normalization, and validation (Task 2.4.13).
 
-Single point of language logic for the backend. Three consumers today:
+Single point of language logic for the backend. Two consumers today:
 
 * ``api.schemas`` — Pydantic field validators on ``RootNodeCreateRequest``
   and ``NodeUpdateRequest`` accept any standard description (639-1,
   639-3, or English name) and normalize to canonical 639-3.
-* ``api.tasks`` (STT auto-detect cache) — wraps ``detected_language``
-  before persisting via ``AuthoredDocumentRepository.set_language_if_unset``.
 * ``api.routes.config`` — ``GET /api/v1/config/languages`` returns the
   allowed set enriched with English names (and native names where
   ``iso639`` exposes them) for the UI selector.

--- a/src/course_supporter/storage/authored_document_repository.py
+++ b/src/course_supporter/storage/authored_document_repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import func, select, update
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from course_supporter.models.source import AssignmentType, MaterialRole
@@ -227,33 +227,6 @@ class AuthoredDocumentRepository:
         )
         result = await self._session.execute(stmt)
         return result.scalars().first()
-
-    async def set_language_if_unset(
-        self,
-        entry_id: uuid.UUID,
-        language: str,
-    ) -> bool:
-        """Atomically set ``language`` only if it is currently NULL.
-
-        Guards against races where a concurrent PATCH may set the
-        language between our read and write. Returns True if the row
-        was updated, False if it was skipped because the language
-        was already set (or the row does not exist).
-        """
-        stmt = (
-            update(AuthoredDocument)
-            .where(
-                AuthoredDocument.id == entry_id,
-                AuthoredDocument.language.is_(None),
-            )
-            .values(language=language)
-            .execution_options(synchronize_session=False)
-        )
-        result = await self._session.execute(stmt)
-        # ``rowcount`` is provided by CursorResult (actual runtime type
-        # for DML execute); SQLAlchemy's static return type is the wider
-        # ``Result`` which does not expose it — hence the ignore.
-        return (result.rowcount or 0) > 0  # type: ignore[attr-defined]
 
     async def set_pending(
         self,

--- a/tests/integration/test_arq_task_e2e.py
+++ b/tests/integration/test_arq_task_e2e.py
@@ -208,10 +208,9 @@ class TestArqIngestMaterialE2E:
         test now locks the inheritance-dominates invariant from task
         2.4.13 рішення 1.
 
-        The orchestrator still calls ``set_language_if_unset`` and
-        still reads ``detected_language`` — that code path is
-        vestigial post-2.4.13 (DD-2.4-N) and is left for a separate
-        cleanup task; this hotfix is tests-only.
+        Task 2.4.21 removed the cache-back path entirely (DD-2.4-N
+        closure): the 2.4.13 inheritance invariant is now the sole
+        guarantee that the entry persists with the root's language.
         """
         mid = committed_seeds["material_id"]
         tid = committed_seeds["tenant_id"]


### PR DESCRIPTION
## Summary

Removes the STT auto-detect cache-back path in ``arq_ingest_material`` (and its lone dependency, ``AuthoredDocumentRepository.set_language_if_unset``). The path became unreachable after task 2.4.13 landed the CHECK ``course_nodes_root_language_required``: the root always has ``default_language``, inheritance fires before STT runs, and the ``UPDATE … WHERE language IS NULL`` atomic guard never matches on a rooted entry. Dead code — deleting it.

One atomic commit (rule #13), deletions only, zero production additions.

**Surfaces touched (4 files, +9 / −74):**

- ``api/tasks.py`` — outer ``detected_language`` local + ``doc.metadata`` re-assignment + cache-back block + three now-unused imports (``InvalidLanguageError`` / ``LanguageNotAllowedError`` / ``normalize_and_validate``). Resolution comment rewritten to name 2.4.13 as the live invariant.
- ``storage/authored_document_repository.py`` — ``set_language_if_unset`` method (single production callsite gone) + ``update`` import (no other DML in this repository).
- ``language.py`` — module docstring trimmed from three to two consumers (``api.tasks`` no longer imports anything from here).
- ``test_arq_task_e2e.py`` — docstring trim only on ``test_inheritance_dominates_over_stt_detection``. **Test semantics + assertions unchanged.** The rationale paragraph now names 2.4.21 as closure and 2.4.13 as sole guarantee.

**Out of scope (operator-deferred per TASK-21):** STT carrier write side — STT providers writing ``SttResult.detected_language``, video ``processor.py`` writing ``doc.metadata["detected_language"]``, ``steps.py:200`` reading it. These are now codebase-vestigial WRT the cache-back consumer that just died, but cleanup of the carrier itself is a separate task.

Spec: ``refactoring-vision/sprint/phases/phase-2-4/PHASE-2-4-task-21.md``.
Branch: ``task-C1-remove-vestigial-stt-cacheback`` off ``main`` (``34d79c0``).

## Test plan

- [x] ``grep -r set_language_if_unset src/`` → 0 matches (method + production callsite gone).
- [x] No cache-back block remains in ``arq_ingest_material``; resolution comment names 2.4.13 invariant + notes the 2.4.21 removal.
- [x] ``test_inheritance_dominates_over_stt_detection`` green; semantics unchanged (verified by docstring-only edit + full suite passing).
- [x] ``uv run ruff check src/ tests/`` — All checks passed.
- [x] ``uv run ruff format --check src/ tests/`` — 289 files already formatted.
- [x] ``uv run mypy src/`` strict — Success: no issues found in 129 source files.
- [x] ``uv run pre-commit run --files <staged>`` — all hooks Passed.
- [x] ``make doctor`` — PASS on healthy stack.
- [x] ``uv run pytest --run-db --run-redis`` — **2246 passed / 0 failed / 3 skipped** (exact 2.4.20 baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)