### PR TITLE
task(2.4.23): registry-aware StageRouter — config-time invariants (K + Q-axis1)

### DIFF
--- a/config/ladders_audio.yaml
+++ b/config/ladders_audio.yaml
@@ -63,6 +63,7 @@ stages:
   # ``_segments_contiguous`` + ``_full_cover`` + ``_subsegments_cover_parent``.
   audio_pass_2a_mapping:
     prompt_ref: "prompts/audio_pass_2a_mapping/v1.md"
+    requires: [structured_output]
     ladder:
       - provider: gemini
         model: gemini-3.1-flash-lite

--- a/config/ladders_mentor.yaml
+++ b/config/ladders_mentor.yaml
@@ -38,6 +38,7 @@ stages:
   # Phase 2.1 concern.
   safety_check:
     prompt_ref: "prompts/safety_check/v1.md"
+    requires: [structured_output]
     ladder:
       - provider: mistral
         model: mistral-small-latest
@@ -54,6 +55,7 @@ stages:
   # off_topic is high-bar. Injection / policy / suspicious preserved.
   safety_check_authored:
     prompt_ref: "prompts/safety_check_authored/v1.md"
+    requires: [structured_output]
     ladder:
       - provider: mistral
         model: mistral-small-latest

--- a/config/ladders_pipeline.yaml
+++ b/config/ladders_pipeline.yaml
@@ -43,6 +43,7 @@ stages:
   # provider-side stability guarantee per existing repo convention).
   pass_2a_mapping:
     prompt_ref: "prompts/pass_2a_mapping/v1.md"
+    requires: [structured_output]
     ladder:
       - provider: deepseek
         model: deepseek-v4-flash

--- a/config/ladders_presentation.yaml
+++ b/config/ladders_presentation.yaml
@@ -118,6 +118,7 @@ stages:
   # ``PresentationProcessor.process_macro``.
   presentation_pass_1_vision:
     prompt_ref: "prompts/presentation_pass_1_vision/v1.md"
+    requires: [vision]
     ladder:
       - provider: dashscope
         model: qwen3-vl-32b-instruct
@@ -141,6 +142,7 @@ stages:
   # completes.
   presentation_pass_2a_mapping:
     prompt_ref: "prompts/presentation_pass_2a_mapping/v1.md"
+    requires: [structured_output]
     ladder:
       - provider: mistral
         model: mistral-large-2512

--- a/config/ladders_video.yaml
+++ b/config/ladders_video.yaml
@@ -55,6 +55,7 @@ stages:
   #   bounded-concurrency gather inside ``VideoProcessor.process_raw``).
   video_pass_1_vision:
     prompt_ref: "prompts/video_pass_1_vision/v1.md"
+    requires: [vision]
     ladder:
       - provider: dashscope
         model: qwen3-vl-32b-instruct
@@ -145,6 +146,7 @@ stages:
   # ratified in task-2.4.12 and preserved here.
   video_pass_2a_mapping:
     prompt_ref: "prompts/video_pass_2a_mapping/v1.md"
+    requires: [structured_output]
     ladder:
       - provider: deepseek_thinking
         model: deepseek-v4-pro

--- a/src/course_supporter/api/app.py
+++ b/src/course_supporter/api/app.py
@@ -31,7 +31,10 @@ from course_supporter.auth.scopes import rate_limiter
 from course_supporter.config import settings
 from course_supporter.llm import create_model_router
 from course_supporter.llm.factory import create_providers
-from course_supporter.llm.ladder_config import load_ladder_config
+from course_supporter.llm.ladder_config import (
+    load_ladder_config,
+    validate_ladders_against_registry,
+)
 from course_supporter.llm.registry import load_registry
 from course_supporter.llm.stage_router import StageRouter
 from course_supporter.logging_config import configure_logging
@@ -84,6 +87,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # (option a, two-build); providers are stateless HTTP wrappers and a
     # second construction is cheap.
     ladder_config = load_ladder_config(settings.ladders_dir)
