### PR TITLE
task(2.4.22): registry-aware StageRouter — runtime invariants (F(a) + H)

### DIFF
--- a/src/course_supporter/api/app.py
+++ b/src/course_supporter/api/app.py
@@ -32,6 +32,7 @@ from course_supporter.config import settings
 from course_supporter.llm import create_model_router
 from course_supporter.llm.factory import create_providers
 from course_supporter.llm.ladder_config import load_ladder_config
+from course_supporter.llm.registry import load_registry
 from course_supporter.llm.stage_router import StageRouter
 from course_supporter.logging_config import configure_logging
 from course_supporter.storage.database import async_session, engine
@@ -70,7 +71,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         environment=str(settings.environment),
         log_level=settings.log_level,
     )
-    app.state.model_router = create_model_router(settings, async_session)
+    # Load the model registry once and share it across both routers
+    # (TASK-2.4.22): ModelRouter consumes it for action-chain routing and
+    # cost; StageRouter consumes it for ESC cost_usd + max_tokens fallback
+    # on unpinned ladder rungs.
+    registry = load_registry(settings.external_services_path)
+    app.state.model_router = create_model_router(
+        settings, async_session, registry=registry
+    )
 
     # KD16 StageRouter — separate provider dict per Phase 1.2 §6.2 ratify
     # (option a, two-build); providers are stateless HTTP wrappers and a
@@ -80,6 +88,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     app.state.stage_router = StageRouter(
         ladder_config=ladder_config,
         providers=stage_router_providers,
+        registry=registry,
         session_factory=async_session,
     )
 

--- a/src/course_supporter/llm/setup.py
+++ b/src/course_supporter/llm/setup.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from course_supporter.config import Settings
 from course_supporter.llm.factory import create_providers
-from course_supporter.llm.registry import load_registry
+from course_supporter.llm.registry import ModelRegistryConfig, load_registry
 from course_supporter.llm.router import ModelRouter
 from course_supporter.service_logging import create_llm_log_callback
 
@@ -26,6 +26,7 @@ def create_model_router(
     session_factory: async_sessionmaker[AsyncSession] | None = None,
     *,
     max_attempts: int = 2,
+    registry: ModelRegistryConfig | None = None,
 ) -> ModelRouter:
     """Assemble ModelRouter with providers, registry, and optional DB logging.
 
@@ -33,11 +34,16 @@ def create_model_router(
         settings: Application settings with API keys and registry path.
         session_factory: If provided, calls are logged to external_service_calls table.
         max_attempts: Max retry attempts per model (default 2).
+        registry: Optional pre-loaded registry to share with StageRouter and
+            avoid a redundant YAML parse. When ``None`` (default), loads from
+            ``settings.external_services_path`` — backwards-compatible with
+            callers built before the StageRouter registry-sharing wiring.
 
     Returns:
         Configured ModelRouter ready for use.
     """
-    registry = load_registry(settings.external_services_path)
+    if registry is None:
+        registry = load_registry(settings.external_services_path)
     providers = create_providers(settings)
 
     log_callback = None

--- a/src/course_supporter/llm/stage_router.py
+++ b/src/course_supporter/llm/stage_router.py
@@ -58,6 +58,7 @@ from course_supporter.llm.error_categories import (
 )
 from course_supporter.llm.ladder_config import LadderConfig, LadderEntry
 from course_supporter.llm.prompt_loader_md import StagePrompt, load_prompt
+from course_supporter.llm.registry import ModelRegistryConfig
 from course_supporter.llm.schemas import LLMRequest, LLMResponse
 from course_supporter.service_logging import _persist
 
@@ -111,6 +112,7 @@ class StageRouter:
         ladder_config: LadderConfig,
         providers: dict[str, LLMProvider],
         *,
+        registry: ModelRegistryConfig,
         session_factory: async_sessionmaker[AsyncSession] | None = None,
         prompt_base_path: Path | None = None,
         max_retries_infrastructure: int = 3,
@@ -118,6 +120,12 @@ class StageRouter:
     ) -> None:
         self._ladder_config = ladder_config
         self._providers = providers
+        # Registry is required (keyword-only, no default) so the
+        # invariant "StageRouter knows pricing + per-model token caps" is
+        # structural — a forgotten registry would silently revert
+        # cost_usd / max_tokens fallback to NULL / None (the bug TASK-2.4.22
+        # closes). Mirrors the legacy ModelRouter's required registry slot.
+        self._registry = registry
         self._session_factory = session_factory
         self._prompt_base_path = prompt_base_path
         self._max_retries_infra = max_retries_infrastructure
