### PR TITLE
task(3.1): NodeSummary data layer (Raw/Final/PreviousSnapshot)

### DIFF
--- a/migrations/versions/phase31_content_hash_defaults.py
+++ b/migrations/versions/phase31_content_hash_defaults.py
@@ -1,0 +1,111 @@
+"""Phase 3.1 commit 4: server_default + NOT NULL on three content_hash columns.
+
+Revision ID: phase31_content_hash_defaults
+Revises: phase31_node_summary_tables
+Create Date: 2026-06-10 00:00:01.000000
+
+Closes the KD9 NULL-at-INSERT regression (vision §3 KD9 "Спостереження
+Phase 1") + lands rule «визначений хеш, ніколи NULL» (Phase 3.1 Q-G)
+atomically across the three hash-bearing tables that hold a methodist-
+layer content hash:
+
+* ``course_nodes.content_hash`` — backfill NULL → EMPTY_NODE_CONTENT_HASH,
+  SET DEFAULT, SET NOT NULL.
+* ``node_summaries_raw.content_hash`` — SET DEFAULT to
+  EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH, SET NOT NULL (table created
+  empty in commit 1; no backfill needed).
+* ``node_summaries_final.content_hash`` — SET DEFAULT to
+  EMPTY_NODE_SUMMARY_FINAL_CONTENT_HASH, SET NOT NULL (same).
+
+Per Phase 2.4.13 ratified corrective + Q-F at 3.1 pre-flight: the
+constants are hardcoded as string literals here rather than imported
+from app code — replay safety. A repo-side assertion test
+(``tests/storage/test_empty_hash_literals.py`` in commit 5) verifies
+each literal equals the constant derived through the live
+``compute_content_hash`` formula in ``storage/content_hash.py``.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "phase31_content_hash_defaults"
+down_revision: str | Sequence[str] | None = "phase31_node_summary_tables"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Hardcoded per Phase 2.4.13 [[feedback-migration-self-contained-no-app-import]].
+# Tests pin parity with the formula-derived constants in
+# ``storage/content_hash.py`` so divergence surfaces immediately.
+_EMPTY_NODE_CONTENT_HASH = (
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+_EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH = (
+    "bcaf467defc6a11d9f437368b2388f310b8538fc2fe21621587f69175766cadd"
+)
+_EMPTY_NODE_SUMMARY_FINAL_CONTENT_HASH = (
+    "85ef8d5f3881ffae484d1c1b47d18c0984b19c03bc9dd44e6fc1010e9fcdbf03"
+)
+
+
+def upgrade() -> None:
+    """Backfill + SET DEFAULT + SET NOT NULL across three content_hash columns."""
+    # CourseNode — backfill required: prior schema allowed NULL and
+    # the Phase 1 regression left existing rows NULL until first PATCH.
+    op.execute(
+        sa.text(
+            "UPDATE course_nodes SET content_hash = :hash WHERE content_hash IS NULL"
+        ).bindparams(hash=_EMPTY_NODE_CONTENT_HASH)
+    )
+    op.alter_column(
+        "course_nodes",
+        "content_hash",
+        existing_type=sa.String(length=64),
+        nullable=False,
+        server_default=sa.text(f"'{_EMPTY_NODE_CONTENT_HASH}'"),
+    )
+
+    # NodeSummaryRaw — created in commit 1, table empty, no backfill needed.
+    op.alter_column(
+        "node_summaries_raw",
+        "content_hash",
+        existing_type=sa.String(length=64),
+        nullable=False,
+        server_default=sa.text(f"'{_EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH}'"),
+    )
+
+    # NodeSummaryFinal — same.
+    op.alter_column(
+        "node_summaries_final",
+        "content_hash",
+        existing_type=sa.String(length=64),
+        nullable=False,
+        server_default=sa.text(f"'{_EMPTY_NODE_SUMMARY_FINAL_CONTENT_HASH}'"),
+    )
+
+
+def downgrade() -> None:
+    """Revert to nullable, no default — preserves prior schema for replay."""
+    op.alter_column(
+        "node_summaries_final",
+        "content_hash",
+        existing_type=sa.String(length=64),
+        nullable=True,
+        server_default=None,
+    )
+    op.alter_column(
+        "node_summaries_raw",
+        "content_hash",
+        existing_type=sa.String(length=64),
+        nullable=True,
+        server_default=None,
+    )
+    op.alter_column(
+        "course_nodes",
+        "content_hash",
+        existing_type=sa.String(length=64),
+        nullable=True,
+        server_default=None,
+    )

--- a/migrations/versions/phase31_node_summary_tables.py
+++ b/migrations/versions/phase31_node_summary_tables.py
@@ -1,0 +1,399 @@
+"""Phase 3.1 commit 1: NodeSummary{Raw,Final,FinalPreviousSnapshot} tables.
+
+Revision ID: phase31_node_summary_tables
+Revises: phase24_root_lang_required
+Create Date: 2026-06-10 00:00:00.000000
+
+Creates the methodist-layer data tables per vision §3 KD9/KD10/KD11.
+Three tables — Raw (system-generated), Final (editable, downstream
+source of truth), FinalPreviousSnapshot (single-version revert
+target before automatic Raw overwrite).
+
+Each Final/Raw is 1:1 with CourseNode (UNIQUE on course_node_id);
+PreviousSnapshot is 1:1 with Final (UNIQUE on node_summary_final_id).
+``content_hash`` columns are created nullable here — server_default
++ NOT NULL lands in commit 4 (task 3.1) together with the KD9
+NULL-at-INSERT regression fix on ``course_nodes``. The same applies
+to enclosing-context columns and meta counts which carry their
+runtime defaults via SQLAlchemy ``server_default`` at the ORM layer
+(JSONB ``'[]'``, integers ``0``, booleans ``false``).
+
+Soft-delete (``deleted_at`` + partial-active index) inherited from
+``SoftDeleteMixin`` per KD3; cascade wiring lands in commit 3.
+
+Self-contained migration — no app-code import per Phase 2.4.13
+ratified corrective.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "phase31_node_summary_tables"
+down_revision: str | Sequence[str] | None = "phase24_root_lang_required"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Shared JSONB type spelt out once for readability.
+_JSONB = postgresql.JSONB(astext_type=sa.Text())
+
+
+def upgrade() -> None:
+    """Create the three NodeSummary tables + their indexes."""
+    op.create_table(
+        "node_summaries_raw",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "course_node_id",
+            sa.Uuid(),
+            sa.ForeignKey("course_nodes.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        # Identity
+        sa.Column("title", sa.String(length=500), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        # Learning outcomes
+        sa.Column(
+            "learning_objectives",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "knowledge",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "skills",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        # Assessment
+        sa.Column(
+            "success_criteria",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("assessment_approach", sa.Text(), nullable=True),
+        # Methodology
+        sa.Column("teaching_approach", sa.Text(), nullable=True),
+        sa.Column(
+            "key_activities",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "common_mistakes",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        # Concepts
+        sa.Column(
+            "main_concepts",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "secondary_concepts",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        # Cross-level context
+        sa.Column("compressed_summary", sa.Text(), nullable=True),
+        sa.Column("enclosing_context", sa.Text(), nullable=True),
+        # Raw-only
+        sa.Column(
+            "methodist_observations",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        # Size metrics
+        sa.Column(
+            "own_documents_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "own_chars_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "cumulative_documents_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "cumulative_chars_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        # Hash axes — server_default + NOT NULL added in commit 4
+        sa.Column("content_hash", sa.String(length=64), nullable=True),
+        sa.Column("enclosing_context_source_hash", sa.String(length=64), nullable=True),
+        # Timestamps
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        # Soft-delete
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        comment=(
+            "System-generated methodist summary (vision §3 KD10) — "
+            "1:1 with CourseNode; rule «є вузол, є Raw» (v0.20.x)"
+        ),
+    )
+    op.create_index(
+        "ix_node_summaries_raw_active",
+        "node_summaries_raw",
+        ["deleted_at"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+    op.create_index(
+        "ix_node_summaries_raw_course_node_id",
+        "node_summaries_raw",
+        ["course_node_id"],
+    )
+
+    op.create_table(
+        "node_summaries_final",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "course_node_id",
+            sa.Uuid(),
+            sa.ForeignKey("course_nodes.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        # Editable
+        sa.Column("title", sa.String(length=500), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "learning_objectives",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "knowledge",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "skills",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "success_criteria",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("assessment_approach", sa.Text(), nullable=True),
+        sa.Column("teaching_approach", sa.Text(), nullable=True),
+        sa.Column(
+            "key_activities",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "common_mistakes",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        # Read-only copies from Raw
+        sa.Column(
+            "main_concepts",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "secondary_concepts",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("enclosing_context", sa.Text(), nullable=True),
+        # Empty-leaf author flow
+        sa.Column(
+            "is_manual",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("manual_description", sa.Text(), nullable=True),
+        # Size metrics
+        sa.Column(
+            "own_documents_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "own_chars_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "cumulative_documents_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "cumulative_chars_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        # Hash axis — server_default + NOT NULL added in commit 4
+        sa.Column("content_hash", sa.String(length=64), nullable=True),
+        # Approval pair
+        sa.Column("approved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "enclosing_context_updated_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        # Timestamps
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        # Soft-delete
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        comment=(
+            "Editable canonical methodist summary (vision §3 KD11) — "
+            "1:1 with CourseNode; downstream source of truth"
+        ),
+    )
+    op.create_index(
+        "ix_node_summaries_final_active",
+        "node_summaries_final",
+        ["deleted_at"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+    op.create_index(
+        "ix_node_summaries_final_course_node_id",
+        "node_summaries_final",
+        ["course_node_id"],
+    )
+
+    op.create_table(
+        "node_summaries_final_previous_snapshots",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "node_summary_final_id",
+            sa.Uuid(),
+            sa.ForeignKey("node_summaries_final.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column(
+            "snapshot",
+            _JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "replaced_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        comment=(
+            "Single prior version of NodeSummaryFinal (vision §3 KD11) — "
+            "1:1; replaced on overwrite; hard-deleted on approve"
+        ),
+    )
+    op.create_index(
+        "ix_node_summaries_final_previous_snapshots_active",
+        "node_summaries_final_previous_snapshots",
+        ["deleted_at"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+    op.create_index(
+        "ix_node_summaries_final_previous_snapshots_final_id",
+        "node_summaries_final_previous_snapshots",
+        ["node_summary_final_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the three NodeSummary tables (PreviousSnapshot → Final → Raw)."""
+    op.drop_index(
+        "ix_node_summaries_final_previous_snapshots_final_id",
+        table_name="node_summaries_final_previous_snapshots",
+    )
+    op.drop_index(
+        "ix_node_summaries_final_previous_snapshots_active",
+        table_name="node_summaries_final_previous_snapshots",
+    )
+    op.drop_table("node_summaries_final_previous_snapshots")
+
+    op.drop_index(
+        "ix_node_summaries_final_course_node_id",
+        table_name="node_summaries_final",
+    )
+    op.drop_index(
+        "ix_node_summaries_final_active",
+        table_name="node_summaries_final",
+    )
+    op.drop_table("node_summaries_final")
+
+    op.drop_index(
+        "ix_node_summaries_raw_course_node_id",
+        table_name="node_summaries_raw",
+    )
+    op.drop_index(
+        "ix_node_summaries_raw_active",
+        table_name="node_summaries_raw",
+    )
+    op.drop_table("node_summaries_raw")

--- a/src/course_supporter/storage/cascade.py
+++ b/src/course_supporter/storage/cascade.py
@@ -253,6 +253,88 @@ async def scrub_authored_document(document: Any) -> None:
     document.source_url = marker
 
 
+async def scrub_node_summary_raw(summary: Any) -> None:
+    """KD3 scrub: clear NodeSummaryRaw author-content fields on soft-delete.
+
+    Per vision §3 KD3 + Phase 3.1 Q-D ratify, all author-meaningful
+    content fields are emptied: top-level string fields receive the
+    formatted marker (:func:`_format_deleted_marker`); list fields
+    (concept sets, learning items, methodist observations) reset to
+    ``[]`` rather than carrying synthetic marker elements.
+
+    Excluded (not author content): ``content_hash``,
+    ``enclosing_context_source_hash`` (top-down memoization key —
+    Phase 3.2), size metrics, FK, timestamps.
+
+    Wired as the class-level ``__scrub_callable__`` on
+    ``NodeSummaryRaw``; fires on every Raw descendant in a cascade
+    (e.g. ``CourseNode`` soft-delete cascading to its Raw).
+    """
+    marker = _format_deleted_marker()
+    summary.title = marker
+    summary.description = marker
+    summary.assessment_approach = marker
+    summary.teaching_approach = marker
+    summary.compressed_summary = marker
+    summary.enclosing_context = marker
+    summary.learning_objectives = []
+    summary.knowledge = []
+    summary.skills = []
+    summary.success_criteria = []
+    summary.key_activities = []
+    summary.common_mistakes = []
+    summary.main_concepts = []
+    summary.secondary_concepts = []
+    summary.methodist_observations = []
+
+
+async def scrub_node_summary_final(summary: Any) -> None:
+    """KD3 scrub: clear NodeSummaryFinal author-content fields on soft-delete.
+
+    Mirrors :func:`scrub_node_summary_raw` for the Final shape: same
+    Q-D ratify (markers for str, ``[]`` for lists). ``manual_description``
+    receives the marker — it is author-provided content for empty-leaf
+    authoring. ``is_manual`` is NOT scrubbed (author-state flag, not
+    content). ``approved_at`` and ``enclosing_context_updated_at`` are
+    timestamps, not author content — excluded.
+
+    Wired as the class-level ``__scrub_callable__`` on
+    ``NodeSummaryFinal``.
+    """
+    marker = _format_deleted_marker()
+    summary.title = marker
+    summary.description = marker
+    summary.assessment_approach = marker
+    summary.teaching_approach = marker
+    summary.enclosing_context = marker
+    summary.manual_description = marker
+    summary.learning_objectives = []
+    summary.knowledge = []
+    summary.skills = []
+    summary.success_criteria = []
+    summary.key_activities = []
+    summary.common_mistakes = []
+    summary.main_concepts = []
+    summary.secondary_concepts = []
+
+
+async def scrub_node_summary_final_previous_snapshot(snapshot: Any) -> None:
+    """KD3 scrub: clear PreviousSnapshot JSONB on soft-delete.
+
+    The ``snapshot`` JSONB column is a bitwise copy of a prior Final
+    version's content fields. Per Phase 3.1 Q-B ratify (vision-side
+    fix to the KD3 scrub table — PreviousSnapshot row was previously
+    missing), the cascade soft-delete path resets it to ``{}``
+    rather than the marker string (the column is a structured
+    payload, not text — emitting a marker would invalidate the
+    document shape).
+
+    Wired as the class-level ``__scrub_callable__`` on
+    ``NodeSummaryFinalPreviousSnapshot``.
+    """
+    snapshot.snapshot = {}
+
+
 def build_cascade_map(root: type) -> dict[type, list[type]]:
     """Build a cascade_map from ``__cascades_soft_delete_to__`` declarations.
 

--- a/src/course_supporter/storage/content_hash.py
+++ b/src/course_supporter/storage/content_hash.py
@@ -29,7 +29,7 @@ import hashlib
 import json
 import uuid
 from datetime import datetime
-from typing import Protocol, cast
+from typing import Final, Protocol, cast
 
 import structlog
 from sqlalchemy import select
@@ -40,6 +40,8 @@ from course_supporter.storage.orm import (
     CourseNode,
     DocumentSegment,
     DocumentSummary,
+    NodeSummaryFinal,
+    NodeSummaryRaw,
 )
 
 logger = structlog.get_logger(__name__)
@@ -407,6 +409,27 @@ class ContentHashService:
             children += [h for (h,) in node_result.all() if h is not None]
             return compute_content_hash(b"", children)
 
+        # NodeSummaryRaw / NodeSummaryFinal — leaves of the content_hash
+        # graph (Q-A ratified at Phase 3.1 pre-flight): CourseNode hash
+        # formula does NOT include NodeSummary children (vision §3 KD9
+        # table line 725), and NodeSummary is derivative of the node,
+        # not a Merkle parent of anything — children=[] for both.
+        # ``enclosing_context`` is EXCLUDED from both formulas per
+        # vision §3 KD9 table lines 729-730: it depends on ancestors,
+        # not on own content, and is propagated through the SEPARATE
+        # top-down axis (``enclosing_context_source_hash``, Phase 3.2).
+        # Concept lists are ``sorted(...)`` at the formula boundary —
+        # same convention as ``DocumentSegment`` / ``DocumentSummary``
+        # — because LLM output order is non-deterministic.
+        if isinstance(entity, NodeSummaryRaw):
+            return compute_content_hash(
+                _encode_local_fields(_node_summary_raw_payload(entity)), []
+            )
+        if isinstance(entity, NodeSummaryFinal):
+            return compute_content_hash(
+                _encode_local_fields(_node_summary_final_payload(entity)), []
+            )
+
         raise TypeError(
             f"ContentHashService does not support entity type {type(entity).__name__}"
         )
@@ -432,6 +455,146 @@ class ContentHashService:
             if entity.parent_id is None:
                 return None
             return await self._session.get(CourseNode, entity.parent_id)
+        if isinstance(entity, NodeSummaryRaw | NodeSummaryFinal):
+            # Leaves of the content_hash graph (Q-A ratified): NodeSummary
+            # is derivative of the CourseNode, not a Merkle ancestor of
+            # anything — and is NOT a child of CourseNode in the hash
+            # formula either (KD9 table line 725 excludes it). Returning
+            # ``None`` means ``invalidate_up(NodeSummary*)`` recomputes
+            # the entity's own hash and stops; no CourseNode parent walk.
+            return None
         raise TypeError(
             f"ContentHashService does not support entity type {type(entity).__name__}"
         )
+
+
+# ──────────────────────────────────────────────
+# NodeSummary content-hash payloads + empty-hash constants (Phase 3.1)
+# ──────────────────────────────────────────────
+# Both Raw and Final hash all content fields EXCEPT ``enclosing_context``
+# per vision §3 KD9 table lines 729-730 — that field depends on
+# ancestors, not on own content, and is propagated through the SEPARATE
+# top-down axis (``enclosing_context_source_hash``; walker lands in
+# Phase 3.2). ``None``-coalescing to ``""``/``[]`` mirrors the
+# ``DocumentSegment`` convention and keeps the formula stable across
+# the empty-value-vs-NULL distinction (rule «є вузол — є Raw»).
+#
+# Concept lists alone are ``sorted(...)`` at the formula boundary —
+# the LLM-output-order non-determinism that motivated sorting in
+# ``DocumentSegment``/``DocumentSummary`` applies here too. Other
+# list fields (objectives, criteria, activities, mistakes, knowledge,
+# skills, methodist_observations) preserve insertion order because
+# they encode author-/methodist-meaningful sequencing rather than
+# a set.
+
+
+def _node_summary_raw_payload(entity: NodeSummaryRaw) -> dict[str, object]:
+    """Stable payload dict for ``NodeSummaryRaw.content_hash`` (vision §3 KD9)."""
+    return {
+        "title": entity.title or "",
+        "description": entity.description or "",
+        "learning_objectives": list(entity.learning_objectives or []),
+        "knowledge": list(entity.knowledge or []),
+        "skills": list(entity.skills or []),
+        "success_criteria": list(entity.success_criteria or []),
+        "assessment_approach": entity.assessment_approach or "",
+        "teaching_approach": entity.teaching_approach or "",
+        "key_activities": list(entity.key_activities or []),
+        "common_mistakes": list(entity.common_mistakes or []),
+        "main_concepts": sorted(entity.main_concepts or []),
+        "secondary_concepts": sorted(entity.secondary_concepts or []),
+        "compressed_summary": entity.compressed_summary or "",
+        # ``enclosing_context`` deliberately EXCLUDED (vision §3 KD9).
+        "methodist_observations": list(entity.methodist_observations or []),
+    }
+
+
+def _node_summary_final_payload(entity: NodeSummaryFinal) -> dict[str, object]:
+    """Stable payload dict for ``NodeSummaryFinal.content_hash`` (vision §3 KD9)."""
+    return {
+        "title": entity.title or "",
+        "description": entity.description or "",
+        "learning_objectives": list(entity.learning_objectives or []),
+        "knowledge": list(entity.knowledge or []),
+        "skills": list(entity.skills or []),
+        "success_criteria": list(entity.success_criteria or []),
+        "assessment_approach": entity.assessment_approach or "",
+        "teaching_approach": entity.teaching_approach or "",
+        "key_activities": list(entity.key_activities or []),
+        "common_mistakes": list(entity.common_mistakes or []),
+        "main_concepts": sorted(entity.main_concepts or []),
+        "secondary_concepts": sorted(entity.secondary_concepts or []),
+        # ``enclosing_context`` deliberately EXCLUDED (vision §3 KD9).
+        # ``compressed_summary`` not stored on Final (vision §267).
+        # ``methodist_observations`` is Raw-only.
+        "is_manual": bool(entity.is_manual),
+        "manual_description": entity.manual_description or "",
+    }
+
+
+def _empty_node_summary_raw_payload() -> dict[str, object]:
+    """Payload for an empty NodeSummaryRaw — every content field at its default."""
+    return {
+        "title": "",
+        "description": "",
+        "learning_objectives": [],
+        "knowledge": [],
+        "skills": [],
+        "success_criteria": [],
+        "assessment_approach": "",
+        "teaching_approach": "",
+        "key_activities": [],
+        "common_mistakes": [],
+        "main_concepts": [],
+        "secondary_concepts": [],
+        "compressed_summary": "",
+        "methodist_observations": [],
+    }
+
+
+def _empty_node_summary_final_payload() -> dict[str, object]:
+    """Payload for an empty NodeSummaryFinal — every content field at its default."""
+    return {
+        "title": "",
+        "description": "",
+        "learning_objectives": [],
+        "knowledge": [],
+        "skills": [],
+        "success_criteria": [],
+        "assessment_approach": "",
+        "teaching_approach": "",
+        "key_activities": [],
+        "common_mistakes": [],
+        "main_concepts": [],
+        "secondary_concepts": [],
+        "is_manual": False,
+        "manual_description": "",
+    }
+
+
+# Empty-hash constants — DERIVED via the same pure helpers used by
+# ``_compute_hash_for`` (Q-F: prove via the actual formula, not assumed).
+# Used by:
+#   * ``CourseNode.content_hash`` ``server_default`` (KD9 NULL-at-INSERT
+#     regression fix — commit 4 of task 3.1).
+#   * ``NodeSummaryRaw.content_hash`` / ``NodeSummaryFinal.content_hash``
+#     ``server_default`` (rule «визначений хеш, ніколи NULL» — Q-G).
+#   * Memoization sentinels for empty leaves (Phase 3.2 generation
+#     pipeline).
+EMPTY_NODE_CONTENT_HASH: Final[str] = compute_content_hash(b"", [])
+"""Hash of an empty CourseNode (no own documents, no children).
+
+Equals ``compute_content_hash(b"", [])`` — the same path
+``_compute_hash_for(CourseNode)`` walks for a node with zero documents
+and zero child nodes.
+"""
+
+EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH: Final[str] = compute_content_hash(
+    _encode_local_fields(_empty_node_summary_raw_payload()), []
+)
+"""Hash of an empty NodeSummaryRaw (all content fields at default)."""
+
+EMPTY_NODE_SUMMARY_FINAL_CONTENT_HASH: Final[str] = compute_content_hash(
+    _encode_local_fields(_empty_node_summary_final_payload()), []
+)
+"""Hash of an empty NodeSummaryFinal (all content fields at default)."""

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -28,6 +28,9 @@ from course_supporter.storage.cascade import (
     ScrubCallable,
     scrub_authored_document,
     scrub_course_node,
+    scrub_node_summary_final,
+    scrub_node_summary_final_previous_snapshot,
+    scrub_node_summary_raw,
 )
 
 
@@ -1439,9 +1442,19 @@ class NodeSummaryFinalPreviousSnapshot(SoftDeleteMixin, Base):
 # Wiring per Phase 1 PHASE.md §1.2 cascade declaration audit. Self-
 # reference on CourseNode supports recursive course-tree traversal.
 Tenant.__cascades_soft_delete_to__ = [APIKey, CourseNode, Student, HomeworkSubmission]
-CourseNode.__cascades_soft_delete_to__ = [CourseNode, AuthoredDocument]
+CourseNode.__cascades_soft_delete_to__ = [
+    CourseNode,
+    AuthoredDocument,
+    NodeSummaryRaw,
+    NodeSummaryFinal,
+]
 AuthoredDocument.__cascades_soft_delete_to__ = [DocumentSummary]
 DocumentSummary.__cascades_soft_delete_to__ = [DocumentSegment]
+# Phase 3.1 Q-C ratify (Option A — two-level): PreviousSnapshot cascades
+# from its parent NodeSummaryFinal, mirroring the AuthoredDocument →
+# DocumentSummary → DocumentSegment two-level pattern. This preserves
+# the 1:1 Final↔PreviousSnapshot invariant on the cascade path.
+NodeSummaryFinal.__cascades_soft_delete_to__ = [NodeSummaryFinalPreviousSnapshot]
 Student.__cascades_soft_delete_to__ = [HomeworkSubmission]
 
 
@@ -1459,3 +1472,8 @@ Student.__cascades_soft_delete_to__ = [HomeworkSubmission]
 # tables stay empty, cascade traversal through them is no-op.
 CourseNode.__scrub_callable__ = scrub_course_node
 AuthoredDocument.__scrub_callable__ = scrub_authored_document
+NodeSummaryRaw.__scrub_callable__ = scrub_node_summary_raw
+NodeSummaryFinal.__scrub_callable__ = scrub_node_summary_final
+NodeSummaryFinalPreviousSnapshot.__scrub_callable__ = (
+    scrub_node_summary_final_previous_snapshot
+)

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar
 
 import uuid_utils as uuid7_lib
 from sqlalchemy import (
+    Boolean,
     CheckConstraint,
     DateTime,
     Enum,
@@ -1070,6 +1071,363 @@ class HomeworkSubmission(SoftDeleteMixin, Base):
             f"HomeworkSubmission(id={self.id!r}, status={self.status!r}, "
             f"student_id={self.student_id!r})"
         )
+
+
+# ──────────────────────────────────────────────
+# Methodist layer — NodeSummary models (vision §2.2, KD6, KD9, KD10, KD11, KD12)
+# ──────────────────────────────────────────────
+
+
+class NodeSummaryRaw(SoftDeleteMixin, Base):
+    """System-generated methodist summary of a CourseNode (vision §3 KD10).
+
+    1:1 with CourseNode (UNIQUE on course_node_id). Produced by the
+    two-pass methodist pipeline: bottom-up generates all canonical
+    fields + compressed_summary; top-down generates enclosing_context
+    + appends methodist_observations. Per vision rule "є вузол, є Raw"
+    (v0.20.x) a Raw row exists for every CourseNode, including empty
+    leaves — emptiness is null-valued content fields, NOT row absence.
+
+    Per KD9 the ``content_hash`` covers all content fields EXCEPT
+    ``enclosing_context`` (which depends on ancestors, not on own
+    content). Per probe-resolved Phase 3 pre-review the second axis
+    of memoization for top-down — ``enclosing_context_source_hash``
+    (hash of parent enclosing_context) — lives on Raw only; the
+    walker service that maintains it lands in Phase 3.2.
+    """
+
+    __tablename__ = "node_summaries_raw"
+    __table_args__ = (
+        Index(
+            "ix_node_summaries_raw_active",
+            "deleted_at",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        {
+            "comment": (
+                "System-generated methodist summary (vision §3 KD10) — "
+                "1:1 with CourseNode; rule «є вузол, є Raw» (v0.20.x)"
+            ),
+        },
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
+    course_node_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("course_nodes.id", ondelete="CASCADE"),
+        unique=True,
+        index=True,
+        comment="FK to CourseNode (UNIQUE — 1:1 invariant per KD10 «є вузол, є Raw»)",
+    )
+
+    # ─── Identity (KD3 scrub targets — str) ──────
+    title: Mapped[str | None] = mapped_column(String(500))
+    description: Mapped[str | None] = mapped_column(Text)
+
+    # ─── Learning outcomes ───────────────────────
+    learning_objectives: Mapped[list[str]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+        comment="Bloom-taxonomy outcome statements (3-7; overflow → observations)",
+    )
+    knowledge: Mapped[list[dict[str, str]]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+        comment="LearningOutcomeItem[]: {name, description} — what student WILL KNOW",
+    )
+    skills: Mapped[list[dict[str, str]]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+        comment="LearningOutcomeItem[]: {name, description} — what student WILL DO",
+    )
+
+    # ─── Assessment ──────────────────────────────
+    success_criteria: Mapped[list[str]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+    )
+    assessment_approach: Mapped[str | None] = mapped_column(Text)
+
+    # ─── Methodology ─────────────────────────────
+    teaching_approach: Mapped[str | None] = mapped_column(Text)
+    key_activities: Mapped[list[str]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+    )
+    common_mistakes: Mapped[list[str]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+        comment="EXPLICIT-only (per KD10) — items mentioned in source documents",
+    )
+
+    # ─── Concepts (navigation) ───────────────────
+    main_concepts: Mapped[list[str]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+    )
+    secondary_concepts: Mapped[list[str]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+    )
+
+    # ─── Cross-level context ─────────────────────
+    compressed_summary: Mapped[str | None] = mapped_column(
+        Text,
+        comment="1-2k tokens, KD10 bottom-up output — passed to parent on next walk",
+    )
+    enclosing_context: Mapped[str | None] = mapped_column(
+        Text,
+        comment="1-2k tokens, KD10 top-down output — NOT included in content_hash "
+        "(depends on ancestors, not own content); NULL on root (top-down skipped)",
+    )
+
+    # ─── Raw-only ────────────────────────────────
+    methodist_observations: Mapped[list[str]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+        comment="Methodist annotations from both passes; Raw-only (not in Final)",
+    )
+
+    # ─── Size metrics ────────────────────────────
+    own_documents_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    own_chars_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    cumulative_documents_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    cumulative_chars_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+
+    # ─── Hash axes ───────────────────────────────
+    content_hash: Mapped[str | None] = mapped_column(
+        String(64),
+        comment="Materialised content_hash (vision §3 KD9, SHA-256 hex) — "
+        "SHA256 over all content fields EXCEPT enclosing_context. "
+        "server_default + NOT NULL wired in task 3.1 commit 4.",
+    )
+    enclosing_context_source_hash: Mapped[str | None] = mapped_column(
+        String(64),
+        comment="Top-down memoization key (KD10) = hash of parent's "
+        "enclosing_context. Raw-only — Final does not carry this key. "
+        "NULL until first top-down walk populates it (walker — Phase 3.2).",
+    )
+
+    # ─── Timestamps ──────────────────────────────
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
+class NodeSummaryFinal(SoftDeleteMixin, Base):
+    """Editable canonical methodist summary for downstream agents (vision §3 KD11).
+
+    1:1 with CourseNode (UNIQUE on course_node_id). Created as a
+    bitwise copy of NodeSummaryRaw immediately after Raw generation;
+    edited by the author thereafter. Three write channels (KD11):
+    (1) automatic overwrite on Raw regeneration (resets approved_at),
+    (2) author manual edit, (3) top-down direct refresh of
+    ``enclosing_context`` + ``enclosing_context_updated_at`` WITHOUT
+    resetting approved_at (third channel — KD11 explicit exception).
+
+    Per KD11 ``enclosing_context`` is read-only on Final (not author-
+    editable); ``main_concepts`` / ``secondary_concepts`` are read-only
+    copies of Raw (concept-based navigation invariant). ``compressed_summary``
+    is NOT stored on Final — downstream gets the full fields, so
+    duplicating the bottom-up bridge would be redundant.
+
+    Empty-leaf author flow (Phase 3.1 MVP — operator-ratified question 6):
+    ``is_manual`` + ``manual_description`` allow the author to
+    populate an empty leaf manually as a future generalisation
+    point. ``methodist_observations`` is Raw-only and intentionally
+    absent here.
+    """
+
+    __tablename__ = "node_summaries_final"
+    __table_args__ = (
+        Index(
+            "ix_node_summaries_final_active",
+            "deleted_at",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        {
+            "comment": (
+                "Editable canonical methodist summary (vision §3 KD11) — "
+                "1:1 with CourseNode; downstream source of truth"
+            ),
+        },
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
+    course_node_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("course_nodes.id", ondelete="CASCADE"),
+        unique=True,
+        index=True,
+        comment="FK to CourseNode (UNIQUE — 1:1 invariant per KD11)",
+    )
+
+    # ─── Editable by author (11 content fields) ──
+    title: Mapped[str | None] = mapped_column(String(500))
+    description: Mapped[str | None] = mapped_column(Text)
+    learning_objectives: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    knowledge: Mapped[list[dict[str, str]]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    skills: Mapped[list[dict[str, str]]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    success_criteria: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    assessment_approach: Mapped[str | None] = mapped_column(Text)
+    teaching_approach: Mapped[str | None] = mapped_column(Text)
+    key_activities: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    common_mistakes: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+
+    # ─── Read-only — copied from Raw (KD11) ──────
+    main_concepts: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    secondary_concepts: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    enclosing_context: Mapped[str | None] = mapped_column(
+        Text,
+        comment="Read-only on Final (KD11). Refreshed via third channel "
+        "(top-down direct write) WITHOUT resetting approved_at. "
+        "NULL on root (top-down skipped). NOT included in content_hash.",
+    )
+
+    # ─── Empty-leaf author flow (probe-resolved question 6, MVP 3.1) ─
+    is_manual: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("false"),
+        comment="True when Final was author-created/edited on an empty "
+        "leaf rather than copied from a Raw with content.",
+    )
+    manual_description: Mapped[str | None] = mapped_column(
+        Text,
+        comment="Author-provided description for empty-leaf author-flow.",
+    )
+
+    # ─── Size metrics ────────────────────────────
+    own_documents_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    own_chars_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    cumulative_documents_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    cumulative_chars_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+
+    # ─── Hash axis ───────────────────────────────
+    content_hash: Mapped[str | None] = mapped_column(
+        String(64),
+        comment="Materialised content_hash (vision §3 KD9, SHA-256 hex) — "
+        "SHA256 over all content fields EXCEPT enclosing_context. "
+        "server_default + NOT NULL wired in task 3.1 commit 4.",
+    )
+
+    # ─── Approval pair (read as two dates per KD11) ──────────
+    approved_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        comment="NULL after automatic Raw-overwrite; set by explicit author "
+        "approve. Top-down third channel refresh does NOT reset this.",
+    )
+    enclosing_context_updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        comment="When top-down last refreshed enclosing_context. Paired "
+        "with approved_at — content can be approved BEFORE the latest "
+        "context refresh. NULL on root (top-down skipped) and until "
+        "the first top-down walk lands.",
+    )
+
+    # ─── Timestamps ──────────────────────────────
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
+class NodeSummaryFinalPreviousSnapshot(SoftDeleteMixin, Base):
+    """Single-version snapshot of NodeSummaryFinal before last overwrite (KD11).
+
+    1:1 with NodeSummaryFinal (UNIQUE on node_summary_final_id) — at
+    most ONE prior version is kept, not a history. Lifecycle (KD11):
+
+    - Created on the FIRST automatic overwrite (Raw regeneration).
+    - REPLACED in-place on every subsequent overwrite.
+    - HARD-DELETED on explicit author approve (KD12 Path 3 — the
+      prior version is irrelevant once the current state is approved).
+    - Cascade soft-deleted with scrub on CourseNode soft-delete
+      (KD3 + KD12 — operator-ratified Q-B (a) at 3.1 pre-flight:
+      both soft-delete-with-scrub and hard-delete-on-approve are
+      legitimate, non-conflicting paths).
+    """
+
+    __tablename__ = "node_summaries_final_previous_snapshots"
+    __table_args__ = (
+        Index(
+            "ix_node_summaries_final_previous_snapshots_active",
+            "deleted_at",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        {
+            "comment": (
+                "Single prior version of NodeSummaryFinal (vision §3 KD11) — "
+                "1:1; replaced on overwrite; hard-deleted on approve"
+            ),
+        },
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid7)
+    node_summary_final_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("node_summaries_final.id", ondelete="CASCADE"),
+        unique=True,
+        index=True,
+        comment="FK to NodeSummaryFinal (UNIQUE — single-version invariant)",
+    )
+    snapshot: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+        comment="Bitwise copy of prior NodeSummaryFinal content fields.",
+    )
+    replaced_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        comment="When the prior version was overwritten by automatic Raw regen.",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
 
 # ──────────────────────────────────────────────

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -261,11 +261,22 @@ class CourseNode(SoftDeleteMixin, Base):
         "sorted last by created_at. Sort: ORDER BY order ASC NULLS LAST, "
         "created_at ASC.",
     )
+    # Python type is ``str | None`` for compatibility with the
+    # ``HashableEntity`` Protocol invariance (the Protocol declares
+    # ``content_hash: str | None`` and all sibling hash-bearing models
+    # use the same nullable Python type). DB layer is ``NOT NULL +
+    # server_default`` so a runtime NULL is impossible — Phase 3.1 Q-G.
     content_hash: Mapped[str | None] = mapped_column(
         String(64),
+        nullable=False,
+        server_default=text(
+            "'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'"
+        ),
         comment="Materialised content_hash (vision §3 KD9, SHA-256 hex). "
-        "NULL = never computed / stale. Populated at INSERT/UPDATE; "
-        "per-entity formula wired in Phase 2/3.",
+        "server_default = EMPTY_NODE_CONTENT_HASH (= compute_content_hash(b'', [])). "
+        "Phase 3.1 commit 4 fixed the KD9 NULL-at-INSERT regression: "
+        "empty CourseNodes now carry a defined empty-hash, not NULL. "
+        "Recomputed at INSERT/UPDATE via ContentHashService.invalidate_up.",
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
@@ -1214,11 +1225,18 @@ class NodeSummaryRaw(SoftDeleteMixin, Base):
     )
 
     # ─── Hash axes ───────────────────────────────
+    # Python type ``str | None`` for HashableEntity Protocol compat;
+    # DB-level NOT NULL + server_default makes runtime NULL impossible.
     content_hash: Mapped[str | None] = mapped_column(
         String(64),
+        nullable=False,
+        server_default=text(
+            "'bcaf467defc6a11d9f437368b2388f310b8538fc2fe21621587f69175766cadd'"
+        ),
         comment="Materialised content_hash (vision §3 KD9, SHA-256 hex) — "
         "SHA256 over all content fields EXCEPT enclosing_context. "
-        "server_default + NOT NULL wired in task 3.1 commit 4.",
+        "server_default = EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH (rule "
+        "«визначений хеш, ніколи NULL» — Phase 3.1 Q-G).",
     )
     enclosing_context_source_hash: Mapped[str | None] = mapped_column(
         String(64),
@@ -1349,11 +1367,18 @@ class NodeSummaryFinal(SoftDeleteMixin, Base):
     )
 
     # ─── Hash axis ───────────────────────────────
+    # Python type ``str | None`` for HashableEntity Protocol compat;
+    # DB-level NOT NULL + server_default makes runtime NULL impossible.
     content_hash: Mapped[str | None] = mapped_column(
         String(64),
+        nullable=False,
+        server_default=text(
+            "'85ef8d5f3881ffae484d1c1b47d18c0984b19c03bc9dd44e6fc1010e9fcdbf03'"
+        ),
         comment="Materialised content_hash (vision §3 KD9, SHA-256 hex) — "
         "SHA256 over all content fields EXCEPT enclosing_context. "
-        "server_default + NOT NULL wired in task 3.1 commit 4.",
+        "server_default = EMPTY_NODE_SUMMARY_FINAL_CONTENT_HASH (rule "
+        "«визначений хеш, ніколи NULL» — Phase 3.1 Q-G).",
     )
 
     # ─── Approval pair (read as two dates per KD11) ──────────

--- a/tests/integration/test_content_hash_persistence.py
+++ b/tests/integration/test_content_hash_persistence.py
@@ -152,11 +152,15 @@ class TestInvalidateUpPersistsHashes:
         section = await _make_section(db_session, entry.id)
         segment = await _make_segment(db_session, section.id, content="hello")
 
-        # All hashes are NULL initially (no backfill in 0.2).
+        # Phase 3.1 commit 4 closed the KD9 NULL-at-INSERT regression
+        # for CourseNode (now carries a server_default empty-hash) —
+        # the three levels below CourseNode still start NULL pending
+        # invalidate_up rewrite per Phase 1.3+ targets.
         assert segment.content_hash is None
         assert section.content_hash is None
         assert entry.content_hash is None
-        assert node.content_hash is None
+        assert node.content_hash is not None
+        node_hash_before = node.content_hash
 
         await ContentHashService(db_session).invalidate_up(segment)
 
@@ -169,6 +173,12 @@ class TestInvalidateUpPersistsHashes:
         assert section.content_hash is not None
         assert entry.content_hash is not None
         assert node.content_hash is not None
+        # The CourseNode hash must NOT still be the empty-hash default
+        # after a content-bearing AuthoredDocument joined its subtree —
+        # ``invalidate_up`` is supposed to recompute it from the new
+        # children. Equality with ``node_hash_before`` would mean the
+        # walker silently stopped one level short.
+        assert node.content_hash != node_hash_before
         # All 64-char lowercase hex.
         for h in (
             segment.content_hash,

--- a/tests/integration/test_node_summary_persistence.py
+++ b/tests/integration/test_node_summary_persistence.py
@@ -1,0 +1,207 @@
+"""Integration: NodeSummary{Raw,Final,FinalPreviousSnapshot} against real PostgreSQL.
+
+Covers Phase 3.1 acceptance #3 (CourseNode INSERT carries the
+defined empty-hash) and acceptance #5 (cascade soft-delete of a
+CourseNode sets ``deleted_at`` on its NodeSummaryRaw / Final /
+PreviousSnapshot through the wired ``__cascades_soft_delete_to__``
+declaration).
+
+Run with: ``uv run pytest -m requires_db --run-db``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.storage.cascade import (
+    CascadeDeleteService,
+    build_cascade_map,
+)
+from course_supporter.storage.content_hash import (
+    EMPTY_NODE_CONTENT_HASH,
+    EMPTY_NODE_SUMMARY_FINAL_CONTENT_HASH,
+    EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH,
+)
+from course_supporter.storage.orm import (
+    CourseNode,
+    NodeSummaryFinal,
+    NodeSummaryFinalPreviousSnapshot,
+    NodeSummaryRaw,
+    Tenant,
+)
+from tests._helpers.course_node_factory import make_root_course_node
+
+pytestmark = pytest.mark.requires_db
+
+
+# ── Fixture helpers ──────────────────────────────────────────────
+
+
+async def _make_tenant(session: AsyncSession) -> Tenant:
+    tenant = Tenant(name=f"ns-test-{uuid.uuid4().hex[:8]}")
+    session.add(tenant)
+    await session.flush()
+    return tenant
+
+
+async def _make_root_node(session: AsyncSession, tenant_id: uuid.UUID) -> CourseNode:
+    node = make_root_course_node(tenant_id=tenant_id, title="root")
+    session.add(node)
+    await session.flush()
+    return node
+
+
+async def _make_raw(session: AsyncSession, course_node_id: uuid.UUID) -> NodeSummaryRaw:
+    raw = NodeSummaryRaw(course_node_id=course_node_id)
+    session.add(raw)
+    await session.flush()
+    return raw
+
+
+async def _make_final(
+    session: AsyncSession, course_node_id: uuid.UUID
+) -> NodeSummaryFinal:
+    final = NodeSummaryFinal(course_node_id=course_node_id)
+    session.add(final)
+    await session.flush()
+    return final
+
+
+async def _make_previous_snapshot(
+    session: AsyncSession, node_summary_final_id: uuid.UUID
+) -> NodeSummaryFinalPreviousSnapshot:
+    snap = NodeSummaryFinalPreviousSnapshot(
+        node_summary_final_id=node_summary_final_id,
+    )
+    session.add(snap)
+    await session.flush()
+    return snap
+
+
+# ── Acceptance #3 — server_default empty-hash at INSERT ──────────
+
+
+class TestServerDefaultEmptyHash:
+    """KD9 NULL-at-INSERT regression CLOSED (Phase 3.1 Q-G).
+
+    All three hash-bearing methodist tables — CourseNode,
+    NodeSummaryRaw, NodeSummaryFinal — carry a DEFINED empty-hash
+    server_default. INSERTing an empty row must NOT yield
+    ``content_hash IS NULL``.
+    """
+
+    async def test_course_node_insert_carries_empty_hash(
+        self, db_session: AsyncSession
+    ) -> None:
+        tenant = await _make_tenant(db_session)
+        node = await _make_root_node(db_session, tenant.id)
+        # ``eager_defaults`` flushes server-side defaults onto the ORM
+        # instance via RETURNING — readback should be the empty hash,
+        # not NULL.
+        await db_session.refresh(node)
+        assert node.content_hash == EMPTY_NODE_CONTENT_HASH
+
+    async def test_node_summary_raw_insert_carries_empty_hash(
+        self, db_session: AsyncSession
+    ) -> None:
+        tenant = await _make_tenant(db_session)
+        node = await _make_root_node(db_session, tenant.id)
+        raw = await _make_raw(db_session, node.id)
+        await db_session.refresh(raw)
+        assert raw.content_hash == EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH
+
+    async def test_node_summary_final_insert_carries_empty_hash(
+        self, db_session: AsyncSession
+    ) -> None:
+        tenant = await _make_tenant(db_session)
+        node = await _make_root_node(db_session, tenant.id)
+        final = await _make_final(db_session, node.id)
+        await db_session.refresh(final)
+        assert final.content_hash == EMPTY_NODE_SUMMARY_FINAL_CONTENT_HASH
+
+
+# ── Acceptance #5 — cascade soft-delete coverage ─────────────────
+
+
+class TestCascadeSoftDelete:
+    """CourseNode soft-delete cascades to NodeSummaryRaw + NodeSummaryFinal,
+    and NodeSummaryFinal soft-delete cascades to PreviousSnapshot.
+
+    Q-C Option A two-level shape: PreviousSnapshot is reached via the
+    Final leg, not directly from CourseNode — mirrors the
+    AuthoredDocument → DocumentSummary → DocumentSegment cascade
+    pattern.
+    """
+
+    async def test_course_node_cascade_reaches_raw_and_final(
+        self, db_session: AsyncSession
+    ) -> None:
+        tenant = await _make_tenant(db_session)
+        node = await _make_root_node(db_session, tenant.id)
+        raw = await _make_raw(db_session, node.id)
+        final = await _make_final(db_session, node.id)
+
+        cascade_map = build_cascade_map(CourseNode)
+        svc = CascadeDeleteService(db_session)
+        await svc.soft_delete_with_cascade(node, cascade_map)
+        await db_session.flush()
+
+        await db_session.refresh(raw)
+        await db_session.refresh(final)
+        assert raw.deleted_at is not None, (
+            "NodeSummaryRaw must be soft-deleted via CourseNode cascade"
+        )
+        assert final.deleted_at is not None, (
+            "NodeSummaryFinal must be soft-deleted via CourseNode cascade"
+        )
+
+    async def test_course_node_cascade_reaches_previous_snapshot(
+        self, db_session: AsyncSession
+    ) -> None:
+        tenant = await _make_tenant(db_session)
+        node = await _make_root_node(db_session, tenant.id)
+        final = await _make_final(db_session, node.id)
+        snap = await _make_previous_snapshot(db_session, final.id)
+
+        cascade_map = build_cascade_map(CourseNode)
+        svc = CascadeDeleteService(db_session)
+        await svc.soft_delete_with_cascade(node, cascade_map)
+        await db_session.flush()
+
+        await db_session.refresh(snap)
+        assert snap.deleted_at is not None, (
+            "PreviousSnapshot must be soft-deleted via "
+            "CourseNode → NodeSummaryFinal → PreviousSnapshot cascade"
+        )
+
+    async def test_course_node_cascade_scrubs_node_summary_content(
+        self, db_session: AsyncSession
+    ) -> None:
+        tenant = await _make_tenant(db_session)
+        node = await _make_root_node(db_session, tenant.id)
+        raw = NodeSummaryRaw(
+            course_node_id=node.id,
+            title="Original title",
+            description="Original description",
+            main_concepts=["alpha", "beta"],
+            methodist_observations=["one"],
+        )
+        db_session.add(raw)
+        await db_session.flush()
+
+        cascade_map = build_cascade_map(CourseNode)
+        svc = CascadeDeleteService(db_session)
+        await svc.soft_delete_with_cascade(node, cascade_map)
+        await db_session.flush()
+
+        await db_session.refresh(raw)
+        # KD3 markers on string content (Q-D ratify); list fields reset
+        # to ``[]`` rather than carrying synthetic marker elements.
+        assert raw.title is not None
+        assert "інформація видалена автором" in raw.title
+        assert "інформація видалена автором" in (raw.description or "")
+        assert raw.main_concepts == []
+        assert raw.methodist_observations == []

--- a/tests/integration/test_node_summary_persistence.py
+++ b/tests/integration/test_node_summary_persistence.py
@@ -33,6 +33,7 @@ from course_supporter.storage.orm import (
     Tenant,
 )
 from tests._helpers.course_node_factory import make_root_course_node
+from tests._helpers.kd3_marker import assert_marker_recent
 
 pytestmark = pytest.mark.requires_db
 
@@ -200,8 +201,14 @@ class TestCascadeSoftDelete:
         await db_session.refresh(raw)
         # KD3 markers on string content (Q-D ratify); list fields reset
         # to ``[]`` rather than carrying synthetic marker elements.
+        # Marker format validated via the canonical helper
+        # ``tests/_helpers/kd3_marker.assert_marker_recent`` (regex +
+        # timestamp tolerance) — sibling tests in ``test_cascade_*``
+        # use the same helper, so a contract change picks up here
+        # atomically without per-test substring drift.
         assert raw.title is not None
-        assert "інформація видалена автором" in raw.title
-        assert "інформація видалена автором" in (raw.description or "")
+        assert_marker_recent(raw.title)
+        assert raw.description is not None
+        assert_marker_recent(raw.description)
         assert raw.main_concepts == []
         assert raw.methodist_observations == []

--- a/tests/storage/test_cascade_declarations.py
+++ b/tests/storage/test_cascade_declarations.py
@@ -14,6 +14,9 @@ from course_supporter.storage.orm import (
     DocumentSegment,
     DocumentSummary,
     HomeworkSubmission,
+    NodeSummaryFinal,
+    NodeSummaryFinalPreviousSnapshot,
+    NodeSummaryRaw,
     Student,
     Tenant,
 )
@@ -33,9 +36,14 @@ class TestCascadeDeclarations:
     def test_course_node_cascades(self) -> None:
         # Self-reference enables recursive course-tree traversal in
         # CascadeDeleteService.build_cascade_map (storage/cascade.py).
+        # Phase 3.1 adds NodeSummaryRaw + NodeSummaryFinal legs per
+        # KD12 (CourseNode subtree cascade includes its methodist
+        # summaries — vision §3 KD12 line 825).
         assert CourseNode.__cascades_soft_delete_to__ == [
             CourseNode,
             AuthoredDocument,
+            NodeSummaryRaw,
+            NodeSummaryFinal,
         ]
 
     def test_authored_document_cascades(self) -> None:
@@ -43,6 +51,15 @@ class TestCascadeDeclarations:
 
     def test_document_summary_cascades(self) -> None:
         assert DocumentSummary.__cascades_soft_delete_to__ == [DocumentSegment]
+
+    def test_node_summary_final_cascades_to_previous_snapshot(self) -> None:
+        # Phase 3.1 Q-C Option A (two-level): PreviousSnapshot is
+        # reached via NodeSummaryFinal, preserving the 1:1 invariant
+        # on the cascade path (sibling shape to AuthoredDocument →
+        # DocumentSummary → DocumentSegment).
+        assert NodeSummaryFinal.__cascades_soft_delete_to__ == [
+            NodeSummaryFinalPreviousSnapshot
+        ]
 
     def test_student_cascades(self) -> None:
         assert Student.__cascades_soft_delete_to__ == [HomeworkSubmission]
@@ -52,6 +69,18 @@ class TestCascadeDeclarations:
         # Per §1.3, APIKey + DocumentSegment + HomeworkSubmission carry no
         # KD3 content scrub responsibility AND no further cascade — they
         # are terminal under their respective entry points.
+        # NodeSummaryRaw + NodeSummaryFinalPreviousSnapshot added in
+        # Phase 3.1 — both are terminal (Raw has no descendants; the
+        # snapshot is the leaf of the Final → PreviousSnapshot pair).
         assert getattr(APIKey, "__cascades_soft_delete_to__", []) == []
         assert getattr(DocumentSegment, "__cascades_soft_delete_to__", []) == []
         assert getattr(HomeworkSubmission, "__cascades_soft_delete_to__", []) == []
+        assert getattr(NodeSummaryRaw, "__cascades_soft_delete_to__", []) == []
+        assert (
+            getattr(
+                NodeSummaryFinalPreviousSnapshot,
+                "__cascades_soft_delete_to__",
+                [],
+            )
+            == []
+        )

--- a/tests/storage/test_empty_hash_literals.py
+++ b/tests/storage/test_empty_hash_literals.py
@@ -1,0 +1,58 @@
+"""Migration literal ↔ formula-derived constant parity (Phase 3.1 Q-F).
+
+The Alembic migration ``phase31_content_hash_defaults`` hardcodes
+each empty-hash as a string literal per
+[[feedback-migration-self-contained-no-app-import]] — Alembic must
+not import application code. Q-F at the 3.1 pre-flight added a
+counter-requirement: the literals MUST equal the constants derived
+through the live ``compute_content_hash`` formula in
+``storage/content_hash.py``. This test pins that parity, so any
+future drift (e.g. someone tweaks ``_empty_node_summary_raw_payload``
+without updating the migration literal) surfaces as a hard test
+failure rather than silent regression at INSERT time.
+
+Sibling-mirror to the migration literal — keep both files in sync.
+"""
+
+from __future__ import annotations
+
+from course_supporter.storage.content_hash import (
+    EMPTY_NODE_CONTENT_HASH,
+    EMPTY_NODE_SUMMARY_FINAL_CONTENT_HASH,
+    EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH,
+)
+
+# The same string literals as in
+# ``migrations/versions/phase31_content_hash_defaults.py``. Pinned
+# verbatim — divergence is the whole point of this test.
+_MIGRATION_LITERAL_NODE_HASH = (
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+_MIGRATION_LITERAL_RAW_HASH = (
+    "bcaf467defc6a11d9f437368b2388f310b8538fc2fe21621587f69175766cadd"
+)
+_MIGRATION_LITERAL_FINAL_HASH = (
+    "85ef8d5f3881ffae484d1c1b47d18c0984b19c03bc9dd44e6fc1010e9fcdbf03"
+)
+
+
+def test_node_content_hash_literal_matches_constant() -> None:
+    assert EMPTY_NODE_CONTENT_HASH == _MIGRATION_LITERAL_NODE_HASH
+
+
+def test_node_summary_raw_content_hash_literal_matches_constant() -> None:
+    assert EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH == _MIGRATION_LITERAL_RAW_HASH
+
+
+def test_node_summary_final_content_hash_literal_matches_constant() -> None:
+    assert EMPTY_NODE_SUMMARY_FINAL_CONTENT_HASH == _MIGRATION_LITERAL_FINAL_HASH
+
+
+def test_three_constants_are_distinct() -> None:
+    # Different payload shapes (CourseNode b"" vs Raw payload vs Final
+    # payload) must produce different empty-hashes. A collision would
+    # mean someone accidentally aligned the payload shapes — would
+    # break memoization-by-empty-hash semantics in Phase 3.2.
+    assert EMPTY_NODE_CONTENT_HASH != EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH
+    assert EMPTY_NODE_CONTENT_HASH != EMPTY_NODE_SUMMARY_FINAL_CONTENT_HASH
+    assert EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH != EMPTY_NODE_SUMMARY_FINAL_CONTENT_HASH

--- a/tests/storage/test_node_summary_formulas.py
+++ b/tests/storage/test_node_summary_formulas.py
@@ -1,0 +1,229 @@
+"""NodeSummaryRaw / NodeSummaryFinal content_hash formula tests (Phase 3.1).
+
+Covers Phase 3.1 acceptance #4 — the load-bearing invariant that
+``content_hash`` excludes ``enclosing_context`` for both Raw and
+Final (vision §3 KD9 table lines 729-730). Two NodeSummary* rows
+that differ ONLY in ``enclosing_context`` must produce byte-
+identical content_hashes; any other content-field change must flip
+the hash.
+
+Mirrors ``test_content_hash_formulas.py`` shape (AsyncMock session,
+``_make_X`` builders, focused per-property classes).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from course_supporter.storage.content_hash import ContentHashService
+from course_supporter.storage.orm import NodeSummaryFinal, NodeSummaryRaw
+
+
+def _make_raw(**overrides: Any) -> NodeSummaryRaw:
+    """Build a NodeSummaryRaw with sane defaults; override individual fields."""
+    defaults: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "course_node_id": uuid.uuid4(),
+        "title": "Node Title",
+        "description": "Node description",
+        "learning_objectives": [],
+        "knowledge": [],
+        "skills": [],
+        "success_criteria": [],
+        "assessment_approach": "",
+        "teaching_approach": "",
+        "key_activities": [],
+        "common_mistakes": [],
+        "main_concepts": [],
+        "secondary_concepts": [],
+        "compressed_summary": "",
+        "enclosing_context": None,
+        "methodist_observations": [],
+        "own_documents_count": 0,
+        "own_chars_count": 0,
+        "cumulative_documents_count": 0,
+        "cumulative_chars_count": 0,
+    }
+    defaults.update(overrides)
+    raw = NodeSummaryRaw(**defaults)
+    raw.deleted_at = None
+    return raw
+
+
+def _make_final(**overrides: Any) -> NodeSummaryFinal:
+    """Build a NodeSummaryFinal with sane defaults; override individual fields."""
+    defaults: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "course_node_id": uuid.uuid4(),
+        "title": "Node Title",
+        "description": "Node description",
+        "learning_objectives": [],
+        "knowledge": [],
+        "skills": [],
+        "success_criteria": [],
+        "assessment_approach": "",
+        "teaching_approach": "",
+        "key_activities": [],
+        "common_mistakes": [],
+        "main_concepts": [],
+        "secondary_concepts": [],
+        "enclosing_context": None,
+        "is_manual": False,
+        "manual_description": None,
+        "own_documents_count": 0,
+        "own_chars_count": 0,
+        "cumulative_documents_count": 0,
+        "cumulative_chars_count": 0,
+    }
+    defaults.update(overrides)
+    final = NodeSummaryFinal(**defaults)
+    final.deleted_at = None
+    return final
+
+
+# ── NodeSummaryRaw formula ───────────────────────────────────────
+
+
+class TestNodeSummaryRawFormula:
+    """``NodeSummaryRaw.content_hash`` covers all content fields EXCEPT
+    ``enclosing_context`` (vision §3 KD9). Concept lists are
+    order-independent; other list fields preserve insertion order.
+    """
+
+    async def test_deterministic_across_calls(self) -> None:
+        raw = _make_raw(title="Lesson 1", main_concepts=["loops"])
+        svc = ContentHashService(AsyncMock())
+        first = await svc._compute_hash_for(raw, exclude_ids=None)
+        second = await svc._compute_hash_for(raw, exclude_ids=None)
+        assert first == second
+
+    async def test_enclosing_context_excluded_from_hash(self) -> None:
+        # Phase 3.1 acceptance #4 — the load-bearing invariant.
+        cnid = uuid.uuid4()
+        a = _make_raw(course_node_id=cnid, enclosing_context=None)
+        b = _make_raw(course_node_id=cnid, enclosing_context="ancestor chain context")
+        # Equalize the id so only enclosing_context differs (id is not
+        # part of the hash formula, but kept aligned for clarity).
+        b.id = a.id
+        svc = ContentHashService(AsyncMock())
+        assert await svc._compute_hash_for(
+            a, exclude_ids=None
+        ) == await svc._compute_hash_for(b, exclude_ids=None)
+
+    async def test_main_concepts_order_independence(self) -> None:
+        a = _make_raw(main_concepts=["alpha", "beta", "gamma"])
+        b = _make_raw(main_concepts=["gamma", "alpha", "beta"])
+        b.id = a.id
+        b.course_node_id = a.course_node_id
+        svc = ContentHashService(AsyncMock())
+        assert await svc._compute_hash_for(
+            a, exclude_ids=None
+        ) == await svc._compute_hash_for(b, exclude_ids=None)
+
+    async def test_title_change_flips_hash(self) -> None:
+        a = _make_raw(title="First")
+        b = _make_raw(title="Second")
+        b.id = a.id
+        b.course_node_id = a.course_node_id
+        svc = ContentHashService(AsyncMock())
+        assert await svc._compute_hash_for(
+            a, exclude_ids=None
+        ) != await svc._compute_hash_for(b, exclude_ids=None)
+
+    async def test_methodist_observations_change_flips_hash(self) -> None:
+        # Raw-only field — must contribute to the hash, not be elided.
+        a = _make_raw(methodist_observations=[])
+        b = _make_raw(methodist_observations=["observation one"])
+        b.id = a.id
+        b.course_node_id = a.course_node_id
+        svc = ContentHashService(AsyncMock())
+        assert await svc._compute_hash_for(
+            a, exclude_ids=None
+        ) != await svc._compute_hash_for(b, exclude_ids=None)
+
+    async def test_compressed_summary_change_flips_hash(self) -> None:
+        a = _make_raw(compressed_summary="")
+        b = _make_raw(compressed_summary="summary")
+        b.id = a.id
+        b.course_node_id = a.course_node_id
+        svc = ContentHashService(AsyncMock())
+        assert await svc._compute_hash_for(
+            a, exclude_ids=None
+        ) != await svc._compute_hash_for(b, exclude_ids=None)
+
+
+# ── NodeSummaryFinal formula ──────────────────────────────────────
+
+
+class TestNodeSummaryFinalFormula:
+    """``NodeSummaryFinal.content_hash`` covers all content fields EXCEPT
+    ``enclosing_context`` (vision §3 KD9); ``compressed_summary`` is NOT
+    persisted on Final (vision §267); ``methodist_observations`` is
+    Raw-only. ``is_manual`` and ``manual_description`` are author
+    content and DO contribute to the hash.
+    """
+
+    async def test_deterministic_across_calls(self) -> None:
+        final = _make_final(title="Lesson 1")
+        svc = ContentHashService(AsyncMock())
+        first = await svc._compute_hash_for(final, exclude_ids=None)
+        second = await svc._compute_hash_for(final, exclude_ids=None)
+        assert first == second
+
+    async def test_enclosing_context_excluded_from_hash(self) -> None:
+        # Phase 3.1 acceptance #4 — Final mirror of the Raw invariant.
+        cnid = uuid.uuid4()
+        a = _make_final(course_node_id=cnid, enclosing_context=None)
+        b = _make_final(course_node_id=cnid, enclosing_context="ancestor chain context")
+        b.id = a.id
+        svc = ContentHashService(AsyncMock())
+        assert await svc._compute_hash_for(
+            a, exclude_ids=None
+        ) == await svc._compute_hash_for(b, exclude_ids=None)
+
+    async def test_is_manual_flip_changes_hash(self) -> None:
+        # Author-state flag — toggling it must flip the hash because
+        # it changes the canonical author-content of an empty leaf.
+        a = _make_final(is_manual=False)
+        b = _make_final(is_manual=True)
+        b.id = a.id
+        b.course_node_id = a.course_node_id
+        svc = ContentHashService(AsyncMock())
+        assert await svc._compute_hash_for(
+            a, exclude_ids=None
+        ) != await svc._compute_hash_for(b, exclude_ids=None)
+
+    async def test_manual_description_change_flips_hash(self) -> None:
+        a = _make_final(manual_description=None)
+        b = _make_final(manual_description="hand-written description")
+        b.id = a.id
+        b.course_node_id = a.course_node_id
+        svc = ContentHashService(AsyncMock())
+        assert await svc._compute_hash_for(
+            a, exclude_ids=None
+        ) != await svc._compute_hash_for(b, exclude_ids=None)
+
+
+# ── Hash-graph topology (Q-A) ─────────────────────────────────────
+
+
+class TestNodeSummaryLeafTopology:
+    """NodeSummaryRaw / Final are LEAVES of the content_hash graph
+    (Q-A ratified at Phase 3.1 pre-flight). ``_fetch_parent`` returns
+    ``None`` for both; ``invalidate_up`` recomputes own hash and stops.
+    """
+
+    @pytest.mark.parametrize(
+        "make",
+        [_make_raw, _make_final],
+        ids=["raw", "final"],
+    )
+    async def test_fetch_parent_returns_none(self, make: Any) -> None:
+        entity = make()
+        svc = ContentHashService(AsyncMock())
+        parent = await svc._fetch_parent(entity)
+        assert parent is None

--- a/tests/unit/test_material_node.py
+++ b/tests/unit/test_material_node.py
@@ -48,10 +48,17 @@ class TestCourseNodeModel:
         assert isinstance(pk, uuid.UUID)
         assert pk.version == 7
 
-    def test_content_hash_nullable(self) -> None:
-        """content_hash is nullable (lazy cached)."""
+    def test_content_hash_not_null_with_empty_default(self) -> None:
+        """``content_hash`` is NOT NULL + ``server_default`` = empty-hash.
+
+        Phase 3.1 commit 4 closed the KD9 NULL-at-INSERT regression
+        (vision §3 KD9 "Спостереження Phase 1"). The column carries a
+        defined empty-hash at INSERT — an empty CourseNode never has
+        ``content_hash IS NULL`` at any point in its lifecycle.
+        """
         col = CourseNode.__table__.c.content_hash
-        assert col.nullable is True
+        assert col.nullable is False
+        assert col.server_default is not None
 
     def test_title_max_length(self) -> None:
         """Title column accepts up to 500 chars."""


### PR DESCRIPTION
## Summary

Phase 3.1 — data layer for the methodist tier (vision §3 KD9/KD10/KD11/KD12). Lands ORM models + migrations + content_hash formulas + cascade wiring + acceptance tests. **No generation, no walker for the second hash axis, no API, no ladders, no agents** — those land in Phase 3.2.

Five atomic commits per the pre-flight contract:

- **`b02af48`** — `NodeSummaryRaw` / `NodeSummaryFinal` / `NodeSummaryFinalPreviousSnapshot` ORM models + Alembic migration `phase31_node_summary_tables` (3 tables, UNIQUE on `course_node_id` / `node_summary_final_id`, partial-active indexes, SoftDeleteMixin). content_hash columns left nullable here.
- **`6609543`** — `_compute_hash_for` branches for Raw/Final (exclude `enclosing_context` per KD9 lines 729-730); `_fetch_parent → None` for both (Q-A: leaves of the content_hash graph). Three `Final[str]` constants — `EMPTY_NODE_CONTENT_HASH`, `EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH`, `EMPTY_NODE_SUMMARY_FINAL_CONTENT_HASH` — DERIVED via the same pure helpers (`compute_content_hash` + `_encode_local_fields`), not hardcoded (Q-F: prove via the actual formula).
- **`b539f16`** — Cascade per KD12 + Q-C Option A two-level shape: `CourseNode.__cascades_soft_delete_to__` extends to `[CourseNode, AuthoredDocument, NodeSummaryRaw, NodeSummaryFinal]`; `NodeSummaryFinal.__cascades_soft_delete_to__ = [PreviousSnapshot]` (preserves 1:1 invariant; mirrors AuthoredDocument → DocumentSummary → DocumentSegment). Three scrub callables — markers for top-level str, `[]` for list fields (Q-D), `{}` for the PreviousSnapshot JSONB payload (Q-B).
- **`90c3617`** — Alembic migration `phase31_content_hash_defaults`: SET DEFAULT + SET NOT NULL + backfill on `course_nodes.content_hash` (closes the KD9 NULL-at-INSERT regression); same for `node_summaries_raw.content_hash` and `node_summaries_final.content_hash` (Q-G: structural «defined hash, never NULL» across all three). Python column type kept as `Mapped[str | None]` for `HashableEntity` Protocol invariance; DB-level NOT NULL + server_default makes runtime NULL impossible. Migration uses hardcoded string literals per [[feedback-migration-self-contained-no-app-import]].
- **`1984846`** — Acceptance tests: `test_node_summary_formulas.py` (enclosing-context exclusion + leaf topology), `test_empty_hash_literals.py` (Q-F migration-literal ↔ formula-derived constant parity + distinctness), `test_node_summary_persistence.py` (#3 server_default empty-hash at INSERT, #5 cascade soft-delete with scrub). Three pre-existing tests updated for the new invariants.

### Pre-flight Q-ratify (decided before any code)

| Q | Ratified |
|---|---|
| A | NodeSummary* are leaves; `_fetch_parent → None`; CourseNode formula unchanged |
| B | PreviousSnapshot = SoftDeleteMixin + JSONB scrub `{}` (KD3 table gap fixed vision-side) |
| C | Two-level cascade: PreviousSnapshot via Final, not direct from CourseNode |
| D | `[]` for list fields, marker only for top-level str |
| E | `list[LearningOutcomeItem]` → JSONB `server_default '[]'::jsonb`, Pydantic at app layer |
| F | Empty-hash constants DERIVED through the formula (not assumed); migration literal pinned by test |
| G | All three content_hash columns get NOT NULL + server_default atomically |

### Out of scope (will STOP-escalate if it creeps in)

Generation pipeline, hash-walker for the second axis (`enclosing_context_source_hash` carrier — column lands here, walker in 3.2), `Job.stage_progress` schema, per-pass ladders, third channel write logic on Final, API endpoints (P6 GET), methodist agent, UI.

## Test plan

- [x] `make doctor` PASS (postgres / redis / minio up, alembic head = `phase31_content_hash_defaults`)
- [x] `alembic upgrade head` + `alembic downgrade -1` round-trip clean for both new migrations
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format` clean
- [x] `uv run mypy src/` strict — 0 errors
- [x] `pre-commit run` clean on every commit (per [[feedback-precommit-ruff-not-equal-local-ruff]])
- [x] **Full `uv run pytest --run-db --run-redis`** (rule #9): **2290 passed / 0 failed / 3 skipped** (+44 new tests)
- [x] KD9 NULL-at-INSERT regression verified live: `CourseNode` INSERT now carries `content_hash = e3b0c4…` instead of NULL
- [x] Q-F literal ↔ formula parity asserted by `test_empty_hash_literals.py`
- [x] `git diff --name-only main..HEAD` — only models / migrations / content_hash / cascade / tests; nothing in pipeline/API/ladders/agents
- [ ] Reviewer bot cycle
- [ ] POST-MERGE-NOTES-3-1.md drafted post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)