+    # Fail-fast on rung-typo / capability-mismatch before the FastAPI
+    # app starts serving (TASK-2.4.23 — DD-2.4-K + DD-2.4-Q-axis1).
+    validate_ladders_against_registry(ladder_config, registry)
     stage_router_providers = create_providers(settings)
     app.state.stage_router = StageRouter(
         ladder_config=ladder_config,

--- a/src/course_supporter/llm/ladder_config.py
+++ b/src/course_supporter/llm/ladder_config.py
@@ -18,6 +18,8 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from course_supporter.llm.registry import Capability, ModelRegistryConfig
+
 # Strict input-config models: typo in a YAML key fails validation
 # instead of silently shadowing a real field.
 _FORBID = ConfigDict(extra="forbid")
@@ -58,12 +60,18 @@ class StageConfig(BaseModel):
             backend repo CWD (e.g. ``"prompts/example/v1.md"``). The
             actual file read happens in
             :mod:`course_supporter.llm.prompt_loader_md`.
+        requires: Capabilities every ladder rung's model must declare
+            (TASK-2.4.23). Empty default keeps existing stages without
+            constraint; non-empty values are checked at startup by
+            :func:`validate_ladders_against_registry`. Mirrors
+            ``ActionConfig.requires`` in the registry.
         ladder: Ordered fallback ladder; at least one entry.
     """
 
     model_config = _FORBID
 
     prompt_ref: str
+    requires: list[Capability] = Field(default_factory=list)
     ladder: list[LadderEntry] = Field(min_length=1)
 
 
@@ -145,3 +153,53 @@ def load_ladder_config(directory: Path) -> LadderConfig:
             origins[stage_name] = path
 
     return LadderConfig(stages=merged)
+
+
+def validate_ladders_against_registry(
+    cfg: LadderConfig, registry: ModelRegistryConfig
+) -> None:
+    """Cross-check every ladder rung against the model registry (TASK-2.4.23).
+
+    Two invariants enforced fail-fast at startup:
+
+    * **K — membership:** every ``rung.model`` must exist in
+      ``registry.models``. A typo / rename / drift between
+      ``ladders_*.yaml`` and ``external_services.yaml`` would otherwise
+      surface only on the first runtime hit through the affected rung.
+    * **Q-axis1 — capability:** every capability declared in
+      ``stage.requires`` must appear in ``model.capabilities`` for each
+      rung. Catches text-only models accidentally placed in a
+      vision-required stage (and similar mismatches).
+
+    Errors are aggregated and raised as a single ``ValueError`` so a
+    multi-typo config surfaces every problem at once. Mirrors the
+    pattern in :meth:`ModelRegistryConfig.validate_and_flatten` for
+    action chains.
+
+    Raises:
+        ValueError: if any rung references an unknown model OR lacks a
+            capability declared in ``stage.requires``.
+    """
+    errors: list[str] = []
+
+    for stage_name, stage in cfg.stages.items():
+        for i, entry in enumerate(stage.ladder):
+            if entry.model not in registry.models:
+                errors.append(
+                    f"Stage '{stage_name}' rung {i} "
+                    f"references unknown model: '{entry.model}'"
+                )
+                continue
+
+            model = registry.models[entry.model]
+            missing = set(stage.requires) - set(model.capabilities)
+            if missing:
+                errors.append(
+                    f"Stage '{stage_name}' rung {i} model '{entry.model}' "
+                    f"lacks required capabilities: {sorted(missing)}"
+                )
+
+    if errors:
+        raise ValueError(
+            "Ladder validation failed:\n" + "\n".join(f"  - {e}" for e in errors)
+        )

--- a/src/course_supporter/worker.py
+++ b/src/course_supporter/worker.py
@@ -39,7 +39,10 @@ async def startup(ctx: WorkerCtx) -> None:
 
     from course_supporter.llm import create_model_router
     from course_supporter.llm.factory import create_providers
-    from course_supporter.llm.ladder_config import load_ladder_config
+    from course_supporter.llm.ladder_config import (
+        load_ladder_config,
+        validate_ladders_against_registry,
+    )
     from course_supporter.llm.registry import load_registry
     from course_supporter.llm.stage_router import StageRouter
     from course_supporter.storage.s3 import S3Client
@@ -73,6 +76,9 @@ async def startup(ctx: WorkerCtx) -> None:
     # invoking ``run_stage2_safety_check``) can read the same ladder
     # registry as HTTP-side consumers.
     ladder_config = load_ladder_config(s.ladders_dir)
+    # Fail-fast on rung-typo / capability-mismatch before the worker
+    # starts accepting jobs (TASK-2.4.23 — DD-2.4-K + DD-2.4-Q-axis1).
+    validate_ladders_against_registry(ladder_config, registry)
     stage_router_providers = create_providers(s)
     stage_router = StageRouter(
         ladder_config=ladder_config,

--- a/tests/unit/test_llm/test_ladder_config.py
+++ b/tests/unit/test_llm/test_ladder_config.py
@@ -11,6 +11,14 @@ from course_supporter.llm.ladder_config import (
     LadderFile,
     StageConfig,
     load_ladder_config,
+    validate_ladders_against_registry,
+)
+from course_supporter.llm.registry import (
+    Capability,
+    ModelRegistryConfig,
+    ProviderConfig,
+    ProviderModelConfig,
+    load_registry,
 )
 
 # ── Helpers ────────────────────────────────────────────────────────
@@ -389,3 +397,182 @@ class TestRealConfigs:
             assert Path(stage.prompt_ref).is_file(), (
                 f"prompt_ref for {stage_name!r} not found: {stage.prompt_ref}"
             )
+
+
+# ── TASK-2.4.23: validate_ladders_against_registry ─────────────────
+
+
+def _two_model_registry() -> ModelRegistryConfig:
+    """Registry with one vision + one text-only model — fixture for tests."""
+    return ModelRegistryConfig(
+        providers={
+            "anthropic": ProviderConfig(
+                type="llm",
+                models=[
+                    ProviderModelConfig(
+                        id="vl-model",
+                        capabilities=[
+                            Capability.VISION,
+                            Capability.STRUCTURED_OUTPUT,
+                        ],
+                    ),
+                    ProviderModelConfig(
+                        id="text-model",
+                        capabilities=[Capability.STRUCTURED_OUTPUT],
+                    ),
+                ],
+            )
+        },
+        actions={},
+    )
+
+
+def _stage(
+    *,
+    requires: list[Capability] | None = None,
+    models: tuple[str, ...] = ("vl-model",),
+) -> StageConfig:
+    return StageConfig(
+        prompt_ref="prompts/x/v1.md",
+        requires=list(requires) if requires is not None else [],
+        ladder=[LadderEntry(provider="anthropic", model=m) for m in models],
+    )
+
+
+class TestStageConfigRequiresField:
+    """StageConfig.requires accepts list[Capability] and defaults to []."""
+
+    def test_default_is_empty_list(self) -> None:
+        stage = StageConfig(
+            prompt_ref="prompts/x.md",
+            ladder=[LadderEntry(provider="anthropic", model="m")],
+        )
+        assert stage.requires == []
+
+    def test_explicit_capability_list_round_trips(self) -> None:
+        stage = StageConfig(
+            prompt_ref="prompts/x.md",
+            requires=[Capability.VISION],
+            ladder=[LadderEntry(provider="anthropic", model="m")],
+        )
+        assert stage.requires == [Capability.VISION]
+
+    def test_yaml_string_capability_coerces(self) -> None:
+        """YAML emits ``requires: [vision]`` as strings — Pydantic coerces."""
+        stage = StageConfig.model_validate(
+            {
+                "prompt_ref": "prompts/x.md",
+                "requires": ["vision", "structured_output"],
+                "ladder": [{"provider": "anthropic", "model": "m"}],
+            }
+        )
+        assert stage.requires == [Capability.VISION, Capability.STRUCTURED_OUTPUT]
+
+
+class TestValidateLaddersAgainstRegistry:
+    """validate_ladders_against_registry — K + Q-axis1 fail-fast."""
+
+    def test_happy_path_no_errors(self) -> None:
+        cfg = LadderConfig(stages={"demo": _stage(models=("vl-model",))})
+        validate_ladders_against_registry(cfg, _two_model_registry())
+        # Returns None on success; absence of exception is the contract.
+
+    def test_unknown_model_raises_with_stage_and_rung(self) -> None:
+        cfg = LadderConfig(
+            stages={"demo": _stage(models=("typo-model",))},
+        )
+        with pytest.raises(ValueError) as exc_info:
+            validate_ladders_against_registry(cfg, _two_model_registry())
+        msg = str(exc_info.value)
+        assert "Ladder validation failed" in msg
+        assert "Stage 'demo' rung 0" in msg
+        assert "typo-model" in msg
+
+    def test_capability_mismatch_raises(self) -> None:
+        cfg = LadderConfig(
+            stages={
+                "vision_stage": _stage(
+                    requires=[Capability.VISION], models=("text-model",)
+                )
+            },
+        )
+        with pytest.raises(ValueError) as exc_info:
+            validate_ladders_against_registry(cfg, _two_model_registry())
+        msg = str(exc_info.value)
+        assert "Stage 'vision_stage' rung 0" in msg
+        assert "text-model" in msg
+        assert "vision" in msg
+        assert "lacks required capabilities" in msg
+
+    def test_capability_satisfied_by_vision_model(self) -> None:
+        cfg = LadderConfig(
+            stages={
+                "vision_stage": _stage(
+                    requires=[Capability.VISION], models=("vl-model",)
+                )
+            },
+        )
+        validate_ladders_against_registry(cfg, _two_model_registry())
+
+    def test_empty_requires_means_no_capability_check(self) -> None:
+        """Default empty requires admits any registered rung."""
+        cfg = LadderConfig(
+            stages={
+                "free_stage": _stage(requires=[], models=("text-model", "vl-model"))
+            },
+        )
+        validate_ladders_against_registry(cfg, _two_model_registry())
+
+    def test_multiple_errors_aggregated(self) -> None:
+        """A multi-typo / multi-mismatch config surfaces all problems at once."""
+        cfg = LadderConfig(
+            stages={
+                "a": _stage(models=("typo-1",)),
+                "b": _stage(
+                    requires=[Capability.VISION], models=("text-model", "typo-2")
+                ),
+            },
+        )
+        with pytest.raises(ValueError) as exc_info:
+            validate_ladders_against_registry(cfg, _two_model_registry())
+        msg = str(exc_info.value)
+        # All three errors present in one raise.
+        assert msg.count("Stage 'a' rung 0") == 1
+        assert "typo-1" in msg
+        assert "Stage 'b' rung 0" in msg
+        assert "text-model" in msg
+        assert "Stage 'b' rung 1" in msg
+        assert "typo-2" in msg
+
+    def test_rung_index_reflects_position(self) -> None:
+        cfg = LadderConfig(
+            stages={"demo": _stage(models=("vl-model", "vl-model", "typo-model"))},
+        )
+        with pytest.raises(ValueError) as exc_info:
+            validate_ladders_against_registry(cfg, _two_model_registry())
+        assert "Stage 'demo' rung 2" in str(exc_info.value)
+
+
+class TestProductionLaddersValidate:
+    """Live config vs live registry passes day-1 (TASK-2.4.23 acceptance #3)."""
+
+    def test_real_config_passes_validation(self) -> None:
+        config = load_ladder_config(Path("config"))
+        registry = load_registry(Path("config/external_services.yaml"))
+        # No exception = invariant holds for every annotated stage.
+        validate_ladders_against_registry(config, registry)
+
+    def test_annotated_stages_carry_expected_requires(self) -> None:
+        config = load_ladder_config(Path("config"))
+        # Spot-check the per-stage requires map from the TASK-23 spec.
+        assert config.get_stage("video_pass_1_vision").requires == [Capability.VISION]
+        assert config.get_stage("presentation_pass_1_vision").requires == [
+            Capability.VISION
+        ]
+        assert config.get_stage("safety_check").requires == [
+            Capability.STRUCTURED_OUTPUT
+        ]
+        # Pass 2c / example stages stay unconstrained.
+        assert config.get_stage("video_pass_2c_denoise").requires == []
+        assert config.get_stage("audio_pass_2c_denoise").requires == []
+        assert config.get_stage("example_stage").requires == []


### PR DESCRIPTION
## Summary

Closes **DD-2.4-K** (rung membership) and **DD-2.4-Q-axis1** (capability check) as one config-time validation node. Builds on the 2.4.22 shared `registry` injection: now `load_ladder_config` is paired with `validate_ladders_against_registry` at both startup sites (`worker.py` + `api/app.py`), so a rung-typo or capability-mismatch aborts the process before any LLM call goes out.

### Three behaviours

- **K — membership.** Every `rung.model` must exist in `registry.models`. A typo / rename / drift between `ladders_*.yaml` and `external_services.yaml` is now caught at startup, not on the first runtime hit through the affected rung. Error message names stage + rung index + offending model id.
- **Q-axis1 — capability.** New `StageConfig.requires: list[Capability]` field (default `[]` — non-breaking for existing stages without constraint). When non-empty, every rung's model must declare every capability listed. Error message names stage + rung index + model id + missing capabilities. Mirrors the action-chain pattern in `ModelRegistryConfig.validate_and_flatten`.
- **Aggregated raise.** Errors are accumulated across all stages/rungs and raised as a single `ValueError("Ladder validation failed:\n  - ...")` so a multi-typo config surfaces every problem at once.

### Per-stage annotations (8 non-empty stages across 5 yaml files)

Pass 2c + test / example stages stay at the `requires: []` default — no explicit write to keep yaml clean.

| File | Stage | `requires:` |
|---|---|---|
| `ladders_video.yaml` | `video_pass_1_vision` | `[vision]` |
| `ladders_video.yaml` | `video_pass_2a_mapping` | `[structured_output]` |
| `ladders_presentation.yaml` | `presentation_pass_1_vision` | `[vision]` |
| `ladders_presentation.yaml` | `presentation_pass_2a_mapping` | `[structured_output]` |
| `ladders_audio.yaml` | `audio_pass_2a_mapping` | `[structured_output]` |
| `ladders_pipeline.yaml` | `pass_2a_mapping` | `[structured_output]` |
| `ladders_mentor.yaml` | `safety_check` | `[structured_output]` |
| `ladders_mentor.yaml` | `safety_check_authored` | `[structured_output]` |

### Day-1 green confirmed

Pre-flight re-probe verified all 24 rung models across 8 annotated stages declare their required capability in registry; first `validate_ladders_against_registry` call on the real config passes without errors:

```
Loaded 13 stages, 24 models
Day-1 validate: PASS
```

### Wiring (mirror across both startup sites)

- `worker.py:75-76` — after `load_ladder_config(...)`, before `StageRouter(...)`. Raise aborts ARQ startup; supervisor bounces the worker rather than accepting jobs against a broken ladder.
- `api/app.py:86-87` — mirror under FastAPI lifespan: raise aborts startup before any HTTP endpoint becomes reachable.

### Twelve new unit tests

- `TestStageConfigRequiresField` (3) — default `[]`; explicit list round-trips; YAML strings coerce to `Capability` via Pydantic.
- `TestValidateLaddersAgainstRegistry` (7) — happy path; unknown model with stage+rung naming; capability mismatch; empty requires admits any rung; multi-error aggregation; rung index reflects position; happy with vision rung.
- `TestProductionLaddersValidate` (2) — live config vs live registry passes; annotated stages carry expected `requires`.

Spec: `refactoring-vision/sprint/phases/phase-2-4/PHASE-2-4-task-23.md`.
Branch: `task-C2b-ladder-config-validation` off `main` (`b105982`).

## Out of scope

- `DD-2.4-Q-axis2` — opt-in startup live availability-probe (billable; separate task).
- `DD-2.4-O` — DashScope endpoint-routing (runtime layer, distinct from capability).
- StageRouter runtime (cost / max_tokens) — closed in 2.4.22.
- Explicit `TEXT` capability — ratified not-added (text = absence of `vision`).
- `registry.py` Capability enum / `validate_and_flatten` — mirrored only for the pattern, not modified.

## Test plan

- [x] `uv run ruff check src/ tests/` — All checks passed.
- [x] `uv run ruff format --check src/ tests/` — 290 files already formatted.
- [x] `uv run mypy src/` strict — Success, 129 source files.
- [x] `uv run pre-commit run --files <staged>` — all hooks Passed.
- [x] `make doctor` — PASS on healthy stack.
- [x] Smoke: `validate_ladders_against_registry` on real config — Day-1 PASS, 8/8 annotated stages × 24 rung models.
- [x] `uv run pytest --run-db --run-redis` — **2267 passed / 0 failed / 3 skipped** (2255 baseline + 12 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)