@@ -233,8 +241,8 @@ class StageRouter:
 
     # ── Private helpers ─────────────────────────────────────────
 
-    @staticmethod
     def _build_request(
+        self,
         prompt: StagePrompt,
         entry: LadderEntry,
         stage_name: str,
@@ -250,6 +258,17 @@ class StageRouter:
         configured value. ``None`` defaults preserve provider-side
         fallbacks (e.g. ``DashScopeProvider.default_max_output_tokens``).
         """
+        # H — max_tokens registry fallback. Rung pin wins (status quo);
+        # unpinned rung resolves the registry's per-model cap (closes the
+        # silent-truncation gap for single-string stages where a truncated
+        # ``response.content`` validates as any string — e.g.
+        # ``presentation_pass_1_vision`` Pass 1 had no rung pin pre-2.4.22).
+        # Model not in registry → ``None`` preserves the legacy provider-
+        # default (DashScopeProvider.default_max_output_tokens etc.).
+        registry_model = self._registry.models.get(entry.model)
+        registry_max_tokens = (
+            registry_model.max_output_tokens if registry_model else None
+        )
         return LLMRequest(
             prompt=prompt.user or "",
             system_prompt=prompt.system,
@@ -258,7 +277,7 @@ class StageRouter:
             strategy="default",
             contents=contents,
             reasoning=entry.reasoning,
-            max_tokens=entry.max_output_tokens,
+            max_tokens=entry.max_output_tokens or registry_max_tokens,
             expects_json=expects_json,
         )
 
@@ -406,6 +425,21 @@ class StageRouter:
                 # async-context violation, etc.) so the original LLM
                 # exception always wins propagation.
                 fallback_latency_ms = int((time.perf_counter() - start) * 1000)
+                # F(a) — compute cost_usd from registry pricing (providers
+                # do not set ``response.cost_usd``; pre-2.4.22 every ESC row
+                # carried NULL). Skip the lookup on failed calls (response
+                # None) and zero-token success (NULL is semantically right
+                # for "nothing billable"). Model not in registry → NULL
+                # (graceful — caller's responsibility to keep registry in
+                # sync). Mirrors legacy ``ModelRouter`` cost computation.
+                computed_cost: float | None = None
+                if response is not None and (response.tokens_in or response.tokens_out):
+                    cost_model = self._registry.models.get(entry.model)
+                    if cost_model is not None:
+                        computed_cost = cost_model.estimate_cost(
+                            response.tokens_in or 0,
+                            response.tokens_out or 0,
+                        )
                 try:
                     await _persist(
                         self._session_factory,
@@ -419,7 +453,7 @@ class StageRouter:
                         latency_ms=(
                             response.latency_ms if response else fallback_latency_ms
                         ),
-                        cost_usd=response.cost_usd if response else None,
+                        cost_usd=computed_cost,
                         success=response is not None,
                         error_message=error_message,
                     )

--- a/src/course_supporter/llm/stage_router.py
+++ b/src/course_supporter/llm/stage_router.py
@@ -255,8 +255,12 @@ class StageRouter:
         Per-rung overrides on ``entry`` (``reasoning`` /
         ``max_output_tokens``) propagate into the corresponding
         :class:`LLMRequest` fields so providers receive the
-        configured value. ``None`` defaults preserve provider-side
-        fallbacks (e.g. ``DashScopeProvider.default_max_output_tokens``).
+        configured value. When the rung's ``max_output_tokens`` is
+        ``None`` (unpinned), the H fallback (TASK-2.4.22) resolves
+        the registry's per-model cap; only when the model is also
+        absent from the registry does ``None`` fall through to the
+        provider-side default
+        (e.g. ``DashScopeProvider.default_max_output_tokens``).
         """
         # H — max_tokens registry fallback. Rung pin wins (status quo);
         # unpinned rung resolves the registry's per-model cap (closes the

--- a/src/course_supporter/worker.py
+++ b/src/course_supporter/worker.py
@@ -40,6 +40,7 @@ async def startup(ctx: WorkerCtx) -> None:
     from course_supporter.llm import create_model_router
     from course_supporter.llm.factory import create_providers
     from course_supporter.llm.ladder_config import load_ladder_config
+    from course_supporter.llm.registry import load_registry
     from course_supporter.llm.stage_router import StageRouter
     from course_supporter.storage.s3 import S3Client
 
@@ -59,7 +60,12 @@ async def startup(ctx: WorkerCtx) -> None:
         class_=AsyncSession,
         expire_on_commit=False,
     )
-    model_router = create_model_router(s, session_factory)
+    # Load the model registry once and share it across both routers
+    # (TASK-2.4.22): ModelRouter consumes it for action-chain routing and
+    # cost; StageRouter consumes it for ESC cost_usd + max_tokens fallback
+    # on unpinned ladder rungs.
+    registry = load_registry(s.external_services_path)
+    model_router = create_model_router(s, session_factory, registry=registry)
 
     # KD16 StageRouter — separate provider dict per Phase 1.2 §6.2 ratify
     # (option a, two-build); mirrors the FastAPI lifespan wiring in
@@ -71,6 +77,7 @@ async def startup(ctx: WorkerCtx) -> None:
     stage_router = StageRouter(
         ladder_config=ladder_config,
         providers=stage_router_providers,
+        registry=registry,
         session_factory=session_factory,
     )
 

--- a/tests/_helpers/registry.py
+++ b/tests/_helpers/registry.py
@@ -1,0 +1,63 @@
+"""Shared registry fixtures for StageRouter tests (TASK-2.4.22).
+
+``StageRouter.__init__`` requires a ``ModelRegistryConfig`` (keyword-only,
+no default) to compute ESC ``cost_usd`` from per-model pricing and to
+fall back to the registry's ``max_output_tokens`` cap when a ladder rung
+is unpinned. Tests that exercise the router's control flow (ladder
+fallback, ESC plumbing, structural retry) don't care about pricing —
+they pass an empty registry through :func:`empty_registry`.
+
+Tests that exercise the cost / max_tokens fallback themselves build a
+populated registry inline (see ``TestRegistryAwareCost`` /
+``TestRegistryAwareMaxTokens`` in ``test_stage_router.py``).
+"""
+
+from __future__ import annotations
+
+from course_supporter.llm.registry import (
+    ModelRegistryConfig,
+    ProviderConfig,
+    ProviderModelConfig,
+)
+
+
+def empty_registry() -> ModelRegistryConfig:
+    """Return a registry with no providers / actions.
+
+    Validates cleanly: ``validate_and_flatten`` iterates ``providers``
+    (empty) and ``actions`` (empty) and raises nothing. Use this fixture
+    in tests whose subject is not the cost / max_tokens path.
+    """
+    return ModelRegistryConfig(providers={}, actions={})
+
+
+def registry_with(
+    *,
+    model_id: str = "claude-x",
+    provider: str = "anthropic",
+    cost_per_1k_in: float = 0.0,
+    cost_per_1k_out: float = 0.0,
+    max_output_tokens: int | None = None,
+) -> ModelRegistryConfig:
+    """Build a registry containing exactly one model entry.
+
+    Use this in tests that exercise the F(a) cost-from-registry path or
+    the H max_tokens registry fallback — both behaviours look up the
+    request's ``model_id`` in ``registry.models``.
+    """
+    return ModelRegistryConfig(
+        providers={
+            provider: ProviderConfig(
+                type="llm",
+                models=[
+                    ProviderModelConfig(
+                        id=model_id,
+                        cost_per_1k_in=cost_per_1k_in,
+                        cost_per_1k_out=cost_per_1k_out,
+                        max_output_tokens=max_output_tokens,
+                    )
+                ],
+            )
+        },
+        actions={},
+    )

--- a/tests/integration/test_app_startup.py
+++ b/tests/integration/test_app_startup.py
@@ -31,6 +31,7 @@ from course_supporter.config import settings
 from course_supporter.llm.factory import create_providers
 from course_supporter.llm.ladder_config import load_ladder_config
 from course_supporter.llm.stage_router import StageRouter
+from tests._helpers.registry import empty_registry
 
 
 @pytest.mark.requires_db
@@ -60,6 +61,7 @@ class TestStageRouterFoundation:
         stage_router = StageRouter(
             ladder_config=ladder_config,
             providers=providers,
+            registry=empty_registry(),
         )
         assert isinstance(stage_router, StageRouter)
 
@@ -75,6 +77,7 @@ class TestStageRouterFoundation:
         sentinel_router = StageRouter(
             ladder_config=ladder_config,
             providers=providers,
+            registry=empty_registry(),
         )
 
         class _State:

--- a/tests/integration/test_stage2_safety_check.py
+++ b/tests/integration/test_stage2_safety_check.py
@@ -55,6 +55,7 @@ from course_supporter.security.schemas import SafetyResult, ViolationCategory
 from course_supporter.security.stage2 import run_stage2_safety_check
 from course_supporter.service_logging import job_scope, tenant_scope
 from course_supporter.storage.orm import ExternalServiceCall, Job
+from tests._helpers.registry import empty_registry
 
 pytestmark = pytest.mark.requires_db
 
@@ -170,6 +171,7 @@ def _build_router(
         config,
         providers,  # type: ignore[arg-type]
         session_factory=session_factory,
+        registry=empty_registry(),
     )
 
 

--- a/tests/integration/test_stage_router_db.py
+++ b/tests/integration/test_stage_router_db.py
@@ -39,6 +39,7 @@ from course_supporter.llm.schemas import LLMResponse
 from course_supporter.llm.stage_router import StageRouter
 from course_supporter.service_logging import job_scope, tenant_scope
 from course_supporter.storage.orm import ExternalServiceCall, Job
+from tests._helpers.registry import empty_registry, registry_with
 
 pytestmark = pytest.mark.requires_db
 
@@ -204,6 +205,15 @@ class TestStageRouterDB:
             config,
             {"anthropic": provider},
             session_factory=session_factory,
+            # TASK-2.4.22: F(a) computes cost_usd from registry pricing
+            # (providers no longer carry it). The mocked response has
+            # tokens_in=12, tokens_out=34; with the rates below the
+            # expected cost is 12*0.1/1000 + 34*0.2/1000 = 0.008.
+            registry=registry_with(
+                model_id="claude-x",
+                cost_per_1k_in=0.1,
+                cost_per_1k_out=0.2,
+            ),
         )
 
         with (
@@ -233,10 +243,11 @@ class TestStageRouterDB:
         assert second.strategy == "default"
         assert second.success is True
         assert second.error_message is None
-        # Successful call carries token / cost telemetry from the response.
+        # Successful call carries token / cost telemetry. Cost is computed
+        # from the registry pricing above (F(a)), not from the response.
         assert second.unit_in == 12
         assert second.unit_out == 34
-        assert second.cost_usd == pytest.approx(0.0123)
+        assert second.cost_usd == pytest.approx(0.008)
 
     async def test_full_ladder_exhaustion(
         self,
@@ -269,6 +280,7 @@ class TestStageRouterDB:
             config,
             {"anthropic": bad_a, "gemini": bad_b},
             session_factory=session_factory,
+            registry=empty_registry(),
         )
 
         with (
@@ -328,6 +340,7 @@ class TestStageRouterDB:
             config,
             {"anthropic": empty_provider, "gemini": good_provider},
             session_factory=session_factory,
+            registry=empty_registry(),
         )
 
         with (

--- a/tests/unit/test_llm/test_stage_router.py
+++ b/tests/unit/test_llm/test_stage_router.py
@@ -24,6 +24,8 @@ from course_supporter.llm.prompt_loader_md import StagePrompt
 from course_supporter.llm.providers.base import LLMProvider
 from course_supporter.llm.schemas import LLMResponse
 from course_supporter.llm.stage_router import StageResult, StageRouter
+from tests._helpers.registry import empty_registry as _registry
+from tests._helpers.registry import registry_with as _registry_with
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -160,7 +162,7 @@ class TestHappyPath:
     ) -> None:
         _mock_load_prompt(monkeypatch)
         provider = _ok_provider("hello world")
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
 
         result = await router.execute_for_stage("demo")
 
@@ -187,6 +189,7 @@ class TestHappyPath:
         router = StageRouter(
             config,
             {"anthropic": bad, "gemini": good},
+            registry=_registry(),
         )
         result = await router.execute_for_stage("demo")
 
@@ -211,7 +214,7 @@ class TestInfrastructureFallback:
 
         provider.classify_error = lambda _exc: ErrorCategory.INFRASTRUCTURE  # type: ignore[method-assign]
 
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
         result = await router.execute_for_stage("demo")
 
         assert result.content == "recovered"
@@ -247,6 +250,7 @@ class TestInfrastructureFallback:
             _config(),
             {"anthropic": provider},
             max_retries_infrastructure=max_retries,
+            registry=_registry(),
         )
 
         with pytest.raises(LadderExhaustedError) as exc_info:
@@ -273,6 +277,7 @@ class TestInfrastructureFallback:
             _config(),
             {"anthropic": provider},
             max_retries_infrastructure=3,
+            registry=_registry(),
         )
 
         with pytest.raises(LadderExhaustedError):
@@ -296,7 +301,7 @@ class TestStructuralRetry:
                 _ok_response("retry succeeded"),
             ],
         )
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
 
         result = await router.execute_for_stage("demo")
 
@@ -327,6 +332,7 @@ class TestStructuralRetry:
         router = StageRouter(
             _config(entries=(("anthropic", "claude-x"), ("gemini", "g-x"))),
             {"anthropic": bad, "gemini": good},
+            registry=_registry(),
         )
 
         result = await router.execute_for_stage("demo")
@@ -349,7 +355,7 @@ class TestStructuralRetry:
                 _ok_response("ok"),
             ],
         )
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
 
         result = await router.execute_for_stage("demo")
         assert result.attempt_count == 2  # original + structural retry
@@ -368,6 +374,7 @@ class TestSemanticFallback:
         router = StageRouter(
             _config(entries=(("anthropic", "claude-x"), ("gemini", "g-x"))),
             {"anthropic": bad, "gemini": good},
+            registry=_registry(),
         )
 
         result = await router.execute_for_stage("demo")
@@ -392,6 +399,7 @@ class TestSemanticFallback:
         router = StageRouter(
             _config(entries=(("anthropic", "claude-x"), ("gemini", "g-x"))),
             {"anthropic": empty_provider, "gemini": good},
+            registry=_registry(),
         )
 
         result = await router.execute_for_stage("demo")
@@ -415,6 +423,7 @@ class TestInputOverflowFallback:
         router = StageRouter(
             _config(entries=(("openai", "gpt-4"), ("gemini", "g-x"))),
             {"openai": bad, "gemini": good},
+            registry=_registry(),
         )
 
         result = await router.execute_for_stage("demo")
@@ -437,6 +446,7 @@ class TestLadderExhaustion:
         router = StageRouter(
             _config(entries=(("anthropic", "a-1"), ("gemini", "g-1"))),
             {"anthropic": bad_a, "gemini": bad_b},
+            registry=_registry(),
         )
 
         with pytest.raises(LadderExhaustedError) as exc_info:
@@ -463,6 +473,7 @@ class TestLadderExhaustion:
         router = StageRouter(
             _config(entries=(("openai", "gpt-4"), ("anthropic", "claude-x"))),
             {"openai": overflow, "anthropic": semantic},
+            registry=_registry(),
         )
 
         with pytest.raises(LadderExhaustedError) as exc_info:
@@ -488,6 +499,7 @@ class TestESCPersistence:
             _config(entries=(("anthropic", "a-x"), ("gemini", "g-x"))),
             {"anthropic": bad, "gemini": good},
             session_factory=AsyncMock(),  # truthy stand-in
+            registry=_registry(),
         )
 
         await router.execute_for_stage("demo")
@@ -513,7 +525,7 @@ class TestESCPersistence:
         calls = _capture_persist_calls(monkeypatch)
 
         provider = _ok_provider("ok")
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
 
         await router.execute_for_stage("demo")
 
@@ -533,6 +545,7 @@ class TestProviderUnavailable:
         router = StageRouter(
             _config(entries=(("absent", "x"), ("gemini", "g-x"))),
             {"gemini": good},  # "absent" not registered
+            registry=_registry(),
         )
 
         result = await router.execute_for_stage("demo")
@@ -552,6 +565,7 @@ class TestProviderUnavailable:
         router = StageRouter(
             _config(entries=(("anthropic", "a-x"), ("gemini", "g-x"))),
             {"anthropic": disabled, "gemini": good},
+            registry=_registry(),
         )
 
         result = await router.execute_for_stage("demo")
@@ -577,7 +591,7 @@ class TestRenderContextFlow:
         )
 
         provider = _ok_provider("ok")
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
 
         await router.execute_for_stage("demo", lang="ua", topic="recursion")
 
@@ -596,7 +610,7 @@ class TestStageNameUnknown:
     ) -> None:
         _mock_load_prompt(monkeypatch)
         provider = _ok_provider()
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
 
         with pytest.raises(KeyError, match="Unknown stage"):
             await router.execute_for_stage("nope")
@@ -642,6 +656,7 @@ class TestPersistFailureDoesNotMask:
             _config(),  # single-entry ladder -- no fallback safety net
             {"anthropic": provider},
             session_factory=AsyncMock(),  # truthy; persist will be invoked
+            registry=_registry(),
         )
 
         result = await router.execute_for_stage("demo")
@@ -666,7 +681,7 @@ class TestResponseValidator:
         _capture_sleeps(monkeypatch)
 
         provider = _ok_provider("legacy answer")
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
 
         result = await router.execute_for_stage("demo")
 
@@ -683,7 +698,7 @@ class TestResponseValidator:
         _capture_sleeps(monkeypatch)
 
         provider = _ok_provider("good content")
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
 
         seen: list[str] = []
 
@@ -715,7 +730,7 @@ class TestResponseValidator:
         )
         provider.classify_error = lambda _exc: ErrorCategory.SEMANTIC
 
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
 
         call_count = {"n": 0}
 
@@ -760,6 +775,7 @@ class TestResponseValidator:
         router = StageRouter(
             _config(entries=(("anthropic", "claude-x"), ("gemini", "g-x"))),
             {"anthropic": bad, "gemini": good},
+            registry=_registry(),
         )
 
         bad_contents = {"bad-1", "bad-2"}
@@ -802,6 +818,7 @@ class TestResponseValidator:
         router = StageRouter(
             _config(entries=(("anthropic", "claude-x"), ("gemini", "g-x"))),
             {"anthropic": bad_a, "gemini": bad_b},
+            registry=_registry(),
         )
 
         def _always_fail(content: str) -> None:
@@ -838,6 +855,7 @@ class TestResponseValidator:
         router = StageRouter(
             _config(entries=(("anthropic", "claude-x"), ("gemini", "g-x"))),
             {"anthropic": empty_provider, "gemini": good},
+            registry=_registry(),
         )
 
         observed: list[str] = []
@@ -865,7 +883,7 @@ class TestExecuteForStageContents:
     ) -> None:
         _mock_load_prompt(monkeypatch)
         provider = _ok_provider("ok")
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
 
         png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
         await router.execute_for_stage("demo", contents=[png])
@@ -881,7 +899,7 @@ class TestExecuteForStageContents:
         # must continue producing requests with ``contents is None``.
         _mock_load_prompt(monkeypatch)
         provider = _ok_provider("ok")
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
 
         await router.execute_for_stage("demo")
 
@@ -913,7 +931,7 @@ class TestLadderEntryOverridesPropagation:
                 ),
             }
         )
-        router = StageRouter(config, {"anthropic": provider})
+        router = StageRouter(config, {"anthropic": provider}, registry=_registry())
 
         await router.execute_for_stage("demo")
 
@@ -941,7 +959,7 @@ class TestLadderEntryOverridesPropagation:
                 ),
             }
         )
-        router = StageRouter(config, {"anthropic": provider})
+        router = StageRouter(config, {"anthropic": provider}, registry=_registry())
 
         await router.execute_for_stage("demo")
 
@@ -957,10 +975,237 @@ class TestLadderEntryOverridesPropagation:
         # is None so the provider uses its class-level default.
         _mock_load_prompt(monkeypatch)
         provider = _ok_provider("ok")
-        router = StageRouter(_config(), {"anthropic": provider})
+        router = StageRouter(_config(), {"anthropic": provider}, registry=_registry())
 
         await router.execute_for_stage("demo")
 
         request = provider.complete.await_args.args[0]
         assert request.reasoning is None
+        assert request.max_tokens is None
+
+
+# ── TASK-2.4.22: registry-aware StageRouter ────────────────────────
+
+
+class TestRegistryAwareCost:
+    """F(a) — StageRouter computes cost_usd from registry pricing."""
+
+    async def test_cost_populated_from_registry_on_success(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _mock_load_prompt(monkeypatch)
+        calls = _capture_persist_calls(monkeypatch)
+
+        provider = _ok_provider("ok")
+        # _ok_response sets tokens_in=10, tokens_out=20 →
+        # 10 * 0.001 / 1000 + 20 * 0.002 / 1000 = 0.00001 + 0.00004 = 0.00005
+        router = StageRouter(
+            _config(),
+            {"anthropic": provider},
+            registry=_registry_with(cost_per_1k_in=0.001, cost_per_1k_out=0.002),
+            session_factory=AsyncMock(),
+        )
+
+        await router.execute_for_stage("demo")
+
+        assert len(calls) == 1
+        assert calls[0]["success"] is True
+        assert calls[0]["cost_usd"] == pytest.approx(0.00005)
+
+    async def test_cost_null_when_model_not_in_registry(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _mock_load_prompt(monkeypatch)
+        calls = _capture_persist_calls(monkeypatch)
+
+        provider = _ok_provider("ok")
+        router = StageRouter(
+            _config(),
+            {"anthropic": provider},
+            registry=_registry(),  # empty registry — model unknown
+            session_factory=AsyncMock(),
+        )
+
+        await router.execute_for_stage("demo")
+
+        assert len(calls) == 1
+        assert calls[0]["success"] is True
+        assert calls[0]["cost_usd"] is None
+
+    async def test_cost_null_when_zero_tokens(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _mock_load_prompt(monkeypatch)
+        calls = _capture_persist_calls(monkeypatch)
+
+        provider = AsyncMock(spec=LLMProvider)
+        provider.enabled = True
+        provider.complete = AsyncMock(
+            return_value=LLMResponse(
+                content="ok",
+                provider="anthropic",
+                model_id="claude-x",
+                tokens_in=0,
+                tokens_out=0,
+                latency_ms=10,
+                cost_usd=None,
+            )
+        )
+        provider.classify_error = lambda _exc: ErrorCategory.SEMANTIC
+
+        router = StageRouter(
+            _config(),
+            {"anthropic": provider},  # type: ignore[dict-item]
+            registry=_registry_with(cost_per_1k_in=0.001, cost_per_1k_out=0.002),
+            session_factory=AsyncMock(),
+        )
+
+        await router.execute_for_stage("demo")
+
+        assert len(calls) == 1
+        assert calls[0]["success"] is True
+        assert calls[0]["cost_usd"] is None
+
+    async def test_cost_null_on_failed_call(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _mock_load_prompt(monkeypatch)
+        _capture_sleeps(monkeypatch)
+        calls = _capture_persist_calls(monkeypatch)
+
+        provider = _failing_provider(side_effects=[_semantic_exception()])
+        router = StageRouter(
+            _config(),
+            {"anthropic": provider},
+            registry=_registry_with(cost_per_1k_in=0.001, cost_per_1k_out=0.002),
+            session_factory=AsyncMock(),
+        )
+
+        with pytest.raises(LadderExhaustedError):
+            await router.execute_for_stage("demo")
+
+        assert len(calls) == 1
+        assert calls[0]["success"] is False
+        assert calls[0]["cost_usd"] is None
+
+    async def test_cost_zero_for_unpriced_model(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Model in registry with 0.0 pricing → cost_usd=0.0 (not NULL).
+
+        Mirrors legacy ModelRouter behaviour; semantically the model is
+        either free or pricing is unset in YAML — caller's responsibility
+        to keep registry accurate (DD-2.4-F audit script territory).
+        """
+        _mock_load_prompt(monkeypatch)
+        calls = _capture_persist_calls(monkeypatch)
+
+        provider = _ok_provider("ok")
+        router = StageRouter(
+            _config(),
+            {"anthropic": provider},
+            registry=_registry_with(cost_per_1k_in=0.0, cost_per_1k_out=0.0),
+            session_factory=AsyncMock(),
+        )
+
+        await router.execute_for_stage("demo")
+
+        assert len(calls) == 1
+        assert calls[0]["cost_usd"] == 0.0
+
+
+class TestRegistryAwareMaxTokens:
+    """H — _build_request resolves max_tokens from registry on unpinned rungs."""
+
+    async def test_rung_pin_wins_over_registry(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _mock_load_prompt(monkeypatch)
+
+        provider = _ok_provider("ok")
+        config = LadderConfig(
+            stages={
+                "demo": StageConfig(
+                    prompt_ref="prompts/example/v1.md",
+                    ladder=[
+                        LadderEntry(
+                            provider="anthropic",
+                            model="claude-x",
+                            max_output_tokens=999,  # rung pin
+                        )
+                    ],
+                )
+            }
+        )
+        router = StageRouter(
+            config,
+            {"anthropic": provider},
+            registry=_registry_with(max_output_tokens=4096),
+        )
+
+        await router.execute_for_stage("demo")
+
+        request = provider.complete.await_args.args[0]
+        assert request.max_tokens == 999  # rung wins
+
+    async def test_unpinned_rung_resolves_registry_max_tokens(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _mock_load_prompt(monkeypatch)
+
+        provider = _ok_provider("ok")
+        router = StageRouter(
+            _config(),  # rung has no max_output_tokens
+            {"anthropic": provider},
+            registry=_registry_with(max_output_tokens=8192),
+        )
+
+        await router.execute_for_stage("demo")
+
+        request = provider.complete.await_args.args[0]
+        assert request.max_tokens == 8192
+
+    async def test_unpinned_rung_with_unknown_model_returns_none(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Status-quo provider-default path when model not in registry."""
+        _mock_load_prompt(monkeypatch)
+
+        provider = _ok_provider("ok")
+        router = StageRouter(
+            _config(),
+            {"anthropic": provider},
+            registry=_registry(),  # empty registry — model unknown
+        )
+
+        await router.execute_for_stage("demo")
+
+        request = provider.complete.await_args.args[0]
+        assert request.max_tokens is None
+
+    async def test_unpinned_rung_with_registry_model_without_cap_returns_none(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Registry has the model but its max_output_tokens is None."""
+        _mock_load_prompt(monkeypatch)
+
+        provider = _ok_provider("ok")
+        router = StageRouter(
+            _config(),
+            {"anthropic": provider},
+            registry=_registry_with(max_output_tokens=None),
+        )
+
+        await router.execute_for_stage("demo")
+
+        request = provider.complete.await_args.args[0]
         assert request.max_tokens is None


### PR DESCRIPTION
## Summary

Closes **DD-2.4-F(a)** (cost_usd NULL in ESC) and **DD-2.4-H** (StageRouter max_tokens divergence) as **one runtime node**, anchored by a single constructor change: ``StageRouter.__init__`` now requires a ``ModelRegistryConfig`` keyword (no default), so the invariant "StageRouter knows pricing + per-model token caps" is **structural** — forgetting registry at a wiring site is a compile-time error, not a silent revert to the bug this task fixes.

### Three runtime behaviours

- **F(a)** — ``_call_with_log`` computes ``cost_usd`` from ``registry.models[entry.model].estimate_cost`` before the ESC write. Providers no longer carry cost (pre-2.4.22 every StageRouter ESC row carried NULL). Skips on failed calls + zero-token success; model not in registry → NULL (graceful, caller-responsibility for registry sync). Mirrors legacy ``ModelRouter._call`` cost computation.
- **H** — ``_build_request`` falls back to the registry's per-model ``max_output_tokens`` when the ladder rung is unpinned. Rung pin still wins; unpinned + known model → registry cap; unknown model → ``None`` preserves the legacy provider-default. **Closes the silent-truncation gap** for ``presentation_pass_1_vision`` (all 3 rungs unpinned pre-2.4.22, single-string output without ``response_validator`` — truncation passed silently).
- **Shared registry source (Option A)** — ``worker.py`` + ``api/app.py`` extract ``registry = load_registry(...)`` once and pass to both ``create_model_router`` (new optional kwarg, backwards-compatible) and ``StageRouter(..., registry=registry)``. No double YAML parse.

### Ratified architectural decision (Option C)

Registry is keyword-only **without default** — default-None would reproduce the bug this task fixes (silently forgotten registry → cost/max_tokens NULL). Required makes the invariant structural.

### Test surface adaptation

``StageRouter`` construction requires the new ``registry=`` kwarg → mechanical update across **~38 sites** in 4 test files via a shared helper:

- **NEW** ``tests/_helpers/registry.py`` with ``empty_registry()`` (control-flow tests) + ``registry_with(*, model_id, pricing, max_output_tokens)`` (F(a) / H tests + integration cost assertion).
- ``_build_request`` promoted from ``@staticmethod`` → instance method to read ``self._registry``; existing call site already used ``self.``.
- ``test_stage_router_db.py::test_two_attempt_success`` adapted: cost now computed from registry (12*0.1/1000 + 34*0.2/1000 = 0.008), not copied from ``response.cost_usd``. Semantically equivalent contract.

### Nine new unit tests

- ``TestRegistryAwareCost`` — populated → cost populated; unknown model → NULL; zero tokens → NULL; failed call → NULL; zero-pricing → 0.0 (mirrors legacy).
- ``TestRegistryAwareMaxTokens`` — rung pin wins; unpinned resolves registry; unknown → ``None``; registry-without-cap → ``None``.

Spec: ``refactoring-vision/sprint/phases/phase-2-4/PHASE-2-4-task-22.md``.
Branch: ``task-C2a-registry-aware-stagerouter-runtime`` off ``main`` (``6030f18``).

## Out of scope

- ``K`` membership + ``Q-axis1`` capability — ``StageConfig.requires``, ``validate_ladders_against_registry``, per-stage yaml annotations → **TASK-2.4.23 / C2b**.
- ``DD-Q axis2`` startup live probe — separate task.
- ``DD-F(b)`` ``scripts/audit_models.py`` — separate operational utility.

## Test plan

- [x] ``uv run ruff check src/ tests/`` — All checks passed.
- [x] ``uv run ruff format --check src/ tests/`` — 290 files already formatted.
- [x] ``uv run mypy src/`` strict — Success, 129 source files.
- [x] ``uv run pre-commit run --files <staged>`` — all hooks Passed.
- [x] ``make doctor`` — PASS on healthy stack.
- [x] ``uv run pytest --run-db --run-redis`` — **2255 passed / 0 failed / 3 skipped** (2246 baseline + 9 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)