### PR TITLE
task(3.2.2): two-pass methodist generation orchestrator (skeleton-first)

### DIFF
--- a/migrations/versions/phase322_raw_source_hash.py
+++ b/migrations/versions/phase322_raw_source_hash.py
@@ -1,0 +1,72 @@
+"""Phase 3.2.2 commit 1: NodeSummaryRaw.source_content_hash (bottom-up memo key).
+
+Revision ID: phase322_raw_source_hash
+Revises: phase31_content_hash_defaults
+Create Date: 2026-06-11 00:00:00.000000
+
+Adds the second axis-1 hash linkage column to ``node_summaries_raw`` per
+vision §3 KD10 line 1011 (bottom-up memoization key = the source
+``CourseNode.content_hash`` at the time the Raw was generated, NOT the
+Raw's own self-hash).
+
+Phase 3.1 shipped ``NodeSummaryRaw.content_hash`` as a self-hash over
+own content fields (KD9 line 729). KD10 line 1011 separately requires a
+**source linkage** column to memo-skip Pass 1 LLM calls when the
+source CourseNode has not changed. These two roles are semantically
+distinct and need two columns; this migration adds the second.
+
+Column shape:
+
+* ``String(64)`` — same width as the other SHA-256-hex columns.
+* ``nullable=True`` — written by the Phase 3.2.2 orchestrator only
+  after a successful Pass 1 visit completes (the LLM hook in skeleton
+  3.2.2 is a no-op, but the orchestrator still materialises the value
+  in the post-hook commit so memo-skip works across reruns). NULL is
+  the legitimate "Raw row exists, Pass 1 has not yet completed against
+  any source" state — see Phase 3.2.2 task spec acceptance #3/#6 for
+  why this two-phase write is required.
+* No ``server_default`` — NULL is the meaningful initial state
+  (mirrors ``enclosing_context_source_hash`` from Phase 3.1).
+
+No backfill: ``node_summaries_raw`` is empty in production (no writer
+exists yet; Phase 3.2.2 orchestrator is the first one). Even in
+dev/test environments where the table is empty, no rows need a
+backfilled value — the NULL semantics correctly mean "not yet
+generated".
+
+Self-contained per [[feedback-migration-self-contained-no-app-import]] —
+no app-code imports.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "phase322_raw_source_hash"
+down_revision: str | Sequence[str] | None = "phase31_content_hash_defaults"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``node_summaries_raw.source_content_hash`` (nullable, no default)."""
+    op.add_column(
+        "node_summaries_raw",
+        sa.Column(
+            "source_content_hash",
+            sa.String(length=64),
+            nullable=True,
+            comment=(
+                "CourseNode.content_hash at the time Pass 1 last completed — "
+                "bottom-up memo key (vision §3 KD10 line 1011). NULL until "
+                "first Pass 1 lands; written by the Phase 3.2.2 orchestrator "
+                "after the LLM hook commits per-node."
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the column. Replay-safe: prior schema had no such column."""
+    op.drop_column("node_summaries_raw", "source_content_hash")

--- a/src/course_supporter/storage/job_repository.py
+++ b/src/course_supporter/storage/job_repository.py
@@ -181,6 +181,36 @@ class JobRepository:
                 stage_name=stage_name,
             )
 
+    async def update_stage_progress(
+        self, job_id: uuid.UUID, payload: dict[str, Any]
+    ) -> None:
+        """Full-replace ``Job.stage_progress`` JSONB (KD13 checkpoint).
+
+        Atomic UPDATE filtered through ``Job.deleted_at IS NULL`` (same
+        contract as :meth:`update_stage`). Silent skip on missing /
+        soft-deleted row + warn-log for observability.
+
+        **Full-replace is safe only because callers are strictly
+        sequential** (Phase 3.2.2 visits await one another; no
+        ``asyncio.gather`` over visits). Parallel visits would need
+        JSON-merge instead of replace — a separate design decision,
+        not a refactor. Any future temptation to fan-out node visits
+        must surface as STOP-escalate first (K3 ratify, Phase 3.2.2
+        commit 2).
+        """
+        stmt = (
+            update(Job)
+            .where(Job.id == job_id, Job.deleted_at.is_(None))
+            .values(stage_progress=payload)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        if (result.rowcount or 0) == 0:  # type: ignore[attr-defined]
+            logger.warning(
+                "update_stage_progress_no_job_found",
+                job_id=str(job_id),
+            )
+
     async def reactivate(self, job_id: uuid.UUID) -> Job:
         """Re-queue a failed Job for retry (vision §3 KD13).
 

--- a/src/course_supporter/storage/node_summary_orchestrator.py
+++ b/src/course_supporter/storage/node_summary_orchestrator.py
@@ -31,6 +31,7 @@ from datetime import UTC, datetime
 from typing import Protocol
 
 import structlog
+from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -45,7 +46,7 @@ from course_supporter.storage.node_summary_run_state import (
     NodeSummaryRunScope,
     NodeSummaryRunState,
 )
-from course_supporter.storage.orm import CourseNode, NodeSummaryRaw
+from course_supporter.storage.orm import CourseNode, Job, NodeSummaryRaw
 
 logger = structlog.get_logger(__name__)
 
@@ -321,6 +322,15 @@ class NodeSummaryGenerationOrchestrator:
             msg = f"run: vertex CourseNode {vertex_node_id} not found or soft-deleted"
             raise ValueError(msg)
 
+        # Preserve cross-run errors[] per Q-4 contract (commit-1: ``errors``
+        # is append-only ACROSS runs so resume sees the full attempt history).
+        # Tolerant per-entry parse on read-back: ``extra='forbid'`` on the
+        # top-level NodeSummaryRunState would refuse a future-version JSON
+        # outright; per-entry ``NodeSummaryRunError.model_validate`` only
+        # drops the offending entry (logged) and keeps the rest. This makes
+        # forward-schema additions on the top-level safe for the resume path.
+        preserved_errors = await self._read_back_preserved_errors(job_id)
+
         job_repo = JobRepository(self._session)
         await job_repo.update_stage(job_id, "bottomup")
 
@@ -332,6 +342,7 @@ class NodeSummaryGenerationOrchestrator:
             pass1={
                 nid: NodeSummaryNodeStatus.PENDING for nid in scope.in_scope_node_ids
             },
+            errors=preserved_errors,
         )
         await self._persist_run_state(job_id, run_state)
         await self._session.commit()
@@ -809,3 +820,31 @@ class NodeSummaryGenerationOrchestrator:
         """Full-replace ``Job.stage_progress`` from ``run_state`` (K3 contract)."""
         job_repo = JobRepository(self._session)
         await job_repo.update_stage_progress(job_id, run_state.to_jsonb())
+
+    async def _read_back_preserved_errors(
+        self, job_id: uuid.UUID
+    ) -> list[NodeSummaryRunError]:
+        """Read ``errors[]`` from existing ``stage_progress`` (Q-4 cross-run).
+
+        Tolerant per-entry parse: bad entries are logged + skipped, good
+        entries are preserved. NULL stage_progress / missing ``errors``
+        key / non-list shape → empty list. Schema drift on the top-level
+        does NOT lose the history (we never call ``from_jsonb`` on the
+        outer envelope here).
+        """
+        existing_job = await self._session.get(Job, job_id)
+        if existing_job is None or not isinstance(existing_job.stage_progress, dict):
+            return []
+        raw_errors = existing_job.stage_progress.get("errors", [])
+        if not isinstance(raw_errors, list):
+            return []
+        preserved: list[NodeSummaryRunError] = []
+        for entry in raw_errors:
+            try:
+                preserved.append(NodeSummaryRunError.model_validate(entry))
+            except ValidationError:
+                logger.warning(
+                    "node_summary_run_state_error_entry_skipped",
+                    job_id=str(job_id),
+                )
+        return preserved

--- a/src/course_supporter/storage/node_summary_orchestrator.py
+++ b/src/course_supporter/storage/node_summary_orchestrator.py
@@ -51,6 +51,15 @@ from course_supporter.storage.orm import CourseNode, Job, NodeSummaryRaw
 logger = structlog.get_logger(__name__)
 
 
+# Defensive cap on the course-tree walk-up depth in ``_collect_course_nodes``.
+# Real courses are shallow (a handful of levels); the cap exists to surface
+# accidentally-introduced cycles in future schema changes rather than to bound
+# legitimate work. Mirrors ``_MAX_WALK_DEPTH`` in ``storage/content_hash.py``
+# (same defensive intent, separate concern: content_hash walks the hash chain;
+# this walks the CourseNode parent chain).
+_MAX_COURSE_DEPTH = 25
+
+
 class Pass2ParentRawMissingError(RuntimeError):
     """Pass 2 None-contract violation: non-root node lost its parent Raw.
 
@@ -391,7 +400,7 @@ class NodeSummaryGenerationOrchestrator:
         """Load every active CourseNode in the course containing ``vertex``."""
         root = vertex
         depth = 0
-        while root.parent_id is not None and depth < 25:
+        while root.parent_id is not None and depth < _MAX_COURSE_DEPTH:
             parent = await self._session.get(CourseNode, root.parent_id)
             if parent is None or parent.deleted_at is not None:
                 break
@@ -413,7 +422,12 @@ class NodeSummaryGenerationOrchestrator:
     def _collect_subtree_ids(
         vertex_id: uuid.UUID, course_nodes: dict[uuid.UUID, CourseNode]
     ) -> set[uuid.UUID]:
-        """BFS-collect IDs under ``vertex_id`` using in-memory parent map."""
+        """Set-collect IDs under ``vertex_id`` using in-memory parent map.
+
+        Iterative DFS with ``list.pop()`` (LIFO, O(1) from end). Returns
+        a set; traversal order is irrelevant to the caller — the only
+        invariant is "every descendant in the active tree is included".
+        """
         children_by_parent: dict[uuid.UUID, list[uuid.UUID]] = {}
         for node_id, node in course_nodes.items():
             if node.parent_id is not None:

--- a/src/course_supporter/storage/node_summary_orchestrator.py
+++ b/src/course_supporter/storage/node_summary_orchestrator.py
@@ -9,11 +9,10 @@ implementation lets the skeleton walk a synthetic subtree end-to-end
 without any model calls; Phase 3.2.3 wires the real methodist agent
 against the same protocol.
 
-This module is **commit 1** of the four-commit Phase 3.2.2 plan: scope-
-validation + run-state shape only. ``ensure_raw`` / ``visit_pass1`` /
-``visit_pass2`` / ``run`` land in subsequent commits and raise
-``NotImplementedError`` here so the import surface is stable but
-incomplete execution is loud.
+Commits 1+2 ship scope-validation, run-state shape, and the full
+Pass 1 leg (ensure-Raw, memo-skip, hook, source-hash materialise,
+per-node COMMIT). ``visit_pass2`` and the Pass 2 leg of :meth:`run`
+land in commit 3 and currently raise ``NotImplementedError``.
 
 Boundary recap (Q-5 ratify): the worker entry, ARQ task function,
 ``enqueue_node_summary_regeneration`` helper, and HTTP trigger all live
@@ -25,16 +24,24 @@ in Phase 3.2.4. The orchestrator's entry point is the plain Python
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 from typing import Protocol
 
 import structlog
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from course_supporter.storage.enclosing_context_hash import (
     EnclosingContextHashService,
 )
-from course_supporter.storage.node_summary_run_state import NodeSummaryRunScope
+from course_supporter.storage.job_repository import JobRepository
+from course_supporter.storage.node_summary_run_state import (
+    NodeSummaryNodeStatus,
+    NodeSummaryRunError,
+    NodeSummaryRunScope,
+    NodeSummaryRunState,
+)
 from course_supporter.storage.orm import CourseNode, NodeSummaryRaw
 
 logger = structlog.get_logger(__name__)
@@ -121,9 +128,9 @@ class NodeSummaryGenerationOrchestrator:
     orchestrator does NOT create Job rows, enqueue ARQ tasks, or
     speak HTTP — Phase 3.2.4 owns all of that.
 
-    Skeleton commit 1 ships only :meth:`validate_scope`; ensure-Raw
-    + Pass 1 + Pass 2 + :meth:`run` land in subsequent commits of
-    the same task.
+    Commit 2 ships scope-validation + Pass 1 leg (ensure-Raw +
+    memo-skip + no-op hook + source-hash materialise + per-node
+    COMMIT). Pass 2 leg + None-contract enforcement land in commit 3.
     """
 
     def __init__(
@@ -208,13 +215,54 @@ class NodeSummaryGenerationOrchestrator:
         vertex_node_id: uuid.UUID,
         force: bool = False,
     ) -> None:
-        """Orchestrate Pass 1 + Pass 2 on the existing ``Job`` row.
+        """Orchestrate Pass 1 (Pass 2 lands in commit 3) on an existing Job row.
 
-        Lands in commits 2-3 of Phase 3.2.2.
+        Commit-2 scope:
+
+        1. ``Job.current_stage='bottomup'``.
+        2. ``validate_scope`` → record into ``run_state.scope``.
+        3. Seed ``run_state.pass1[node]=pending`` for every in-scope node;
+           persist + commit (so resume sees the initial scope even if
+           a crash happens before the first visit lands).
+        4. Walk in-scope leaf→root order; for each node call
+           :meth:`_visit_pass1` (per-node atomic transaction:
+           ensure-Raw → memo-skip OR hook → source-hash → status → commit).
+
+        ``force`` is informational here per K1 ratify (memo-skip is
+        unconditional; force only changes the API's 422 decision,
+        recorded into run-state for resume diagnostics).
         """
-        del job_id, vertex_node_id, force
-        msg = "run() lands in Phase 3.2.2 commits 2-3 (Pass 1 + Pass 2 visits)"
-        raise NotImplementedError(msg)
+        vertex = await self._session.get(CourseNode, vertex_node_id)
+        if vertex is None or vertex.deleted_at is not None:
+            msg = f"run: vertex CourseNode {vertex_node_id} not found or soft-deleted"
+            raise ValueError(msg)
+
+        job_repo = JobRepository(self._session)
+        await job_repo.update_stage(job_id, "bottomup")
+
+        scope = await self.validate_scope(vertex_node_id, force)
+        run_state = NodeSummaryRunState(
+            vertex_node_id=vertex_node_id,
+            force=force,
+            scope=scope,
+            pass1={
+                nid: NodeSummaryNodeStatus.PENDING for nid in scope.in_scope_node_ids
+            },
+        )
+        await self._persist_run_state(job_id, run_state)
+        await self._session.commit()
+
+        course_nodes = await self._collect_course_nodes(vertex)
+        order = self._compute_leaf_to_root_order(
+            vertex_node_id,
+            set(scope.in_scope_node_ids),
+            course_nodes,
+        )
+        for nid in order:
+            # K3 ratify: visits are STRICTLY sequential. Full-replace JSON
+            # on Job.stage_progress is safe only because no two visits
+            # race. Any future asyncio.gather over this loop = STOP-escalate.
+            await self._visit_pass1(course_nodes[nid], run_state, job_id)
 
     # ─── helpers (private) ────────────────────────
 
@@ -280,11 +328,193 @@ class NodeSummaryGenerationOrchestrator:
     async def _is_node_stale(
         self, node: CourseNode, raw: NodeSummaryRaw | None
     ) -> bool:
-        """Two-axis staleness check (vision §3 KD10 line 975)."""
-        if raw is None:
+        """Two-axis staleness check (vision §3 KD10 line 975).
+
+        Axis-1 negation delegates to :meth:`_is_axis1_fresh` so the
+        memo-skip predicate in :meth:`_visit_pass1` and the scope-
+        validation predicate here share one formula (single source of
+        truth — no risk of the two drifting on a future tweak).
+        """
+        if not self._is_axis1_fresh(node, raw):
             return True
-        if raw.source_content_hash != node.content_hash:
-            return True
+        # Past the early return, raw is non-None and axis-1 fresh.
         if node.parent_id is None:
             return False
+        assert raw is not None
         return await self._encl_hash.is_stale(raw)
+
+    @staticmethod
+    def _is_axis1_fresh(node: CourseNode, raw: NodeSummaryRaw | None) -> bool:
+        """Axis-1 (``content_hash`` linkage) freshness — KD10 line 1011.
+
+        Shared by :meth:`_is_node_stale` (scope-validation) and
+        :meth:`_visit_pass1` (memo-skip). Both read the same column
+        with the same comparator; centralising the formula eliminates
+        the drift risk between the two call-sites.
+        """
+        return raw is not None and raw.source_content_hash == node.content_hash
+
+    async def _ensure_raw(self, course_node_id: uuid.UUID) -> NodeSummaryRaw:
+        """Idempotent ensure-Raw — race-free at the DB level.
+
+        Uses ``INSERT ... ON CONFLICT (course_node_id) DO NOTHING`` via
+        the PG dialect so a parallel orchestrator (e.g. two operators
+        re-running on overlapping subtrees) cannot collide on the
+        ``UNIQUE`` constraint mid-flight. ``source_content_hash`` stays
+        NULL on insert — only :meth:`_visit_pass1` materialises it
+        (after the LLM hook commits per-node, even when the hook is the
+        no-op default in skeleton 3.2.2).
+
+        Returns the live Raw row (newly inserted or pre-existing).
+        Structural fields land at their server-side defaults (empty
+        strings / ``'[]'::jsonb`` / zero counters / empty-hash literal
+        on ``content_hash``). Canonical content fields stay at their
+        defaults until the LLM hook populates them in commit-2/3 +
+        Phase 3.2.3.
+        """
+        stmt = (
+            pg_insert(NodeSummaryRaw)
+            .values(course_node_id=course_node_id)
+            .on_conflict_do_nothing(index_elements=["course_node_id"])
+        )
+        await self._session.execute(stmt)
+        await self._session.flush()
+        result = await self._session.execute(
+            select(NodeSummaryRaw).where(
+                NodeSummaryRaw.course_node_id == course_node_id,
+                NodeSummaryRaw.deleted_at.is_(None),
+            )
+        )
+        raw = result.scalar_one_or_none()
+        if raw is None:  # pragma: no cover — implies cascade soft-delete race
+            msg = (
+                f"_ensure_raw: NodeSummaryRaw for course_node {course_node_id} "
+                f"is missing after INSERT — likely a concurrent cascade "
+                f"soft-delete on the parent CourseNode"
+            )
+            raise RuntimeError(msg)
+        return raw
+
+    @staticmethod
+    def _compute_leaf_to_root_order(
+        vertex_id: uuid.UUID,
+        in_scope_ids: set[uuid.UUID],
+        course_nodes: dict[uuid.UUID, CourseNode],
+    ) -> list[uuid.UUID]:
+        """Post-order DFS from ``vertex_id`` over in-scope children.
+
+        Iterative implementation (explicit stack of ``(node_id, processed)``
+        tuples) to keep the recursion-depth ceiling on the Python stack
+        out of the picture for pathologically deep courses. Course trees
+        are shallow in practice (<10 levels), but the post-order DFS
+        guarantee — every child emitted before its parent — is the
+        correctness condition for the bottom-up pass (KD10 line 1024:
+        children must be committed before the parent's visit starts).
+        """
+        children_by_parent: dict[uuid.UUID, list[uuid.UUID]] = {}
+        for node_id in in_scope_ids:
+            parent_id = course_nodes[node_id].parent_id
+            if parent_id is not None and parent_id in in_scope_ids:
+                children_by_parent.setdefault(parent_id, []).append(node_id)
+
+        order: list[uuid.UUID] = []
+        stack: list[tuple[uuid.UUID, bool]] = [(vertex_id, False)]
+        seen: set[uuid.UUID] = set()
+        while stack:
+            node_id, processed = stack.pop()
+            if processed:
+                order.append(node_id)
+                continue
+            if node_id in seen:
+                continue
+            seen.add(node_id)
+            stack.append((node_id, True))
+            for child_id in children_by_parent.get(node_id, []):
+                stack.append((child_id, False))
+        return order
+
+    async def _visit_pass1(
+        self,
+        node: CourseNode,
+        run_state: NodeSummaryRunState,
+        job_id: uuid.UUID,
+    ) -> None:
+        """Per-node Pass 1 visit — atomic transaction (KD10 commit-per-node).
+
+        Sequence within the single transaction:
+
+        1. ensure-Raw (idempotent INSERT ON CONFLICT DO NOTHING).
+        2. fetch the live Raw row.
+        3. memo-skip check (:meth:`_is_axis1_fresh`) — **unconditional**
+           per K1 ratify; ``force`` does not regenerate axis-1-fresh
+           nodes (force only widens scope at validate-time / API-time).
+        4. invoke ``MethodistGenerator.generate_bottomup`` (no-op default
+           in skeleton; Phase 3.2.3 fills it in).
+        5. materialise ``raw.source_content_hash := node.content_hash``
+           **after** the hook returns (even when the hook is no-op).
+        6. record status in ``run_state.pass1[node.id]``.
+        7. persist run-state + ``await self._session.commit()``.
+
+        Error contract (K2 ratify): an exception inside the hook is
+        recorded into ``run_state.errors[]`` + ``pass1[node]=error`` and
+        committed; the walk **does not abort**. The default no-op hook
+        cannot raise; this branch protects future Phase 3.2.3 LLM hooks
+        + lets resume diagnostics see the full history. An error on a
+        child leaves the parent with incomplete bottom-up input — the
+        downstream propagation policy (whether the parent should still
+        attempt generation, mark itself blocked, etc.) is **not**
+        decided here; operators inspect errors[] after the run.
+        """
+        await self._ensure_raw(node.id)
+        raw = await self._fetch_raw_for_node(node.id)
+        if raw is None:  # pragma: no cover — _ensure_raw guarantees presence
+            msg = f"_visit_pass1: Raw row vanished between ensure and fetch ({node.id})"
+            raise RuntimeError(msg)
+
+        if self._is_axis1_fresh(node, raw):
+            run_state.pass1[node.id] = NodeSummaryNodeStatus.SKIPPED_MEMO
+            run_state.updated_at = datetime.now(UTC)
+            await self._persist_run_state(job_id, run_state)
+            await self._session.commit()
+            return
+
+        try:
+            await self._methodist.generate_bottomup(node, raw)
+        except Exception as exc:
+            run_state.errors.append(
+                NodeSummaryRunError(
+                    node_id=node.id,
+                    stage="bottomup",
+                    reason=str(exc),
+                )
+            )
+            run_state.pass1[node.id] = NodeSummaryNodeStatus.ERROR
+            run_state.updated_at = datetime.now(UTC)
+            await self._persist_run_state(job_id, run_state)
+            await self._session.commit()
+            return
+
+        raw.source_content_hash = node.content_hash
+        run_state.pass1[node.id] = NodeSummaryNodeStatus.DONE
+        run_state.updated_at = datetime.now(UTC)
+        await self._persist_run_state(job_id, run_state)
+        await self._session.commit()
+
+    async def _fetch_raw_for_node(
+        self, course_node_id: uuid.UUID
+    ) -> NodeSummaryRaw | None:
+        """Load the active Raw row for a single CourseNode (1:1)."""
+        result = await self._session.execute(
+            select(NodeSummaryRaw).where(
+                NodeSummaryRaw.course_node_id == course_node_id,
+                NodeSummaryRaw.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def _persist_run_state(
+        self, job_id: uuid.UUID, run_state: NodeSummaryRunState
+    ) -> None:
+        """Full-replace ``Job.stage_progress`` from ``run_state`` (K3 contract)."""
+        job_repo = JobRepository(self._session)
+        await job_repo.update_stage_progress(job_id, run_state.to_jsonb())

--- a/src/course_supporter/storage/node_summary_orchestrator.py
+++ b/src/course_supporter/storage/node_summary_orchestrator.py
@@ -9,10 +9,13 @@ implementation lets the skeleton walk a synthetic subtree end-to-end
 without any model calls; Phase 3.2.3 wires the real methodist agent
 against the same protocol.
 
-Commits 1+2 ship scope-validation, run-state shape, and the full
-Pass 1 leg (ensure-Raw, memo-skip, hook, source-hash materialise,
-per-node COMMIT). ``visit_pass2`` and the Pass 2 leg of :meth:`run`
-land in commit 3 and currently raise ``NotImplementedError``.
+Commits 1-3 ship scope-validation, run-state shape, the Pass 1 leg
+(ensure-Raw, memo-skip, hook, source-hash materialise, per-node
+COMMIT), and the Pass 2 leg (root-of-course exemption, parent-Raw
+resolution with None-contract enforcement, composite-key memoization
+via Phase 3.2.1, ``enclosing_context_source_hash`` materialise).
+Commit 4 adds the full crash-resume integration coverage on top of
+the per-node COMMIT atomicity already enforced here.
 
 Boundary recap (Q-5 ratify): the worker entry, ARQ task function,
 ``enqueue_node_summary_regeneration`` helper, and HTTP trigger all live
@@ -45,6 +48,79 @@ from course_supporter.storage.node_summary_run_state import (
 from course_supporter.storage.orm import CourseNode, NodeSummaryRaw
 
 logger = structlog.get_logger(__name__)
+
+
+class Pass2ParentRawMissingError(RuntimeError):
+    """Pass 2 None-contract violation: non-root node lost its parent Raw.
+
+    Vision §3 KD10 + the 3.2.1 service ``_fetch_parent_raw`` collapses
+    three semantically different "parent Raw absent" cases into a
+    single ``None`` return value (root / missing CourseNode / missing
+    parent Raw). The orchestrator excludes the root case BEFORE asking
+    (Pass 2 short-circuits on ``node.parent_id IS NULL`` →
+    :attr:`NodeSummaryNodeStatus.NOT_APPLICABLE`), so a ``None`` from
+    parent-Raw lookup at this point is **always** an invariant
+    violation — fail loud per K2-analog for axis 2.
+
+    Discrimination (Phase 3.2.2 commit 3): three orthogonal sub-cases,
+    pinned to inline diagnostics via the two boolean discriminators:
+
+    * **A1 — ordering violation (in-scope parent without Raw):**
+      ``parent_course_node_present=True`` and ``parent_in_scope=True``.
+      Pass 1 was supposed to ensure-Raw before Pass 2 touched a
+      child. Implies a Pass 1 visit error on the parent (also in
+      ``errors[]``) — operator inspects both and decides whether to
+      reactivate.
+
+    * **A2 — uncovered-stale bypassed by ``force``:**
+      ``parent_course_node_present=True`` and ``parent_in_scope=False``.
+      Vertex is not the course root and its parent (outside scope) has
+      no Raw — ``validate_scope`` flagged this as ``uncovered_stale``;
+      the user ran with ``force=True``. Expected when force is used
+      with a small vertex.
+
+    * **B — missing parent CourseNode:**
+      ``parent_course_node_present=False``. The parent CourseNode is
+      not in the orchestrator's in-memory course tree, either because
+      a cascade soft-delete fired between scope-validation and the
+      Pass 2 visit, or because ``node.parent_id`` points at a deleted
+      / nonexistent CourseNode (structural inconsistency).
+
+    Caught by :meth:`NodeSummaryGenerationOrchestrator._visit_pass2`;
+    recorded into ``run_state.errors[]`` + ``pass2[node]=ERROR``; the
+    walk **continues** (K2 contract). ``update_source_hash(None)`` is
+    NEVER called (which would corrupt the second-axis cache).
+    """
+
+    def __init__(
+        self,
+        *,
+        node_id: uuid.UUID,
+        parent_course_node_id: uuid.UUID,
+        parent_course_node_present: bool,
+        parent_in_scope: bool,
+    ) -> None:
+        self.node_id = node_id
+        self.parent_course_node_id = parent_course_node_id
+        self.parent_course_node_present = parent_course_node_present
+        self.parent_in_scope = parent_in_scope
+
+        if not parent_course_node_present:
+            sub_case = (
+                "B (missing parent CourseNode — soft-delete race or "
+                "structural inconsistency)"
+            )
+        elif parent_in_scope:
+            sub_case = "A1 (in-scope parent without Raw — Pass 1 ordering violation)"
+        else:
+            sub_case = (
+                "A2 (out-of-scope parent without Raw — uncovered_stale "
+                "bypassed by force=True)"
+            )
+        super().__init__(
+            f"Pass 2 None-contract violation on node {node_id}: {sub_case} "
+            f"(parent_course_node_id={parent_course_node_id})"
+        )
 
 
 class MethodistGenerator(Protocol):
@@ -128,9 +204,12 @@ class NodeSummaryGenerationOrchestrator:
     orchestrator does NOT create Job rows, enqueue ARQ tasks, or
     speak HTTP — Phase 3.2.4 owns all of that.
 
-    Commit 2 ships scope-validation + Pass 1 leg (ensure-Raw +
-    memo-skip + no-op hook + source-hash materialise + per-node
-    COMMIT). Pass 2 leg + None-contract enforcement land in commit 3.
+    Commit 3 ships the Pass 2 leg in addition to Pass 1 + scope
+    validation: root-of-course → ``NOT_APPLICABLE`` short-circuit,
+    parent-Raw resolution with None-contract enforcement
+    (:class:`Pass2ParentRawMissingError`), composite-key memoization
+    via the Phase 3.2.1 service, and per-node materialisation of
+    ``enclosing_context_source_hash`` after the (no-op default) hook.
     """
 
     def __init__(
@@ -217,20 +296,25 @@ class NodeSummaryGenerationOrchestrator:
     ) -> None:
         """Orchestrate Pass 1 (Pass 2 lands in commit 3) on an existing Job row.
 
-        Commit-2 scope:
+        Commits 2+3 scope:
 
-        1. ``Job.current_stage='bottomup'``.
-        2. ``validate_scope`` → record into ``run_state.scope``.
-        3. Seed ``run_state.pass1[node]=pending`` for every in-scope node;
-           persist + commit (so resume sees the initial scope even if
-           a crash happens before the first visit lands).
-        4. Walk in-scope leaf→root order; for each node call
-           :meth:`_visit_pass1` (per-node atomic transaction:
-           ensure-Raw → memo-skip OR hook → source-hash → status → commit).
+        1. ``Job.current_stage='bottomup'`` + ``validate_scope`` +
+           seed ``pass1`` PENDING + commit.
+        2. Walk in-scope **leaf→root** for Pass 1
+           (:meth:`_visit_pass1` — ensure-Raw / memo-skip / hook /
+           materialise source_content_hash / per-node COMMIT).
+        3. ``Job.current_stage='topdown'`` + seed ``pass2`` PENDING +
+           commit.
+        4. Walk in-scope **root→leaves** for Pass 2
+           (:meth:`_visit_pass2` — root-of-course →
+           ``NOT_APPLICABLE``; non-root → fetch parent_raw with
+           None-contract enforcement, composite-key memo, hook,
+           materialise ``enclosing_context_source_hash`` via the
+           3.2.1 service, per-node COMMIT).
 
         ``force`` is informational here per K1 ratify (memo-skip is
-        unconditional; force only changes the API's 422 decision,
-        recorded into run-state for resume diagnostics).
+        unconditional on both axes; force only changes the API's 422
+        decision and is recorded into run-state for diagnostics).
         """
         vertex = await self._session.get(CourseNode, vertex_node_id)
         if vertex is None or vertex.deleted_at is not None:
@@ -253,16 +337,40 @@ class NodeSummaryGenerationOrchestrator:
         await self._session.commit()
 
         course_nodes = await self._collect_course_nodes(vertex)
-        order = self._compute_leaf_to_root_order(
+        in_scope_set = set(scope.in_scope_node_ids)
+        pass1_order = self._compute_leaf_to_root_order(
             vertex_node_id,
-            set(scope.in_scope_node_ids),
+            in_scope_set,
             course_nodes,
         )
-        for nid in order:
+        for nid in pass1_order:
             # K3 ratify: visits are STRICTLY sequential. Full-replace JSON
             # on Job.stage_progress is safe only because no two visits
             # race. Any future asyncio.gather over this loop = STOP-escalate.
             await self._visit_pass1(course_nodes[nid], run_state, job_id)
+
+        # ── Pass 2 leg (commit 3) ──────────────────
+        await job_repo.update_stage(job_id, "topdown")
+        for nid in in_scope_set:
+            run_state.pass2[nid] = NodeSummaryNodeStatus.PENDING
+        run_state.updated_at = datetime.now(UTC)
+        await self._persist_run_state(job_id, run_state)
+        await self._session.commit()
+
+        pass2_order = self._compute_root_to_leaf_order(
+            vertex_node_id,
+            in_scope_set,
+            course_nodes,
+        )
+        for nid in pass2_order:
+            # Same K3 sequential-only invariant as Pass 1.
+            await self._visit_pass2(
+                course_nodes[nid],
+                run_state,
+                job_id,
+                course_nodes=course_nodes,
+                in_scope_ids=in_scope_set,
+            )
 
     # ─── helpers (private) ────────────────────────
 
@@ -433,6 +541,42 @@ class NodeSummaryGenerationOrchestrator:
                 stack.append((child_id, False))
         return order
 
+    @staticmethod
+    def _compute_root_to_leaf_order(
+        vertex_id: uuid.UUID,
+        in_scope_ids: set[uuid.UUID],
+        course_nodes: dict[uuid.UUID, CourseNode],
+    ) -> list[uuid.UUID]:
+        """Pre-order DFS from ``vertex_id`` over in-scope children.
+
+        Mirror of :meth:`_compute_leaf_to_root_order` but emits the
+        parent **before** its children — the correctness condition for
+        the top-down Pass 2 (KD10 line 989: parents must materialise
+        their ``enclosing_context`` before children read it for their
+        own second-axis key). Iterative for the same depth-ceiling
+        reason as the bottom-up sibling; children are pushed reversed
+        so the pop order matches their natural insertion order.
+        """
+        children_by_parent: dict[uuid.UUID, list[uuid.UUID]] = {}
+        for node_id in in_scope_ids:
+            parent_id = course_nodes[node_id].parent_id
+            if parent_id is not None and parent_id in in_scope_ids:
+                children_by_parent.setdefault(parent_id, []).append(node_id)
+
+        order: list[uuid.UUID] = []
+        stack: list[uuid.UUID] = [vertex_id]
+        seen: set[uuid.UUID] = set()
+        while stack:
+            node_id = stack.pop()
+            if node_id in seen:
+                continue
+            seen.add(node_id)
+            order.append(node_id)
+            # Reverse so the natural-order child is popped first.
+            for child_id in reversed(children_by_parent.get(node_id, [])):
+                stack.append(child_id)
+        return order
+
     async def _visit_pass1(
         self,
         node: CourseNode,
@@ -496,6 +640,153 @@ class NodeSummaryGenerationOrchestrator:
 
         raw.source_content_hash = node.content_hash
         run_state.pass1[node.id] = NodeSummaryNodeStatus.DONE
+        run_state.updated_at = datetime.now(UTC)
+        await self._persist_run_state(job_id, run_state)
+        await self._session.commit()
+
+    async def _visit_pass2(
+        self,
+        node: CourseNode,
+        run_state: NodeSummaryRunState,
+        job_id: uuid.UUID,
+        *,
+        course_nodes: dict[uuid.UUID, CourseNode],
+        in_scope_ids: set[uuid.UUID],
+    ) -> None:
+        """Per-node Pass 2 visit — atomic transaction (KD10 commit-per-node).
+
+        Sequence within the single transaction:
+
+        1. Course-root short-circuit: ``node.parent_id IS NULL`` →
+           ``pass2[node]=NOT_APPLICABLE`` + commit; return. This is the
+           **structural** Pass 2 exemption from KD10 line 1001 — applies
+           only to the course root (not to the run's vertex when the
+           vertex is an inner node, which is processed normally with
+           its out-of-scope parent's Raw).
+        2. Fetch own Raw (created by Pass 1). If missing → error path
+           (Pass 1 prerequisite violation).
+        3. Fetch parent Raw via direct lookup. ``None`` triggers
+           :class:`Pass2ParentRawMissingError` with the A1/A2/B
+           discrimination via in-memory ``course_nodes`` +
+           ``in_scope_ids`` (Q-3b ratify); caught locally, recorded
+           into ``run_state.errors[]`` + ``pass2[node]=ERROR``,
+           ``update_source_hash(None)`` is NEVER called.
+        4. Composite-key memo check via 3.2.1
+           ``compute_source_hash_for(raw)``; equal to stored
+           ``raw.enclosing_context_source_hash`` → ``SKIPPED_MEMO`` +
+           commit; return. **Pass 2 skeleton does not write
+           ``Final.enclosing_context_updated_at``** — the third
+           channel that touches that timestamp lives in Phase 3.2.4
+           (KD11 lines 1060-1066); acceptance #7 is closed
+           by-construction here.
+        5. Invoke ``MethodistGenerator.generate_topdown(node, raw,
+           parent_raw)`` (no-op default in skeleton; Phase 3.2.3 fills
+           it in). ``parent_raw`` is guaranteed non-None at this point
+           by the discriminator above.
+        6. Materialise ``raw.enclosing_context_source_hash`` via the
+           3.2.1 service ``update_source_hash`` (mirror Pass 1 timing —
+           write after the hook returns, even when the hook is no-op).
+        7. ``DONE`` status + persist + commit.
+
+        Error contract (K2 dual): same as Pass 1. Per-node error
+        records into ``errors[]`` + ``pass2[node]=ERROR``, the walk
+        continues. A child's Pass 2 visit may then see its parent in
+        ERROR state (parent's enclosing_context unchanged from its
+        previous value — possibly NULL on first ever run); skeleton's
+        deterministic-key formula keeps the child's hash stable across
+        runs in that case (parent.enclosing_context coalesces to "" in
+        the 3.2.1 service).
+        """
+        # Step 1 — course-root structural exemption.
+        if node.parent_id is None:
+            run_state.pass2[node.id] = NodeSummaryNodeStatus.NOT_APPLICABLE
+            run_state.updated_at = datetime.now(UTC)
+            await self._persist_run_state(job_id, run_state)
+            await self._session.commit()
+            return
+
+        # Step 2 — own Raw must exist (Pass 1 ensure-Raw).
+        raw = await self._fetch_raw_for_node(node.id)
+        if raw is None:
+            run_state.errors.append(
+                NodeSummaryRunError(
+                    node_id=node.id,
+                    stage="topdown",
+                    reason=(
+                        "Pass 2 prerequisite: own NodeSummaryRaw row is missing "
+                        "(Pass 1 must run successfully before Pass 2 visits a node)"
+                    ),
+                )
+            )
+            run_state.pass2[node.id] = NodeSummaryNodeStatus.ERROR
+            run_state.updated_at = datetime.now(UTC)
+            await self._persist_run_state(job_id, run_state)
+            await self._session.commit()
+            return
+
+        # Step 3 — fetch parent Raw with None-contract discrimination.
+        parent_course_node_id = node.parent_id
+        parent_raw = await self._fetch_raw_for_node(parent_course_node_id)
+        if parent_raw is None:
+            parent_present = parent_course_node_id in course_nodes
+            parent_in_scope = parent_present and parent_course_node_id in in_scope_ids
+            exc = Pass2ParentRawMissingError(
+                node_id=node.id,
+                parent_course_node_id=parent_course_node_id,
+                parent_course_node_present=parent_present,
+                parent_in_scope=parent_in_scope,
+            )
+            run_state.errors.append(
+                NodeSummaryRunError(
+                    node_id=node.id,
+                    stage="topdown",
+                    reason=str(exc),
+                )
+            )
+            run_state.pass2[node.id] = NodeSummaryNodeStatus.ERROR
+            run_state.updated_at = datetime.now(UTC)
+            await self._persist_run_state(job_id, run_state)
+            await self._session.commit()
+            return
+
+        # Step 4 — composite-key memo via 3.2.1.
+        computed_hash = await self._encl_hash.compute_source_hash_for(raw)
+        if computed_hash is None:  # pragma: no cover — 3.2.1 contract drift guard
+            msg = (
+                f"compute_source_hash_for returned None despite parent_raw "
+                f"being present for node {node.id}"
+            )
+            raise RuntimeError(msg)
+
+        if computed_hash == raw.enclosing_context_source_hash:
+            run_state.pass2[node.id] = NodeSummaryNodeStatus.SKIPPED_MEMO
+            run_state.updated_at = datetime.now(UTC)
+            await self._persist_run_state(job_id, run_state)
+            await self._session.commit()
+            return
+
+        # Step 5 — invoke the hook.
+        try:
+            await self._methodist.generate_topdown(node, raw, parent_raw)
+        except Exception as exc:
+            run_state.errors.append(
+                NodeSummaryRunError(
+                    node_id=node.id,
+                    stage="topdown",
+                    reason=str(exc),
+                )
+            )
+            run_state.pass2[node.id] = NodeSummaryNodeStatus.ERROR
+            run_state.updated_at = datetime.now(UTC)
+            await self._persist_run_state(job_id, run_state)
+            await self._session.commit()
+            return
+
+        # Step 6 — materialise via 3.2.1 (mirror Pass 1 timing).
+        await self._encl_hash.update_source_hash(raw, computed_hash)
+
+        # Step 7 — DONE.
+        run_state.pass2[node.id] = NodeSummaryNodeStatus.DONE
         run_state.updated_at = datetime.now(UTC)
         await self._persist_run_state(job_id, run_state)
         await self._session.commit()

--- a/src/course_supporter/storage/node_summary_orchestrator.py
+++ b/src/course_supporter/storage/node_summary_orchestrator.py
@@ -1,0 +1,290 @@
+"""Two-pass methodist generation orchestrator (vision §3 KD10, Phase 3.2.2).
+
+Skeleton-first. Owns the deterministic bones of ``node_summary_regeneration``:
+the downward walk shape, ensure-Raw, two-axis scope-validation, per-node
+COMMIT, run-state on ``Job.stage_progress``, and the DI seam for the
+LLM hook that Phase 3.2.3 will fill in. **LLM generation itself is
+stubbed** here via :class:`MethodistGenerator` — the default no-op
+implementation lets the skeleton walk a synthetic subtree end-to-end
+without any model calls; Phase 3.2.3 wires the real methodist agent
+against the same protocol.
+
+This module is **commit 1** of the four-commit Phase 3.2.2 plan: scope-
+validation + run-state shape only. ``ensure_raw`` / ``visit_pass1`` /
+``visit_pass2`` / ``run`` land in subsequent commits and raise
+``NotImplementedError`` here so the import surface is stable but
+incomplete execution is loud.
+
+Boundary recap (Q-5 ratify): the worker entry, ARQ task function,
+``enqueue_node_summary_regeneration`` helper, and HTTP trigger all live
+in Phase 3.2.4. The orchestrator's entry point is the plain Python
+:meth:`run` method, which operates within an **already-created**
+``Job`` row of type ``node_summary_regeneration``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Protocol
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.storage.enclosing_context_hash import (
+    EnclosingContextHashService,
+)
+from course_supporter.storage.node_summary_run_state import NodeSummaryRunScope
+from course_supporter.storage.orm import CourseNode, NodeSummaryRaw
+
+logger = structlog.get_logger(__name__)
+
+
+class MethodistGenerator(Protocol):
+    """LLM-bearing hook for both methodist passes (vision §3 KD10).
+
+    Phase 3.2.3 ships the concrete implementation backed by the
+    methodist agent + ``ladders_methodist.yaml`` (stages
+    ``methodist_bottomup`` / ``methodist_topdown``). Phase 3.2.2 ships
+    only the no-op default so the orchestrator can drive its
+    skeleton over a synthetic subtree without any LLM calls.
+
+    Single-protocol decision (Q-3 ratify): the methodist is **one
+    agent with two passes**, not two agents. Matching ladders_methodist
+    yaml shape (one config, two stages). Both methods receive the
+    Raw row as a **mutable** ORM object and write canonical content
+    fields (Pass 1) or ``enclosing_context`` (Pass 2) directly onto
+    it; the orchestrator owns flush + COMMIT + materialise of the
+    two source-hash linkages.
+
+    None-contract (orchestrator-enforced, hook never sees it): for
+    a root node Pass 2 is **skipped entirely** by the orchestrator —
+    the hook is not invoked, ``parent_raw`` is never ``None`` in
+    real flow. For a non-root node with missing parent Raw, the
+    orchestrator raises before calling the hook (run-state error +
+    Pass 2 visit aborts). Hooks therefore receive a guaranteed-
+    present ``parent_raw`` on every Pass 2 invocation.
+    """
+
+    async def generate_bottomup(self, node: CourseNode, raw: NodeSummaryRaw) -> None:
+        """Write Pass 1 canonical fields + ``compressed_summary`` on ``raw``.
+
+        Mutate ``raw`` in place; the orchestrator flushes/commits
+        and materialises ``raw.source_content_hash`` after the hook
+        returns. Re-raise any LLM/retry/structural error — the
+        orchestrator catches and routes into run-state errors[].
+        """
+
+    async def generate_topdown(
+        self,
+        node: CourseNode,
+        raw: NodeSummaryRaw,
+        parent_raw: NodeSummaryRaw,
+    ) -> None:
+        """Write Pass 2 ``enclosing_context`` + observations on ``raw``.
+
+        ``parent_raw`` is guaranteed non-None (root short-circuits in
+        the orchestrator). Mutate ``raw`` in place; the orchestrator
+        flushes/commits and materialises
+        ``raw.enclosing_context_source_hash`` after the hook returns.
+        """
+
+
+class _NoOpMethodistGenerator:
+    """Default :class:`MethodistGenerator` — does nothing (Phase 3.2.2 skeleton).
+
+    Phase 3.2.3 replaces this with the real methodist agent via DI.
+    With this stub installed the orchestrator's per-node COMMITs are
+    "structural-only": Raw rows get materialised + ``source_content_hash``
+    is recorded, but canonical content fields stay at their DB defaults
+    (empty strings / empty lists). This keeps the resumability and
+    memoization machinery testable end-to-end without any LLM calls.
+    """
+
+    async def generate_bottomup(self, node: CourseNode, raw: NodeSummaryRaw) -> None:
+        return
+
+    async def generate_topdown(
+        self,
+        node: CourseNode,
+        raw: NodeSummaryRaw,
+        parent_raw: NodeSummaryRaw,
+    ) -> None:
+        return
+
+
+class NodeSummaryGenerationOrchestrator:
+    """Two-pass methodist generation orchestrator (vision §3 KD10).
+
+    Construct one per ``Job``; instances are stateless aside from the
+    bound session and the injected :class:`MethodistGenerator`. The
+    orchestrator does NOT create Job rows, enqueue ARQ tasks, or
+    speak HTTP — Phase 3.2.4 owns all of that.
+
+    Skeleton commit 1 ships only :meth:`validate_scope`; ensure-Raw
+    + Pass 1 + Pass 2 + :meth:`run` land in subsequent commits of
+    the same task.
+    """
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        methodist: MethodistGenerator | None = None,
+    ) -> None:
+        self._session = session
+        self._methodist: MethodistGenerator = methodist or _NoOpMethodistGenerator()
+        self._encl_hash = EnclosingContextHashService(session)
+
+    async def validate_scope(
+        self, vertex_node_id: uuid.UUID, force: bool
+    ) -> NodeSummaryRunScope:
+        """Classify all course CourseNodes by ``in_scope`` vs ``uncovered_stale``.
+
+        Walks the entire course (rooted at ``vertex``'s root ancestor)
+        and returns two disjoint sets:
+
+        * ``in_scope_node_ids`` — every active CourseNode in the
+          subtree under ``vertex`` (root inclusive); these are what
+          Pass 1 + Pass 2 will visit. Memoization handles freshness
+          optimization at visit time; scope itself is structural.
+        * ``uncovered_stale_node_ids`` — stale CourseNodes elsewhere
+          in the course (NOT in the vertex's subtree) that the
+          current run will leave behind. Informational only — the
+          run does **not** raise on this; the 422 surface is the
+          API in Phase 3.2.4.
+
+        Staleness is two-axis (vision §3 KD10 line 975):
+
+        * Axis 1 — ``content_hash`` linkage. A CourseNode is axis-1
+          stale when its Raw row is absent OR its
+          ``raw.source_content_hash`` does not equal the live
+          ``course_node.content_hash`` (KD10 line 1011 cache key).
+        * Axis 2 — ``enclosing_context`` linkage. A non-root
+          CourseNode whose Raw exists is axis-2 stale when the
+          Phase 3.2.1 service reports
+          ``EnclosingContextHashService.is_stale(raw)``.
+
+        ``force`` is accepted for signature symmetry with the
+        orchestrator's :meth:`run` and the 3.2.4 API; the
+        classification itself is force-agnostic by design (force only
+        affects whether the API raises 422 on
+        ``uncovered_stale_node_ids``, not what classification the
+        nodes receive).
+        """
+        del force  # informational at run/API level; not a classifier input
+
+        vertex = await self._session.get(CourseNode, vertex_node_id)
+        if vertex is None or vertex.deleted_at is not None:
+            msg = (
+                f"validate_scope: vertex CourseNode {vertex_node_id} "
+                f"not found or soft-deleted"
+            )
+            raise ValueError(msg)
+
+        course_nodes = await self._collect_course_nodes(vertex)
+        subtree_ids = self._collect_subtree_ids(vertex.id, course_nodes)
+
+        raws_by_node = await self._fetch_raws(list(course_nodes.keys()))
+
+        stale_anywhere: set[uuid.UUID] = set()
+        for node_id, node in course_nodes.items():
+            raw = raws_by_node.get(node_id)
+            if await self._is_node_stale(node, raw):
+                stale_anywhere.add(node_id)
+
+        uncovered = sorted(stale_anywhere - subtree_ids)
+        in_scope = sorted(subtree_ids)
+
+        return NodeSummaryRunScope(
+            in_scope_node_ids=in_scope,
+            uncovered_stale_node_ids=uncovered,
+        )
+
+    async def run(
+        self,
+        *,
+        job_id: uuid.UUID,
+        vertex_node_id: uuid.UUID,
+        force: bool = False,
+    ) -> None:
+        """Orchestrate Pass 1 + Pass 2 on the existing ``Job`` row.
+
+        Lands in commits 2-3 of Phase 3.2.2.
+        """
+        del job_id, vertex_node_id, force
+        msg = "run() lands in Phase 3.2.2 commits 2-3 (Pass 1 + Pass 2 visits)"
+        raise NotImplementedError(msg)
+
+    # ─── helpers (private) ────────────────────────
+
+    async def _collect_course_nodes(
+        self, vertex: CourseNode
+    ) -> dict[uuid.UUID, CourseNode]:
+        """Load every active CourseNode in the course containing ``vertex``."""
+        root = vertex
+        depth = 0
+        while root.parent_id is not None and depth < 25:
+            parent = await self._session.get(CourseNode, root.parent_id)
+            if parent is None or parent.deleted_at is not None:
+                break
+            root = parent
+            depth += 1
+
+        result = await self._session.execute(
+            select(CourseNode).where(
+                CourseNode.tenant_id == root.tenant_id,
+                CourseNode.deleted_at.is_(None),
+            )
+        )
+        by_id = {n.id: n for n in result.scalars().all()}
+        by_id.setdefault(root.id, root)
+        by_id.setdefault(vertex.id, vertex)
+        return by_id
+
+    @staticmethod
+    def _collect_subtree_ids(
+        vertex_id: uuid.UUID, course_nodes: dict[uuid.UUID, CourseNode]
+    ) -> set[uuid.UUID]:
+        """BFS-collect IDs under ``vertex_id`` using in-memory parent map."""
+        children_by_parent: dict[uuid.UUID, list[uuid.UUID]] = {}
+        for node_id, node in course_nodes.items():
+            if node.parent_id is not None:
+                children_by_parent.setdefault(node.parent_id, []).append(node_id)
+
+        collected: set[uuid.UUID] = {vertex_id}
+        frontier = [vertex_id]
+        while frontier:
+            current = frontier.pop()
+            for child_id in children_by_parent.get(current, []):
+                if child_id in collected:
+                    continue
+                collected.add(child_id)
+                frontier.append(child_id)
+        return collected
+
+    async def _fetch_raws(
+        self, course_node_ids: list[uuid.UUID]
+    ) -> dict[uuid.UUID, NodeSummaryRaw]:
+        """Load active Raw rows for the given CourseNode IDs."""
+        if not course_node_ids:
+            return {}
+        result = await self._session.execute(
+            select(NodeSummaryRaw).where(
+                NodeSummaryRaw.course_node_id.in_(course_node_ids),
+                NodeSummaryRaw.deleted_at.is_(None),
+            )
+        )
+        return {r.course_node_id: r for r in result.scalars().all()}
+
+    async def _is_node_stale(
+        self, node: CourseNode, raw: NodeSummaryRaw | None
+    ) -> bool:
+        """Two-axis staleness check (vision §3 KD10 line 975)."""
+        if raw is None:
+            return True
+        if raw.source_content_hash != node.content_hash:
+            return True
+        if node.parent_id is None:
+            return False
+        return await self._encl_hash.is_stale(raw)

--- a/src/course_supporter/storage/node_summary_run_state.py
+++ b/src/course_supporter/storage/node_summary_run_state.py
@@ -1,0 +1,116 @@
+"""Run-state schema for ``node_summary_regeneration`` jobs (vision §3 KD10).
+
+KD10 line 1026 puts per-run + per-node statuses on the **pipeline-run
+entity** (the Job row), explicitly NOT on the CourseNode/Raw — otherwise
+the freshness signal becomes a third ephemeral axis next to
+``content_hash`` and ``enclosing_context_source_hash``. ``Job`` already
+carries the canonical columns: ``current_stage`` (the active pass —
+``bottomup`` / ``topdown`` / NULL when not running), and
+``stage_progress`` (JSONB, schema intentionally not enforced at the DB
+level per the orm comment).
+
+This module pins the JSON shape under ``Job.stage_progress`` for the
+``node_summary_regeneration`` job type and ships the round-trip
+helpers (``to_jsonb`` / ``from_jsonb``) so the orchestrator and tests
+read/write identical bytes. Schema decisions (Q-4 ratify, Phase 3.2.2):
+
+* ``current_stage`` is **NOT duplicated** here — it lives in the
+  ``Job.current_stage`` column and would drift if mirrored.
+* Completion is signalled via ``Job.status='completed'``, never via a
+  ``current_stage='completed'`` sentinel value.
+* ``pass1`` / ``pass2`` are per-node maps from ``uuid`` to one of four
+  statuses: ``pending`` / ``done`` / ``skipped_memo`` / ``error``.
+* ``errors`` is an append-only list (resume sees the full history of
+  attempts across reruns).
+* ``scope`` records what ``validate_scope`` decided when the run
+  started; ``uncovered_stale`` is informational and does NOT block
+  the run from proceeding.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class NodeSummaryNodeStatus(StrEnum):
+    """Per-node lifecycle status inside a ``node_summary_regeneration`` run."""
+
+    PENDING = "pending"
+    """Node is in scope but the pass has not yet committed against it."""
+
+    DONE = "done"
+    """LLM hook executed and node was committed (canonical fields written)."""
+
+    SKIPPED_MEMO = "skipped_memo"
+    """Memoization short-circuit fired; LLM hook was NOT invoked."""
+
+    ERROR = "error"
+    """A raise inside the visit was caught; see ``errors[]`` for the entry."""
+
+
+class NodeSummaryRunScope(BaseModel):
+    """What scope-validation decided at run start (vision §3 KD10 scope-valid).
+
+    ``uncovered_stale`` is informational only — the API at 3.2.4 will
+    surface it as a 422 (with ``force=True`` bypass), but the
+    orchestrator itself does NOT raise on uncovered stale (Q-1
+    ratify: logic-only, HTTP-surfacing is 3.2.4).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    in_scope_node_ids: list[uuid.UUID] = Field(default_factory=list)
+    uncovered_stale_node_ids: list[uuid.UUID] = Field(default_factory=list)
+
+
+class NodeSummaryRunError(BaseModel):
+    """A single error observed during a per-node visit (append-only)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    node_id: uuid.UUID
+    stage: str
+    """``'bottomup'`` / ``'topdown'`` (matches Job.current_stage values)."""
+    reason: str
+    """Short operator-facing diagnostic; full stack trace stays in logs."""
+    at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class NodeSummaryRunState(BaseModel):
+    """Top-level shape persisted under ``Job.stage_progress``.
+
+    ``vertex_node_id`` + ``force`` are the run inputs (echoed back so
+    resume sees the original parameters without re-deriving them from
+    ``Job.input_params``). ``scope`` is the scope-validation result.
+    ``pass1`` / ``pass2`` are per-node status maps keyed by
+    ``CourseNode.id``. ``errors`` is append-only.
+
+    JSON round-trip serializes UUIDs and datetimes via Pydantic's
+    default JSON-mode dump so the resulting dict is JSONB-storable
+    without further massaging on the SQLAlchemy side.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    vertex_node_id: uuid.UUID
+    force: bool = False
+    scope: NodeSummaryRunScope = Field(default_factory=NodeSummaryRunScope)
+    pass1: dict[uuid.UUID, NodeSummaryNodeStatus] = Field(default_factory=dict)
+    pass2: dict[uuid.UUID, NodeSummaryNodeStatus] = Field(default_factory=dict)
+    errors: list[NodeSummaryRunError] = Field(default_factory=list)
+    started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    def to_jsonb(self) -> dict[str, Any]:
+        """Serialize to a JSONB-compatible dict (UUID/datetime → str)."""
+        return self.model_dump(mode="json")
+
+    @classmethod
+    def from_jsonb(cls, payload: dict[str, Any]) -> NodeSummaryRunState:
+        """Deserialize from ``Job.stage_progress`` JSONB content."""
+        return cls.model_validate(payload)

--- a/src/course_supporter/storage/node_summary_run_state.py
+++ b/src/course_supporter/storage/node_summary_run_state.py
@@ -47,7 +47,25 @@ class NodeSummaryNodeStatus(StrEnum):
     """LLM hook executed and node was committed (canonical fields written)."""
 
     SKIPPED_MEMO = "skipped_memo"
-    """Memoization short-circuit fired; LLM hook was NOT invoked."""
+    """Memoization short-circuit fired; LLM hook was NOT invoked.
+
+    Semantic: "we computed the cache key and it matched the stored value
+    — the work is already fresh". Distinct from ``NOT_APPLICABLE`` which
+    means the pass does not apply by construction.
+    """
+
+    NOT_APPLICABLE = "not_applicable"
+    """The pass does not apply to this node by construction.
+
+    Pass 2 (top-down) on the **course root** (``CourseNode.parent_id IS
+    NULL``) uses this status: vision §3 KD10 line 1001 — "top-down
+    пропускається (немає охоплюючого контексту)". The root has no
+    parent to read ``enclosing_context`` from; the key is undefined by
+    construction, not "empty" or "fresh". Distinct from
+    ``SKIPPED_MEMO`` so UI / resume diagnostics can tell apart "no
+    work needed because already fresh" from "no work could be done
+    because the pass is structurally exempt here".
+    """
 
     ERROR = "error"
     """A raise inside the visit was caught; see ``errors[]`` for the entry."""

--- a/src/course_supporter/storage/orm.py
+++ b/src/course_supporter/storage/orm.py
@@ -1244,6 +1244,15 @@ class NodeSummaryRaw(SoftDeleteMixin, Base):
         "enclosing_context. Raw-only — Final does not carry this key. "
         "NULL until first top-down walk populates it (walker — Phase 3.2).",
     )
+    source_content_hash: Mapped[str | None] = mapped_column(
+        String(64),
+        comment="Bottom-up memoization key (KD10 line 1011) = "
+        "CourseNode.content_hash at the time Pass 1 last completed. "
+        "Distinct from self ``content_hash`` (which hashes own "
+        "generated fields per KD9 line 729). NULL until first Pass 1 "
+        "lands; written by the Phase 3.2.2 orchestrator after the LLM "
+        "hook commits per-node.",
+    )
 
     # ─── Timestamps ──────────────────────────────
     created_at: Mapped[datetime] = mapped_column(

--- a/tests/integration/test_node_summary_orchestrator_crash_resume.py
+++ b/tests/integration/test_node_summary_orchestrator_crash_resume.py
@@ -1,0 +1,498 @@
+"""Integration: crash-resume acceptance (Phase 3.2.2 commit 4).
+
+Closes acceptance #6 (FULL) of the task spec — "падіння всередині
+проходу лишає закомічені вузли цілими, перезапуск продовжує":
+
+* Pass 1 crash on one node → walk continues per K2 (failed node ERROR,
+  others DONE); re-run with clean methodist memo-skips the DONE nodes
+  and retries ONLY the failed node.
+* Pass 2 crash on one node → analogous semantics with topdown.
+* Crash on Pass 1 of node X does NOT block Pass 2 of node X in the
+  SAME run — ensure-Raw created the row before the hook, so visit_pass2
+  finds the Raw row and proceeds (X has source_content_hash NULL, but
+  visit_pass2 only needs the row to exist + a parent_raw).
+* errors[] accumulates across runs (Q-4 ratify cross-run contract):
+  run 1 records 1 error → run 2 succeeds → errors[] still carries
+  the run-1 entry.
+
+Crash injection via the ``MethodistGenerator`` DI seam (NOT
+monkeypatch). The fault generator raises RuntimeError on the N-th
+hook call only; subsequent calls succeed — matches the cleanest
+resume-property pin (one failed node, exact retry assertion).
+
+Run with: ``uv run pytest -m requires_db --run-db``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from course_supporter.jobs import JobType
+from course_supporter.storage.node_summary_orchestrator import (
+    NodeSummaryGenerationOrchestrator,
+)
+from course_supporter.storage.node_summary_run_state import (
+    NodeSummaryNodeStatus,
+    NodeSummaryRunState,
+)
+from course_supporter.storage.orm import (
+    CourseNode,
+    Job,
+    NodeSummaryFinal,
+    NodeSummaryRaw,
+    Tenant,
+)
+from tests._helpers.course_node_factory import make_root_course_node
+
+pytestmark = pytest.mark.requires_db
+
+
+# ── Tree + Job setup ──────────────────────────────────────────────
+
+
+async def _setup_course_with_job(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> dict[str, Any]:
+    """Build root + 3 children + 2 grand-children + active Job; commit."""
+    async with session_factory() as session:
+        tenant = Tenant(name=f"resume-{uuid.uuid4().hex[:8]}")
+        session.add(tenant)
+        await session.flush()
+
+        root = make_root_course_node(tenant_id=tenant.id, title="root", order=0)
+        session.add(root)
+        await session.flush()
+
+        a = CourseNode(tenant_id=tenant.id, parent_id=root.id, title="a", order=0)
+        b = CourseNode(tenant_id=tenant.id, parent_id=root.id, title="b", order=1)
+        c = CourseNode(tenant_id=tenant.id, parent_id=root.id, title="c", order=2)
+        session.add_all([a, b, c])
+        await session.flush()
+
+        a1 = CourseNode(tenant_id=tenant.id, parent_id=a.id, title="a1", order=0)
+        a2 = CourseNode(tenant_id=tenant.id, parent_id=a.id, title="a2", order=1)
+        session.add_all([a1, a2])
+        await session.flush()
+
+        job = Job(
+            tenant_id=tenant.id,
+            course_node_id=root.id,
+            job_type=JobType.NODE_SUMMARY_REGENERATION,
+            status="active",
+            input_params={"vertex_node_id": str(root.id), "force": False},
+        )
+        session.add(job)
+        await session.flush()
+        await session.commit()
+
+        return {
+            "tenant_id": tenant.id,
+            "job_id": job.id,
+            "root": root.id,
+            "a": a.id,
+            "b": b.id,
+            "c": c.id,
+            "a1": a1.id,
+            "a2": a2.id,
+        }
+
+
+async def _cleanup_course(
+    session_factory: async_sessionmaker[AsyncSession], tenant_id: uuid.UUID
+) -> None:
+    async with session_factory() as session:
+        await session.execute(
+            delete(NodeSummaryFinal).where(
+                NodeSummaryFinal.course_node_id.in_(
+                    select(CourseNode.id).where(CourseNode.tenant_id == tenant_id)
+                )
+            )
+        )
+        await session.execute(
+            delete(NodeSummaryRaw).where(
+                NodeSummaryRaw.course_node_id.in_(
+                    select(CourseNode.id).where(CourseNode.tenant_id == tenant_id)
+                )
+            )
+        )
+        await session.execute(delete(Job).where(Job.tenant_id == tenant_id))
+        await session.execute(
+            delete(CourseNode).where(CourseNode.tenant_id == tenant_id)
+        )
+        await session.execute(delete(Tenant).where(Tenant.id == tenant_id))
+        await session.commit()
+
+
+# ── Fault generators (DI seam — NOT monkeypatch) ──────────────────
+
+
+class _RaiseOnNthBottomupMethodist:
+    """Raises RuntimeError on the N-th ``generate_bottomup`` call only.
+
+    All other calls (before and after) succeed (no-op). Pins the exact
+    resume semantics: one failed node, every other DONE on first run;
+    re-run retries ONLY the failed node.
+    """
+
+    def __init__(self, *, raise_on_call: int) -> None:
+        self._raise_on = raise_on_call
+        self.bottomup_calls: list[uuid.UUID] = []
+        self.topdown_calls: list[uuid.UUID] = []
+
+    async def generate_bottomup(self, node: CourseNode, raw: NodeSummaryRaw) -> None:
+        self.bottomup_calls.append(node.id)
+        if len(self.bottomup_calls) == self._raise_on:
+            raise RuntimeError("synthetic crash on N-th bottomup")
+
+    async def generate_topdown(
+        self,
+        node: CourseNode,
+        raw: NodeSummaryRaw,
+        parent_raw: NodeSummaryRaw,
+    ) -> None:
+        self.topdown_calls.append(node.id)
+
+
+class _RaiseOnNthTopdownMethodist:
+    """Raises RuntimeError on the N-th ``generate_topdown`` call only."""
+
+    def __init__(self, *, raise_on_call: int) -> None:
+        self._raise_on = raise_on_call
+        self.bottomup_calls: list[uuid.UUID] = []
+        self.topdown_calls: list[uuid.UUID] = []
+
+    async def generate_bottomup(self, node: CourseNode, raw: NodeSummaryRaw) -> None:
+        self.bottomup_calls.append(node.id)
+
+    async def generate_topdown(
+        self,
+        node: CourseNode,
+        raw: NodeSummaryRaw,
+        parent_raw: NodeSummaryRaw,
+    ) -> None:
+        self.topdown_calls.append(node.id)
+        if len(self.topdown_calls) == self._raise_on:
+            raise RuntimeError("synthetic crash on N-th topdown")
+
+
+class _RecordingMethodist:
+    """Clean methodist — no faults. Records call order."""
+
+    def __init__(self) -> None:
+        self.bottomup_calls: list[uuid.UUID] = []
+        self.topdown_calls: list[uuid.UUID] = []
+
+    async def generate_bottomup(self, node: CourseNode, raw: NodeSummaryRaw) -> None:
+        self.bottomup_calls.append(node.id)
+
+    async def generate_topdown(
+        self,
+        node: CourseNode,
+        raw: NodeSummaryRaw,
+        parent_raw: NodeSummaryRaw,
+    ) -> None:
+        self.topdown_calls.append(node.id)
+
+
+# ── #6 FULL — Pass 1 crash-resume ─────────────────────────────────
+
+
+class TestPass1ResumeAfterError:
+    """Crash on one Pass 1 hook → re-run retries ONLY that node."""
+
+    async def test_run1_records_one_error_run2_retries_only_failed(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            # Run 1 — crash on the 3rd Pass-1 hook call.
+            crash_methodist = _RaiseOnNthBottomupMethodist(raise_on_call=3)
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=crash_methodist
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            # The 3rd visited node is the failed one. Capture it via the
+            # recorded call order.
+            assert len(crash_methodist.bottomup_calls) == 6  # K2 continues
+            failed_node_id = crash_methodist.bottomup_calls[2]
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                # Only the failed node is ERROR; others are DONE.
+                for nid in ids.values():
+                    if not isinstance(nid, uuid.UUID):
+                        continue
+                    if nid == ids["job_id"] or nid == ids["tenant_id"]:
+                        continue
+                    if nid in state.pass1:
+                        expected = (
+                            NodeSummaryNodeStatus.ERROR
+                            if nid == failed_node_id
+                            else NodeSummaryNodeStatus.DONE
+                        )
+                        assert state.pass1[nid] is expected
+                # One errors[] entry references the failed node + 'bottomup'.
+                assert len(state.errors) == 1
+                assert state.errors[0].node_id == failed_node_id
+                assert state.errors[0].stage == "bottomup"
+
+            # Run 2 — clean methodist; expect ONLY the failed node retried.
+            clean_methodist = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=clean_methodist
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            assert clean_methodist.bottomup_calls == [failed_node_id]
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                # Recovered: failed node now DONE.
+                assert state.pass1[failed_node_id] is NodeSummaryNodeStatus.DONE
+                # All other nodes SKIPPED_MEMO (no hook called).
+                for nid in (
+                    ids["root"],
+                    ids["a"],
+                    ids["b"],
+                    ids["c"],
+                    ids["a1"],
+                    ids["a2"],
+                ):
+                    if nid == failed_node_id:
+                        continue
+                    assert state.pass1[nid] is NodeSummaryNodeStatus.SKIPPED_MEMO
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── #6 FULL — Pass 2 crash-resume ─────────────────────────────────
+
+
+class TestPass2ResumeAfterError:
+    """Crash on one Pass 2 hook → re-run retries ONLY that node."""
+
+    async def test_run1_topdown_error_run2_retries_only_failed(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            # Pass 2 raises on its 3rd call. With 5 non-root in_scope nodes,
+            # the 3rd top-down call will land on whatever the orchestrator's
+            # root→leaves order produces — we capture it dynamically.
+            crash_methodist = _RaiseOnNthTopdownMethodist(raise_on_call=3)
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=crash_methodist
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            # 5 non-root nodes were visited in Pass 2 (root is NOT_APPLICABLE).
+            assert len(crash_methodist.topdown_calls) == 5
+            failed_node_id = crash_methodist.topdown_calls[2]
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                assert state.pass2[failed_node_id] is NodeSummaryNodeStatus.ERROR
+                # All other non-root nodes DONE; root NOT_APPLICABLE.
+                assert state.pass2[ids["root"]] is NodeSummaryNodeStatus.NOT_APPLICABLE
+                # One errors[] entry — topdown stage.
+                topdown_errors = [e for e in state.errors if e.stage == "topdown"]
+                assert len(topdown_errors) == 1
+                assert topdown_errors[0].node_id == failed_node_id
+
+            # Run 2 — clean methodist; only the failed node retried in Pass 2.
+            clean_methodist = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=clean_methodist
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+            # Pass 1 fully memo-skips (all source_content_hash written in run 1).
+            assert clean_methodist.bottomup_calls == []
+            # Pass 2 retries only the failed node.
+            assert clean_methodist.topdown_calls == [failed_node_id]
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── Pass 1 ERROR does not block Pass 2 on same node in same run ───
+
+
+class TestCrashInPass1NodePassesPass2InSameRun:
+    """Pass 1 ERROR on node X does NOT prevent Pass 2 on X in the same run.
+
+    ensure-Raw creates the row BEFORE the hook, so even when the hook
+    raises, the row exists with ``source_content_hash=NULL``. Pass 2
+    then finds the row, fetches the parent's Raw, and proceeds.
+    """
+
+    async def test_pass2_succeeds_on_pass1_errored_node(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            crash_methodist = _RaiseOnNthBottomupMethodist(raise_on_call=1)
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=crash_methodist
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            # 1st bottomup call is the first leaf (a1 in leaf→root order
+            # within the {root,a,a1,a2,b,c} subtree). Capture the failed id.
+            failed_id = crash_methodist.bottomup_calls[0]
+            # Pass 2 of failed_id still ran. Confirm via state.
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                # Pass 1 failed_id = ERROR.
+                assert state.pass1[failed_id] is NodeSummaryNodeStatus.ERROR
+                # Pass 2 failed_id = DONE (Pass 1 ERROR didn't block Pass 2).
+                # Unless failed_id is the course root, in which case
+                # NOT_APPLICABLE. With raise_on_call=1 and leaf→root order,
+                # failed_id is always a leaf — never root.
+                assert state.pass2[failed_id] is NodeSummaryNodeStatus.DONE
+                # ensure-Raw row exists with source_content_hash=NULL
+                # (hook never reached materialise step) but
+                # enclosing_context_source_hash IS populated (Pass 2 DONE).
+                result = await session.execute(
+                    select(NodeSummaryRaw).where(
+                        NodeSummaryRaw.course_node_id == failed_id
+                    )
+                )
+                raw = result.scalar_one()
+                assert raw.source_content_hash is None
+                assert raw.enclosing_context_source_hash is not None
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── Q-4 cross-run errors[] preservation ───────────────────────────
+
+
+class TestErrorsPreservedAcrossRuns:
+    """``errors[]`` accumulates across runs (Q-4 ratify contract)."""
+
+    async def test_errors_from_first_run_survive_second_run(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            # Run 1 — crash on 2nd bottomup; one error recorded.
+            crash_methodist = _RaiseOnNthBottomupMethodist(raise_on_call=2)
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=crash_methodist
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                run1_error_count = len(state.errors)
+                assert run1_error_count == 1
+                run1_error_reason = state.errors[0].reason
+
+            # Run 2 — clean methodist; no NEW errors, but run-1 entry preserved.
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=_RecordingMethodist()
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                # Run-1 error preserved verbatim.
+                assert len(state.errors) == 1
+                assert state.errors[0].reason == run1_error_reason
+
+            # Run 3 — crash again (different node); errors[] grows to 2.
+            crash_methodist_3 = _RaiseOnNthBottomupMethodist(raise_on_call=1)
+            # But run 3 starts with all axis-1-fresh from run 2 → memo-skip
+            # all of Pass 1 → no hook calls → no new errors. Use a flipped
+            # CourseNode.content_hash to force regeneration.
+            async with session_factory() as session:
+                # Flip every node's content_hash → axis-1 stale everywhere.
+                result = await session.execute(
+                    select(CourseNode).where(CourseNode.tenant_id == ids["tenant_id"])
+                )
+                for node in result.scalars().all():
+                    node.content_hash = uuid.uuid4().hex + "0" * 32
+                await session.commit()
+
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=crash_methodist_3
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                # Two errors now — original preserved + new one appended.
+                assert len(state.errors) == 2
+                assert state.errors[0].reason == run1_error_reason
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── Q-4 condition 1 — tolerant read-back on malformed errors entry ─
+
+
+class TestReadBackToleratesMalformedEntries:
+    """Bad error entry → log + skip; good entries preserved."""
+
+    async def test_malformed_error_entry_skipped(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            # Hand-craft a stage_progress payload with one good + one bad entry.
+            good_entry = {
+                "node_id": str(uuid.uuid4()),
+                "stage": "bottomup",
+                "reason": "good entry",
+                "at": "2026-06-11T00:00:00+00:00",
+            }
+            bad_entry = {"this_is_not": "a valid error entry"}
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                job.stage_progress = {"errors": [good_entry, bad_entry]}
+                await session.commit()
+
+            # Run — read-back must skip the bad entry, preserve the good one.
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=_RecordingMethodist()
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                # Good entry preserved; bad entry dropped.
+                assert len(state.errors) == 1
+                assert state.errors[0].reason == "good entry"
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])

--- a/tests/integration/test_node_summary_orchestrator_mixed_staleness.py
+++ b/tests/integration/test_node_summary_orchestrator_mixed_staleness.py
@@ -1,0 +1,387 @@
+"""Integration: mixed-staleness + edge cases (Phase 3.2.2 commit 4).
+
+Closes commit-4 acceptance hostings:
+
+* Mixed-staleness subtree: pre-seed Raws so some nodes are axis-1 fresh
+  and others are axis-1 stale. Verify selective memo-skip — hook called
+  ONLY on stale nodes, fresh nodes get ``SKIPPED_MEMO``. Goes beyond
+  idempotency (which is "all-fresh") by pinning the selective behavior.
+
+* Deeply nested tree (6 levels): orchestrator handles a course with
+  the maximum realistic depth without breaking either order algorithm
+  or per-node atomicity.
+
+* Multiple force runs: each run records ``force`` into run-state; the
+  K1 invariant (memo-skip ignores force) holds across consecutive
+  force=True runs over the same vertex.
+
+Run with: ``uv run pytest -m requires_db --run-db``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from course_supporter.jobs import JobType
+from course_supporter.storage.node_summary_orchestrator import (
+    NodeSummaryGenerationOrchestrator,
+)
+from course_supporter.storage.node_summary_run_state import (
+    NodeSummaryNodeStatus,
+    NodeSummaryRunState,
+)
+from course_supporter.storage.orm import (
+    CourseNode,
+    Job,
+    NodeSummaryFinal,
+    NodeSummaryRaw,
+    Tenant,
+)
+from tests._helpers.course_node_factory import make_root_course_node
+
+pytestmark = pytest.mark.requires_db
+
+
+# ── Recording methodist ───────────────────────────────────────────
+
+
+class _RecordingMethodist:
+    def __init__(self) -> None:
+        self.bottomup_calls: list[uuid.UUID] = []
+        self.topdown_calls: list[uuid.UUID] = []
+
+    async def generate_bottomup(self, node: CourseNode, raw: NodeSummaryRaw) -> None:
+        self.bottomup_calls.append(node.id)
+
+    async def generate_topdown(
+        self,
+        node: CourseNode,
+        raw: NodeSummaryRaw,
+        parent_raw: NodeSummaryRaw,
+    ) -> None:
+        self.topdown_calls.append(node.id)
+
+
+async def _cleanup_tenant(
+    session_factory: async_sessionmaker[AsyncSession], tenant_id: uuid.UUID
+) -> None:
+    async with session_factory() as session:
+        await session.execute(
+            delete(NodeSummaryFinal).where(
+                NodeSummaryFinal.course_node_id.in_(
+                    select(CourseNode.id).where(CourseNode.tenant_id == tenant_id)
+                )
+            )
+        )
+        await session.execute(
+            delete(NodeSummaryRaw).where(
+                NodeSummaryRaw.course_node_id.in_(
+                    select(CourseNode.id).where(CourseNode.tenant_id == tenant_id)
+                )
+            )
+        )
+        await session.execute(delete(Job).where(Job.tenant_id == tenant_id))
+        await session.execute(
+            delete(CourseNode).where(CourseNode.tenant_id == tenant_id)
+        )
+        await session.execute(delete(Tenant).where(Tenant.id == tenant_id))
+        await session.commit()
+
+
+# ── Mixed-staleness ───────────────────────────────────────────────
+
+
+class TestMixedStalenessSelectiveMemoSkip:
+    """Selective memo-skip: hook called ONLY on axis-1-stale in-scope nodes."""
+
+    async def test_selective_memo_skip_matches_staleness_state(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            tenant = Tenant(name=f"mixed-{uuid.uuid4().hex[:8]}")
+            session.add(tenant)
+            await session.flush()
+
+            root = make_root_course_node(tenant_id=tenant.id, title="root", order=0)
+            session.add(root)
+            await session.flush()
+
+            a = CourseNode(tenant_id=tenant.id, parent_id=root.id, title="a", order=0)
+            b = CourseNode(tenant_id=tenant.id, parent_id=root.id, title="b", order=1)
+            session.add_all([a, b])
+            await session.flush()
+
+            a1 = CourseNode(tenant_id=tenant.id, parent_id=a.id, title="a1", order=0)
+            a2 = CourseNode(tenant_id=tenant.id, parent_id=a.id, title="a2", order=1)
+            session.add_all([a1, a2])
+            await session.flush()
+
+            # Pre-seed Raws with mixed staleness:
+            #  - a:  Raw with source_content_hash == a.content_hash → fresh
+            #  - a2: Raw with source_content_hash == a2.content_hash → fresh
+            #  - b:  Raw with WRONG source_content_hash → stale
+            #  - root, a1: NO Raw → stale
+            session.add(
+                NodeSummaryRaw(course_node_id=a.id, source_content_hash=a.content_hash)
+            )
+            session.add(
+                NodeSummaryRaw(
+                    course_node_id=a2.id, source_content_hash=a2.content_hash
+                )
+            )
+            session.add(
+                NodeSummaryRaw(course_node_id=b.id, source_content_hash="f" * 64)
+            )
+
+            job = Job(
+                tenant_id=tenant.id,
+                course_node_id=root.id,
+                job_type=JobType.NODE_SUMMARY_REGENERATION,
+                status="active",
+            )
+            session.add(job)
+            await session.flush()
+            await session.commit()
+
+            tenant_id = tenant.id
+            job_id = job.id
+            ids = {
+                "root": root.id,
+                "a": a.id,
+                "b": b.id,
+                "a1": a1.id,
+                "a2": a2.id,
+            }
+        try:
+            methodist = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(session, methodist=methodist)
+                await orch.run(job_id=job_id, vertex_node_id=ids["root"])
+
+            # Pass 1 hook called ONLY on stale nodes: root, b, a1.
+            # Memo-skipped nodes (a, a2) get NO hook call.
+            assert set(methodist.bottomup_calls) == {
+                ids["root"],
+                ids["b"],
+                ids["a1"],
+            }
+
+            async with session_factory() as session:
+                job = await session.get(Job, job_id)
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                assert state.pass1[ids["a"]] is NodeSummaryNodeStatus.SKIPPED_MEMO
+                assert state.pass1[ids["a2"]] is NodeSummaryNodeStatus.SKIPPED_MEMO
+                assert state.pass1[ids["root"]] is NodeSummaryNodeStatus.DONE
+                assert state.pass1[ids["b"]] is NodeSummaryNodeStatus.DONE
+                assert state.pass1[ids["a1"]] is NodeSummaryNodeStatus.DONE
+        finally:
+            await _cleanup_tenant(session_factory, tenant_id)
+
+
+# ── Deeply nested tree (6 levels) ─────────────────────────────────
+
+
+class TestDeeplyNestedTree:
+    """6-level deep course: ordering + atomicity hold at depth."""
+
+    async def test_six_level_tree_processes_in_order(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            tenant = Tenant(name=f"deep-{uuid.uuid4().hex[:8]}")
+            session.add(tenant)
+            await session.flush()
+
+            # root → l1 → l2 → l3 → l4 → l5 (single chain, 6 levels)
+            root = make_root_course_node(tenant_id=tenant.id, title="root", order=0)
+            session.add(root)
+            await session.flush()
+            chain: list[CourseNode] = [root]
+            parent: CourseNode = root
+            for i in range(1, 6):
+                child = CourseNode(
+                    tenant_id=tenant.id,
+                    parent_id=parent.id,
+                    title=f"l{i}",
+                    order=0,
+                )
+                session.add(child)
+                await session.flush()
+                chain.append(child)
+                parent = child
+
+            job = Job(
+                tenant_id=tenant.id,
+                course_node_id=root.id,
+                job_type=JobType.NODE_SUMMARY_REGENERATION,
+                status="active",
+            )
+            session.add(job)
+            await session.flush()
+            await session.commit()
+
+            tenant_id = tenant.id
+            job_id = job.id
+            chain_ids = [n.id for n in chain]
+        try:
+            methodist = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(session, methodist=methodist)
+                await orch.run(job_id=job_id, vertex_node_id=chain_ids[0])
+
+            # Pass 1 (leaf→root) — l5, l4, l3, l2, l1, root.
+            assert methodist.bottomup_calls == [
+                chain_ids[5],
+                chain_ids[4],
+                chain_ids[3],
+                chain_ids[2],
+                chain_ids[1],
+                chain_ids[0],
+            ]
+            # Pass 2 (root→leaves, root NOT_APPLICABLE) — l1, l2, l3, l4, l5.
+            assert methodist.topdown_calls == [
+                chain_ids[1],
+                chain_ids[2],
+                chain_ids[3],
+                chain_ids[4],
+                chain_ids[5],
+            ]
+
+            async with session_factory() as session:
+                job = await session.get(Job, job_id)
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                for nid in chain_ids:
+                    assert state.pass1[nid] is NodeSummaryNodeStatus.DONE
+                assert state.pass2[chain_ids[0]] is NodeSummaryNodeStatus.NOT_APPLICABLE
+                for nid in chain_ids[1:]:
+                    assert state.pass2[nid] is NodeSummaryNodeStatus.DONE
+        finally:
+            await _cleanup_tenant(session_factory, tenant_id)
+
+
+# ── Multiple force runs ───────────────────────────────────────────
+
+
+class TestMultipleForceRuns:
+    """Successive force=True runs each record force; memo-skip ignores it."""
+
+    async def test_two_force_runs_both_record_force_and_memo_skip(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            tenant = Tenant(name=f"force-{uuid.uuid4().hex[:8]}")
+            session.add(tenant)
+            await session.flush()
+            root = make_root_course_node(tenant_id=tenant.id, title="root", order=0)
+            session.add(root)
+            await session.flush()
+            a = CourseNode(tenant_id=tenant.id, parent_id=root.id, title="a", order=0)
+            session.add(a)
+            await session.flush()
+            job = Job(
+                tenant_id=tenant.id,
+                course_node_id=root.id,
+                job_type=JobType.NODE_SUMMARY_REGENERATION,
+                status="active",
+            )
+            session.add(job)
+            await session.flush()
+            await session.commit()
+            tenant_id = tenant.id
+            job_id = job.id
+            root_id = root.id
+        try:
+            # Run 1 — force=True, vertex=root, no uncovered_stale.
+            methodist1 = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(session, methodist=methodist1)
+                await orch.run(job_id=job_id, vertex_node_id=root_id, force=True)
+
+            async with session_factory() as session:
+                job = await session.get(Job, job_id)
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                assert state.force is True
+
+            # Run 2 — force=True again. K1 invariant: memo-skip fires
+            # despite force (axis-1-fresh nodes are NOT regenerated).
+            methodist2 = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(session, methodist=methodist2)
+                await orch.run(job_id=job_id, vertex_node_id=root_id, force=True)
+            # Zero hook calls on run 2 — memo-skip ignores force.
+            assert methodist2.bottomup_calls == []
+            assert methodist2.topdown_calls == []
+
+            async with session_factory() as session:
+                job = await session.get(Job, job_id)
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                assert state.force is True
+        finally:
+            await _cleanup_tenant(session_factory, tenant_id)
+
+
+# ── Final acceptance #1 sanity: empty-hash literals match formula ─
+
+
+class TestEmptyHashLiteralsParitySanity:
+    """Sanity: server_default constants match the formula-derived values.
+
+    Phase 3.1 ``test_empty_hash_literals`` already pins this for the three
+    empty-hash literals. This is a smoke-confirmation that the same
+    empty-content invariant holds for orchestrator-driven flow: a node
+    visited with the no-op hook ends with ``raw.content_hash`` equal to
+    the ``EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH`` literal.
+    """
+
+    async def test_no_op_hook_leaves_content_hash_at_empty_default(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            tenant = Tenant(name=f"empty-{uuid.uuid4().hex[:8]}")
+            session.add(tenant)
+            await session.flush()
+            root = make_root_course_node(tenant_id=tenant.id, title="root", order=0)
+            session.add(root)
+            await session.flush()
+            job = Job(
+                tenant_id=tenant.id,
+                course_node_id=root.id,
+                job_type=JobType.NODE_SUMMARY_REGENERATION,
+                status="active",
+            )
+            session.add(job)
+            await session.flush()
+            await session.commit()
+            tenant_id = tenant.id
+            job_id = job.id
+            root_id = root.id
+        try:
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=_RecordingMethodist()
+                )
+                await orch.run(job_id=job_id, vertex_node_id=root_id)
+
+            async with session_factory() as session:
+                result = await session.execute(
+                    select(NodeSummaryRaw).where(
+                        NodeSummaryRaw.course_node_id == root_id
+                    )
+                )
+                raw = result.scalar_one()
+                # No-op hook never touched content fields → empty default.
+                from course_supporter.storage.content_hash import (
+                    EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH,
+                )
+
+                assert raw.content_hash == EMPTY_NODE_SUMMARY_RAW_CONTENT_HASH
+        finally:
+            await _cleanup_tenant(session_factory, tenant_id)

--- a/tests/integration/test_node_summary_orchestrator_pass1.py
+++ b/tests/integration/test_node_summary_orchestrator_pass1.py
@@ -1,0 +1,509 @@
+"""Integration: Pass 1 leg of NodeSummaryGenerationOrchestrator (Phase 3.2.2 commit 2).
+
+Pins commit-2 acceptance:
+
+* #3 (idempotency, partial) — second run of the same scope produces no
+  new Raw rows and skips every node by memoization
+  (``pass1[node]=skipped_memo``); ``source_content_hash`` is stable.
+* #4 (leaf→root order, partial) — for any in-scope subtree, the
+  ``MethodistGenerator.generate_bottomup`` calls land children before
+  parents.
+* memo-skip is **unconditional** with respect to ``force`` (K1 ratify) —
+  axis-1-fresh nodes are skipped even when ``force=True``; ``force``
+  only widens scope at validate-time.
+* error in the hook does **not** abort the run (K2 ratify) — errors
+  accumulate in ``run_state.errors[]`` while the walk continues; other
+  nodes still finish DONE.
+* per-node atomicity (K3 ratify) — every successful visit commits;
+  resume after crash sees the committed state.
+
+Pass 2 acceptance + None-contract land in commit 3; full crash-resume
+end-to-end lands in commit 4.
+
+Run with: ``uv run pytest -m requires_db --run-db``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from course_supporter.jobs import JobType
+from course_supporter.storage.job_repository import JobRepository
+from course_supporter.storage.node_summary_orchestrator import (
+    NodeSummaryGenerationOrchestrator,
+)
+from course_supporter.storage.node_summary_run_state import (
+    NodeSummaryNodeStatus,
+    NodeSummaryRunState,
+)
+from course_supporter.storage.orm import CourseNode, Job, NodeSummaryRaw, Tenant
+from tests._helpers.course_node_factory import make_root_course_node
+
+pytestmark = pytest.mark.requires_db
+
+
+# ── Tree + Job setup helpers (commit per call — visits commit too) ─
+
+
+async def _setup_course_with_job(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> dict[str, Any]:
+    """Build root + 3 children + 2 grand-children + a fresh Job; commit.
+
+    Returns a dict with ``tenant_id``, ``job_id``, and per-name
+    ``CourseNode`` ids so the test can drive the orchestrator with a
+    fresh session and verify state from a third.
+    """
+    async with session_factory() as session:
+        tenant = Tenant(name=f"pass1-{uuid.uuid4().hex[:8]}")
+        session.add(tenant)
+        await session.flush()
+
+        root = make_root_course_node(tenant_id=tenant.id, title="root", order=0)
+        session.add(root)
+        await session.flush()
+
+        a = CourseNode(tenant_id=tenant.id, parent_id=root.id, title="a", order=0)
+        b = CourseNode(tenant_id=tenant.id, parent_id=root.id, title="b", order=1)
+        c = CourseNode(tenant_id=tenant.id, parent_id=root.id, title="c", order=2)
+        session.add_all([a, b, c])
+        await session.flush()
+
+        a1 = CourseNode(tenant_id=tenant.id, parent_id=a.id, title="a1", order=0)
+        a2 = CourseNode(tenant_id=tenant.id, parent_id=a.id, title="a2", order=1)
+        session.add_all([a1, a2])
+        await session.flush()
+
+        job = Job(
+            tenant_id=tenant.id,
+            course_node_id=root.id,
+            job_type=JobType.NODE_SUMMARY_REGENERATION,
+            status="active",
+            input_params={"vertex_node_id": str(root.id), "force": False},
+        )
+        session.add(job)
+        await session.flush()
+        await session.commit()
+
+        return {
+            "tenant_id": tenant.id,
+            "job_id": job.id,
+            "root": root.id,
+            "a": a.id,
+            "b": b.id,
+            "c": c.id,
+            "a1": a1.id,
+            "a2": a2.id,
+        }
+
+
+async def _cleanup_course(
+    session_factory: async_sessionmaker[AsyncSession], tenant_id: uuid.UUID
+) -> None:
+    """Hard-delete the test course rows (commit-aware fixtures own cleanup)."""
+    from sqlalchemy import delete
+
+    async with session_factory() as session:
+        # Delete Raw + Job first (FK on course_nodes); then nodes; then tenant.
+        await session.execute(
+            delete(NodeSummaryRaw).where(
+                NodeSummaryRaw.course_node_id.in_(
+                    select(CourseNode.id).where(CourseNode.tenant_id == tenant_id)
+                )
+            )
+        )
+        await session.execute(delete(Job).where(Job.tenant_id == tenant_id))
+        await session.execute(
+            delete(CourseNode).where(CourseNode.tenant_id == tenant_id)
+        )
+        await session.execute(delete(Tenant).where(Tenant.id == tenant_id))
+        await session.commit()
+
+
+# ── Test methodist that records call order ─────────────────────────
+
+
+class _RecordingMethodist:
+    """``MethodistGenerator`` stub that records the order of bottom-up calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[uuid.UUID] = []
+
+    async def generate_bottomup(self, node: CourseNode, raw: NodeSummaryRaw) -> None:
+        self.calls.append(node.id)
+
+    async def generate_topdown(
+        self,
+        node: CourseNode,
+        raw: NodeSummaryRaw,
+        parent_raw: NodeSummaryRaw,
+    ) -> None:
+        return
+
+
+class _RaisingOnNodeMethodist:
+    """Raises on the named node; otherwise records calls (for K2 error tests)."""
+
+    def __init__(self, raise_on: uuid.UUID) -> None:
+        self._raise_on = raise_on
+        self.calls: list[uuid.UUID] = []
+
+    async def generate_bottomup(self, node: CourseNode, raw: NodeSummaryRaw) -> None:
+        self.calls.append(node.id)
+        if node.id == self._raise_on:
+            raise RuntimeError("synthetic hook failure")
+
+    async def generate_topdown(
+        self,
+        node: CourseNode,
+        raw: NodeSummaryRaw,
+        parent_raw: NodeSummaryRaw,
+    ) -> None:
+        return
+
+
+# ── #3 idempotency ────────────────────────────────────────────────
+
+
+class TestIdempotency:
+    """Second run with stable course state hits memo-skip on every node."""
+
+    async def test_second_run_skips_all_by_memo(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            # First run — every visit is a fresh INSERT + hook + materialise.
+            methodist_first = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=methodist_first
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            # Every in-scope node should have been visited once.
+            assert set(methodist_first.calls) == {
+                ids["root"],
+                ids["a"],
+                ids["b"],
+                ids["c"],
+                ids["a1"],
+                ids["a2"],
+            }
+
+            # Second run — same vertex, no state changes, every node fresh.
+            methodist_second = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=methodist_second
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            assert methodist_second.calls == []
+
+            # Verify run-state on Job — pass1 all skipped_memo.
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                assert job.stage_progress is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress)
+                for nid in (
+                    ids["root"],
+                    ids["a"],
+                    ids["b"],
+                    ids["c"],
+                    ids["a1"],
+                    ids["a2"],
+                ):
+                    assert state.pass1[nid] is NodeSummaryNodeStatus.SKIPPED_MEMO
+
+            # One Raw per CourseNode (UNIQUE + ON CONFLICT DO NOTHING).
+            async with session_factory() as session:
+                result = await session.execute(
+                    select(NodeSummaryRaw).where(
+                        NodeSummaryRaw.course_node_id.in_(
+                            [
+                                ids["root"],
+                                ids["a"],
+                                ids["b"],
+                                ids["c"],
+                                ids["a1"],
+                                ids["a2"],
+                            ]
+                        )
+                    )
+                )
+                raws = result.scalars().all()
+                assert len(raws) == 6  # 6 nodes → 6 Raws (no duplicates)
+
+                # source_content_hash stable: equals CourseNode.content_hash.
+                course_nodes = await session.execute(
+                    select(CourseNode).where(CourseNode.tenant_id == ids["tenant_id"])
+                )
+                by_id = {n.id: n for n in course_nodes.scalars().all()}
+                for raw in raws:
+                    expected = by_id[raw.course_node_id].content_hash
+                    assert raw.source_content_hash == expected
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── #4 leaf→root order ────────────────────────────────────────────
+
+
+class TestLeafToRootOrder:
+    """For every parent in scope, all in-scope children precede the parent."""
+
+    async def test_children_emitted_before_parents(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            methodist = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(session, methodist=methodist)
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            positions = {nid: idx for idx, nid in enumerate(methodist.calls)}
+
+            # a1, a2 → a → root  AND  b → root  AND  c → root.
+            assert positions[ids["a1"]] < positions[ids["a"]]
+            assert positions[ids["a2"]] < positions[ids["a"]]
+            assert positions[ids["a"]] < positions[ids["root"]]
+            assert positions[ids["b"]] < positions[ids["root"]]
+            assert positions[ids["c"]] < positions[ids["root"]]
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── K1 memo-skip unconditional w.r.t. force ────────────────────────
+
+
+class TestMemoSkipIgnoresForce:
+    """``force=True`` does NOT regenerate axis-1-fresh nodes (K1 ratify)."""
+
+    async def test_force_does_not_invoke_hook_on_fresh_nodes(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            # First run — populate source_content_hash everywhere.
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=_RecordingMethodist()
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            # Second run with force=True — memo-skip still fires.
+            methodist_forced = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=methodist_forced
+                )
+                await orch.run(
+                    job_id=ids["job_id"], vertex_node_id=ids["root"], force=True
+                )
+            assert methodist_forced.calls == []
+
+            # Verify force value is recorded in run-state.
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                assert job.stage_progress is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress)
+                assert state.force is True
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── K2 error-on-node does not abort the walk ───────────────────────
+
+
+class TestErrorDoesNotAbortRun:
+    """A raise inside one node's hook records error + status; walk continues."""
+
+    async def test_walk_continues_after_per_node_error(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            methodist = _RaisingOnNodeMethodist(raise_on=ids["a"])
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(session, methodist=methodist)
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            # Hook called on every node (a1, a2, a, b, c, root may vary in
+            # order between b/c but a's hook was invoked even though it raised).
+            assert ids["a1"] in methodist.calls
+            assert ids["a2"] in methodist.calls
+            assert ids["a"] in methodist.calls
+            assert ids["b"] in methodist.calls
+            assert ids["c"] in methodist.calls
+            assert ids["root"] in methodist.calls
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+
+                # Node "a" got error status + an entry in errors[].
+                assert state.pass1[ids["a"]] is NodeSummaryNodeStatus.ERROR
+                assert any(
+                    e.node_id == ids["a"] and e.stage == "bottomup"
+                    for e in state.errors
+                )
+
+                # Other nodes completed normally.
+                for nid in (
+                    ids["root"],
+                    ids["b"],
+                    ids["c"],
+                    ids["a1"],
+                    ids["a2"],
+                ):
+                    assert state.pass1[nid] is NodeSummaryNodeStatus.DONE
+
+                # source_content_hash written on success-path nodes;
+                # NOT written on the erroring node (the materialise step
+                # follows the hook).
+                result = await session.execute(
+                    select(NodeSummaryRaw).where(
+                        NodeSummaryRaw.course_node_id.in_(
+                            [ids["a"], ids["b"], ids["c"]]
+                        )
+                    )
+                )
+                by_node = {r.course_node_id: r for r in result.scalars().all()}
+                assert by_node[ids["a"]].source_content_hash is None
+                assert by_node[ids["b"]].source_content_hash is not None
+                assert by_node[ids["c"]].source_content_hash is not None
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── K3 per-node COMMIT atomicity ────────────────────────────────
+
+
+class TestPerNodeCommit:
+    """Every successful visit commits; partial progress is durable."""
+
+    async def test_first_visit_commits_before_second_starts(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            # Methodist that reads committed state mid-walk via a fresh session.
+            observed: list[int] = []
+
+            class _Snooper:
+                async def generate_bottomup(
+                    self, node: CourseNode, raw: NodeSummaryRaw
+                ) -> None:
+                    # Side-channel read with a fresh session — must see the
+                    # rows committed by visits that ran before this one.
+                    async with session_factory() as snoop:
+                        result = await snoop.execute(
+                            select(NodeSummaryRaw).where(
+                                NodeSummaryRaw.course_node_id.in_(
+                                    [
+                                        ids["root"],
+                                        ids["a"],
+                                        ids["b"],
+                                        ids["c"],
+                                        ids["a1"],
+                                        ids["a2"],
+                                    ]
+                                )
+                            )
+                        )
+                        observed.append(len(result.scalars().all()))
+
+                async def generate_topdown(
+                    self,
+                    node: CourseNode,
+                    raw: NodeSummaryRaw,
+                    parent_raw: NodeSummaryRaw,
+                ) -> None:
+                    return
+
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(session, methodist=_Snooper())
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            # Per-node atomicity: the orchestrator's TX commits ensure-Raw
+            # + source_hash + status as one unit AFTER the hook returns,
+            # so during visit N the snooper (separate session) sees exactly
+            # N-1 Raws (rows from visits 1..N-1 are committed; visit N's
+            # row is in the orchestrator's uncommitted TX).
+            # Observation list must be [0, 1, 2, 3, 4, 5] — monotonic by
+            # exactly +1 per visit. This proves both that visits commit
+            # serially AND that nothing leaks before the per-node commit.
+            assert observed == [0, 1, 2, 3, 4, 5]
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── Job.current_stage advances to 'bottomup' ───────────────────
+
+
+class TestJobStageMarker:
+    """``Job.current_stage`` flips to ``'bottomup'`` when the run starts."""
+
+    async def test_current_stage_set_to_bottomup(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=_RecordingMethodist()
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                assert job.current_stage == "bottomup"
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── update_stage_progress repo behaviour ───────────────────────
+
+
+class TestUpdateStageProgressRepository:
+    """``JobRepository.update_stage_progress`` writes the full JSON payload."""
+
+    async def test_full_replace_overwrites_previous_payload(
+        self, db_session: AsyncSession
+    ) -> None:
+        tenant = Tenant(name=f"sp-{uuid.uuid4().hex[:8]}")
+        db_session.add(tenant)
+        await db_session.flush()
+        node = make_root_course_node(tenant_id=tenant.id, title="root", order=0)
+        db_session.add(node)
+        await db_session.flush()
+        job = Job(
+            tenant_id=tenant.id,
+            course_node_id=node.id,
+            job_type=JobType.NODE_SUMMARY_REGENERATION,
+            status="active",
+            stage_progress={"old": "payload"},
+        )
+        db_session.add(job)
+        await db_session.flush()
+
+        repo = JobRepository(db_session)
+        await repo.update_stage_progress(job.id, {"fresh": ["payload", 2]})
+        await db_session.refresh(job)
+        assert job.stage_progress == {"fresh": ["payload", 2]}
+
+    async def test_silent_skip_on_missing_job(self, db_session: AsyncSession) -> None:
+        repo = JobRepository(db_session)
+        # No raise — mirrors update_stage convention.
+        await repo.update_stage_progress(uuid.uuid4(), {"ignored": True})

--- a/tests/integration/test_node_summary_orchestrator_pass1.py
+++ b/tests/integration/test_node_summary_orchestrator_pass1.py
@@ -448,27 +448,50 @@ class TestPerNodeCommit:
             await _cleanup_course(session_factory, ids["tenant_id"])
 
 
-# ── Job.current_stage advances to 'bottomup' ───────────────────
+# ── Job.current_stage advances through Pass 1 ───────────────────
 
 
 class TestJobStageMarker:
-    """``Job.current_stage`` flips to ``'bottomup'`` when the run starts."""
+    """``Job.current_stage`` is set to ``'bottomup'`` once Pass 1 starts.
 
-    async def test_current_stage_set_to_bottomup(
+    Post commit-3 the final value advances to ``'topdown'`` (the last
+    pass to run); the Pass 1 marker is verified mid-flight via a hook
+    that snapshots ``Job.current_stage`` from a fresh session.
+    """
+
+    async def test_current_stage_is_bottomup_during_pass1(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
         ids = await _setup_course_with_job(session_factory)
         try:
+            observed_stage: list[str | None] = []
+
+            class _SnoopStage:
+                async def generate_bottomup(
+                    self, node: CourseNode, raw: NodeSummaryRaw
+                ) -> None:
+                    async with session_factory() as snoop:
+                        job = await snoop.get(Job, ids["job_id"])
+                        if job is not None:
+                            observed_stage.append(job.current_stage)
+
+                async def generate_topdown(
+                    self,
+                    node: CourseNode,
+                    raw: NodeSummaryRaw,
+                    parent_raw: NodeSummaryRaw,
+                ) -> None:
+                    return
+
             async with session_factory() as session:
                 orch = NodeSummaryGenerationOrchestrator(
-                    session, methodist=_RecordingMethodist()
+                    session, methodist=_SnoopStage()
                 )
                 await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
 
-            async with session_factory() as session:
-                job = await session.get(Job, ids["job_id"])
-                assert job is not None
-                assert job.current_stage == "bottomup"
+            # Every Pass 1 hook invocation saw current_stage='bottomup'.
+            assert observed_stage  # at least one bottom-up hook fired
+            assert all(stage == "bottomup" for stage in observed_stage)
         finally:
             await _cleanup_course(session_factory, ids["tenant_id"])
 

--- a/tests/integration/test_node_summary_orchestrator_pass2.py
+++ b/tests/integration/test_node_summary_orchestrator_pass2.py
@@ -1,0 +1,549 @@
+"""Integration: Pass 2 leg of NodeSummaryGenerationOrchestrator (commit 3).
+
+Pins commit-3 acceptance:
+
+* #4 (full) — Pass 1 + Pass 2 ordering: bottom-up leaves→root precedes
+  top-down root→leaves; course-root is root-of-course, not vertex.
+* #5 (full) — None-contract: ``Pass2ParentRawMissingError`` raised
+  internally with A1/A2/B discrimination when non-root parent Raw is
+  missing; recorded into ``errors[]`` + ``pass2[node]=ERROR``; walk
+  continues; ``update_source_hash`` is NEVER called with ``None``.
+* #6 (Pass 2 partial) — Pass 2 per-node statuses written to
+  ``Job.stage_progress``; ``Job.current_stage`` advances
+  ``bottomup → topdown``.
+* #7 (skeleton-form) — Pass 2 memo-skip does NOT touch
+  ``NodeSummaryFinal.enclosing_context_updated_at`` (inverted pin via
+  pre-seeded Final row + post-run unchanged assertion). Skeleton 3.2.2
+  does not write Final at all; this test future-proofs against
+  accidental writes when 3.2.4 lands the third channel.
+* Bonus pin: Pass 2 idempotency — second run all SKIPPED_MEMO (root
+  ``NOT_APPLICABLE``); ``generate_topdown`` called zero times on rerun.
+
+Full crash-resume integration coverage lands in commit 4.
+
+Run with: ``uv run pytest -m requires_db --run-db``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from course_supporter.jobs import JobType
+from course_supporter.storage.node_summary_orchestrator import (
+    NodeSummaryGenerationOrchestrator,
+)
+from course_supporter.storage.node_summary_run_state import (
+    NodeSummaryNodeStatus,
+    NodeSummaryRunState,
+)
+from course_supporter.storage.orm import (
+    CourseNode,
+    Job,
+    NodeSummaryFinal,
+    NodeSummaryRaw,
+    Tenant,
+)
+from tests._helpers.course_node_factory import make_root_course_node
+
+pytestmark = pytest.mark.requires_db
+
+
+# ── Tree + Job setup ──────────────────────────────────────────────
+
+
+async def _setup_course_with_job(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> dict[str, Any]:
+    """Build root + 3 children + 2 grand-children + active Job; commit."""
+    async with session_factory() as session:
+        tenant = Tenant(name=f"pass2-{uuid.uuid4().hex[:8]}")
+        session.add(tenant)
+        await session.flush()
+
+        root = make_root_course_node(tenant_id=tenant.id, title="root", order=0)
+        session.add(root)
+        await session.flush()
+
+        a = CourseNode(tenant_id=tenant.id, parent_id=root.id, title="a", order=0)
+        b = CourseNode(tenant_id=tenant.id, parent_id=root.id, title="b", order=1)
+        c = CourseNode(tenant_id=tenant.id, parent_id=root.id, title="c", order=2)
+        session.add_all([a, b, c])
+        await session.flush()
+
+        a1 = CourseNode(tenant_id=tenant.id, parent_id=a.id, title="a1", order=0)
+        a2 = CourseNode(tenant_id=tenant.id, parent_id=a.id, title="a2", order=1)
+        session.add_all([a1, a2])
+        await session.flush()
+
+        job = Job(
+            tenant_id=tenant.id,
+            course_node_id=root.id,
+            job_type=JobType.NODE_SUMMARY_REGENERATION,
+            status="active",
+            input_params={"vertex_node_id": str(root.id), "force": False},
+        )
+        session.add(job)
+        await session.flush()
+        await session.commit()
+
+        return {
+            "tenant_id": tenant.id,
+            "job_id": job.id,
+            "root": root.id,
+            "a": a.id,
+            "b": b.id,
+            "c": c.id,
+            "a1": a1.id,
+            "a2": a2.id,
+        }
+
+
+async def _cleanup_course(
+    session_factory: async_sessionmaker[AsyncSession], tenant_id: uuid.UUID
+) -> None:
+    async with session_factory() as session:
+        await session.execute(
+            delete(NodeSummaryFinal).where(
+                NodeSummaryFinal.course_node_id.in_(
+                    select(CourseNode.id).where(CourseNode.tenant_id == tenant_id)
+                )
+            )
+        )
+        await session.execute(
+            delete(NodeSummaryRaw).where(
+                NodeSummaryRaw.course_node_id.in_(
+                    select(CourseNode.id).where(CourseNode.tenant_id == tenant_id)
+                )
+            )
+        )
+        await session.execute(delete(Job).where(Job.tenant_id == tenant_id))
+        await session.execute(
+            delete(CourseNode).where(CourseNode.tenant_id == tenant_id)
+        )
+        await session.execute(delete(Tenant).where(Tenant.id == tenant_id))
+        await session.commit()
+
+
+# ── Recording methodist ───────────────────────────────────────────
+
+
+class _RecordingMethodist:
+    """Records bottom-up + top-down call order; never raises."""
+
+    def __init__(self) -> None:
+        self.bottomup_calls: list[uuid.UUID] = []
+        self.topdown_calls: list[uuid.UUID] = []
+        # Capture the (node_id, parent_raw_present) tuple so tests can pin
+        # that parent_raw is never None (None-contract negative pin).
+        self.topdown_parent_present: list[tuple[uuid.UUID, bool]] = []
+
+    async def generate_bottomup(self, node: CourseNode, raw: NodeSummaryRaw) -> None:
+        self.bottomup_calls.append(node.id)
+
+    async def generate_topdown(
+        self,
+        node: CourseNode,
+        raw: NodeSummaryRaw,
+        parent_raw: NodeSummaryRaw,
+    ) -> None:
+        self.topdown_calls.append(node.id)
+        self.topdown_parent_present.append((node.id, parent_raw is not None))
+
+
+# ── #4 ordering: leaf→root precedes root→leaves ───────────────────
+
+
+class TestPassOrdering:
+    """Acceptance #4 (full)."""
+
+    async def test_bottomup_finishes_before_topdown_starts(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            methodist = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(session, methodist=methodist)
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            # Pass 1 visited every node; Pass 2 visited every non-root.
+            assert set(methodist.bottomup_calls) == {
+                ids["root"],
+                ids["a"],
+                ids["b"],
+                ids["c"],
+                ids["a1"],
+                ids["a2"],
+            }
+            # Pass 2 root is NOT_APPLICABLE → hook not called for root.
+            assert ids["root"] not in methodist.topdown_calls
+            assert set(methodist.topdown_calls) == {
+                ids["a"],
+                ids["b"],
+                ids["c"],
+                ids["a1"],
+                ids["a2"],
+            }
+
+            # Pass 2 ordering: parent precedes children (root→leaves).
+            pos = {nid: idx for idx, nid in enumerate(methodist.topdown_calls)}
+            assert pos[ids["a"]] < pos[ids["a1"]]
+            assert pos[ids["a"]] < pos[ids["a2"]]
+
+            # Sanity: parent_raw was non-None on every topdown invocation.
+            assert all(present for _, present in methodist.topdown_parent_present)
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── root NOT_APPLICABLE + current_stage transition ────────────────
+
+
+class TestRootNotApplicable:
+    """Pass 2 on course root → ``NOT_APPLICABLE`` (KD10 line 1001)."""
+
+    async def test_root_marked_not_applicable_and_stage_advances(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=_RecordingMethodist()
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                assert state.pass2[ids["root"]] is NodeSummaryNodeStatus.NOT_APPLICABLE
+                # Non-root nodes all DONE.
+                for nid in (
+                    ids["a"],
+                    ids["b"],
+                    ids["c"],
+                    ids["a1"],
+                    ids["a2"],
+                ):
+                    assert state.pass2[nid] is NodeSummaryNodeStatus.DONE
+                # current_stage finished on 'topdown' (last value written).
+                assert job.current_stage == "topdown"
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── inner vertex with out-of-scope parent ──────────────────────────
+
+
+class TestInnerVertexWithOutOfScopeParent:
+    """Vertex ≠ course root, parent has Raw outside scope → vertex Pass 2 OK."""
+
+    async def test_inner_vertex_processes_normally_with_outscope_parent(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            # First run with vertex=root populates Raws across the whole course.
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=_RecordingMethodist()
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            # Simulate axis-1 + axis-2 staleness on 'a' so Pass 2 has to
+            # actually invoke the hook (rather than memo-skip). Flip 'a's
+            # content_hash AND clear its axis-2 source_hash. The parent of
+            # 'a' is 'root', which is out_of_scope when vertex='a'; 'root'
+            # HAS Raw from the first run, so the orchestrator must fetch
+            # that out-of-scope parent's Raw correctly.
+            async with session_factory() as session:
+                node_a = await session.get(CourseNode, ids["a"])
+                assert node_a is not None
+                node_a.content_hash = "a" * 64
+                raw_a = (
+                    await session.execute(
+                        select(NodeSummaryRaw).where(
+                            NodeSummaryRaw.course_node_id == ids["a"]
+                        )
+                    )
+                ).scalar_one()
+                raw_a.enclosing_context_source_hash = None
+                await session.commit()
+
+            methodist_second = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=methodist_second
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["a"])
+
+            # Pass 1: 'a' axis-1 stale → hook called.
+            assert ids["a"] in methodist_second.bottomup_calls
+            # Pass 2: 'a' axis-2 stale → hook called WITH out-of-scope
+            # parent_raw (root's Raw). The negative pin on None-contract:
+            # parent_raw was non-None.
+            assert ids["a"] in methodist_second.topdown_calls
+            a_invocation = next(
+                (
+                    present
+                    for nid, present in methodist_second.topdown_parent_present
+                    if nid == ids["a"]
+                ),
+                None,
+            )
+            assert a_invocation is True
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+                # 'a' visited because parent (root) has Raw — no raise.
+                assert state.pass2[ids["a"]] is NodeSummaryNodeStatus.DONE
+                # No ERROR entries on the path.
+                error_node_ids = {e.node_id for e in state.errors}
+                assert ids["a"] not in error_node_ids
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── #5 None-contract — A1/A2/B discrimination ─────────────────────
+
+
+class TestNoneContractDiscrimination:
+    """Pass 2 raises ``Pass2ParentRawMissingError`` with proper discriminator."""
+
+    async def test_force_bypasses_uncovered_then_pass2_errors_on_vertex(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        # Build a course where 'a' is the vertex AND 'root' is uncovered_stale
+        # (root has no Raw). validate_scope flags root in uncovered_stale; user
+        # uses force=True; Pass 2 on 'a' fetches parent Raw → None → raises.
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            methodist_calls: list[uuid.UUID] = []
+
+            class _ObservedMethodist:
+                async def generate_bottomup(
+                    self, node: CourseNode, raw: NodeSummaryRaw
+                ) -> None:
+                    methodist_calls.append(node.id)
+
+                async def generate_topdown(
+                    self,
+                    node: CourseNode,
+                    raw: NodeSummaryRaw,
+                    parent_raw: NodeSummaryRaw,
+                ) -> None:
+                    # If we ever get here for 'a', parent_raw is non-None
+                    # by orchestrator contract.
+                    pass
+
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=_ObservedMethodist()
+                )
+                # vertex = 'a'; root is uncovered (no Raw); force=True.
+                await orch.run(
+                    job_id=ids["job_id"],
+                    vertex_node_id=ids["a"],
+                    force=True,
+                )
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+
+                # 'a' pass2 = ERROR because root (parent) has no Raw.
+                assert state.pass2[ids["a"]] is NodeSummaryNodeStatus.ERROR
+
+                # Error entry references topdown stage and node 'a';
+                # discriminator-bearing message identifies sub-case A2 (out-
+                # of-scope parent without Raw — uncovered_stale bypassed by
+                # force=True).
+                a_errors = [
+                    e
+                    for e in state.errors
+                    if e.node_id == ids["a"] and e.stage == "topdown"
+                ]
+                assert len(a_errors) == 1
+                assert "A2" in a_errors[0].reason
+                assert "uncovered_stale" in a_errors[0].reason
+
+                # Children of 'a' (a1, a2) Pass 2 succeed because their parent
+                # ('a') HAS Raw from Pass 1 — walk continues after the error.
+                # But: a's enclosing_context is NULL, so children's computed
+                # source_hash is hash(""), which equals their stored value
+                # (NULL ≠ computed hash → ERROR? no — first time around,
+                # children's stored hash is NULL, computed is hex → ≠ → DONE).
+                for nid in (ids["a1"], ids["a2"]):
+                    assert state.pass2[nid] in {
+                        NodeSummaryNodeStatus.DONE,
+                        NodeSummaryNodeStatus.SKIPPED_MEMO,
+                    }
+
+                # Verify Raw of 'a' did NOT get enclosing_context_source_hash
+                # written (we did not call update_source_hash on ERROR path).
+                result = await session.execute(
+                    select(NodeSummaryRaw).where(
+                        NodeSummaryRaw.course_node_id == ids["a"]
+                    )
+                )
+                raw_a = result.scalar_one()
+                assert raw_a.enclosing_context_source_hash is None
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── #7 inverted pin — Final.enclosing_context_updated_at untouched ─
+
+
+class TestFinalUpdatedAtUntouched:
+    """Skeleton 3.2.2 does not write Final; pre-seeded timestamp survives."""
+
+    async def test_pass2_memo_skip_does_not_touch_final_timestamp(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            # First run — populate everything axis-1 + axis-2 fresh.
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=_RecordingMethodist()
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            # Seed a NodeSummaryFinal with a pre-existing timestamp on the
+            # non-root inner node 'a' (any Final-bearing node would do).
+            sentinel = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+            async with session_factory() as session:
+                final = NodeSummaryFinal(
+                    course_node_id=ids["a"],
+                    enclosing_context_updated_at=sentinel,
+                    approved_at=sentinel,
+                )
+                session.add(final)
+                await session.commit()
+
+            # Second run — every Pass 2 should memo-skip (no work),
+            # in particular not touching Final.
+            methodist_second = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=methodist_second
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+            assert methodist_second.topdown_calls == []
+
+            # Assert Final timestamp untouched.
+            async with session_factory() as session:
+                result = await session.execute(
+                    select(NodeSummaryFinal).where(
+                        NodeSummaryFinal.course_node_id == ids["a"]
+                    )
+                )
+                final_after = result.scalar_one()
+                assert final_after.enclosing_context_updated_at == sentinel
+                assert final_after.approved_at == sentinel
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── Pass 2 idempotency on rerun ────────────────────────────────────
+
+
+class TestPass2Idempotency:
+    """Second run with stable second-axis state → all SKIPPED_MEMO / NOT_APPLICABLE."""
+
+    async def test_second_run_skips_topdown_everywhere(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            # First run.
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=_RecordingMethodist()
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            # Second run.
+            methodist_second = _RecordingMethodist()
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=methodist_second
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+            assert methodist_second.topdown_calls == []
+            assert methodist_second.bottomup_calls == []
+
+            async with session_factory() as session:
+                job = await session.get(Job, ids["job_id"])
+                assert job is not None
+                state = NodeSummaryRunState.from_jsonb(job.stage_progress or {})
+
+                # Root NOT_APPLICABLE.
+                assert state.pass2[ids["root"]] is NodeSummaryNodeStatus.NOT_APPLICABLE
+                # All other nodes SKIPPED_MEMO on second run.
+                for nid in (
+                    ids["a"],
+                    ids["b"],
+                    ids["c"],
+                    ids["a1"],
+                    ids["a2"],
+                ):
+                    assert state.pass2[nid] is NodeSummaryNodeStatus.SKIPPED_MEMO
+                    assert state.pass1[nid] is NodeSummaryNodeStatus.SKIPPED_MEMO
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])
+
+
+# ── enclosing_context_source_hash materialised ─────────────────────
+
+
+class TestEnclosingContextSourceHashMaterialised:
+    """After a clean run, every non-root Raw has axis-2 source-hash written."""
+
+    async def test_axis2_hash_written_for_non_root_nodes(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ids = await _setup_course_with_job(session_factory)
+        try:
+            async with session_factory() as session:
+                orch = NodeSummaryGenerationOrchestrator(
+                    session, methodist=_RecordingMethodist()
+                )
+                await orch.run(job_id=ids["job_id"], vertex_node_id=ids["root"])
+
+            async with session_factory() as session:
+                result = await session.execute(
+                    select(NodeSummaryRaw).where(
+                        NodeSummaryRaw.course_node_id.in_(
+                            [
+                                ids["root"],
+                                ids["a"],
+                                ids["b"],
+                                ids["c"],
+                                ids["a1"],
+                                ids["a2"],
+                            ]
+                        )
+                    )
+                )
+                by_node = {r.course_node_id: r for r in result.scalars().all()}
+                # Root: not touched by Pass 2 → enclosing_context_source_hash
+                # remains NULL.
+                assert by_node[ids["root"]].enclosing_context_source_hash is None
+                # Non-root: every node has axis-2 hash materialised.
+                for nid in (ids["a"], ids["b"], ids["c"], ids["a1"], ids["a2"]):
+                    assert by_node[nid].enclosing_context_source_hash is not None
+                    assert len(by_node[nid].enclosing_context_source_hash) == 64
+        finally:
+            await _cleanup_course(session_factory, ids["tenant_id"])

--- a/tests/integration/test_node_summary_orchestrator_scope.py
+++ b/tests/integration/test_node_summary_orchestrator_scope.py
@@ -1,0 +1,338 @@
+"""Integration: ``validate_scope`` from Phase 3.2.2 orchestrator (commit 1).
+
+Pins the two-axis scope-validation logic from vision §3 KD10 line 975
+against a real PostgreSQL schema (so the new
+``node_summaries_raw.source_content_hash`` column from
+``phase322_node_summary_raw_source_hash`` is exercised end-to-end).
+
+Acceptance scope for commit 1:
+
+* in-scope = subtree of vertex (memo-skip is a visit-time concern,
+  not a scope-time concern).
+* uncovered-stale = stale CourseNodes anywhere in the course but
+  outside vertex's subtree.
+* axis-1 staleness fires on missing Raw OR mismatched
+  ``source_content_hash``.
+* axis-2 staleness fires on a non-root Raw whose
+  ``enclosing_context_source_hash`` differs from the live parent's
+  ``enclosing_context``.
+* ``force`` is informational at validate_scope level (same return
+  shape regardless of value).
+* soft-deleted vertex → ``ValueError`` (caller is responsible for
+  surfacing this as 404 at the 3.2.4 API).
+
+Full Pass 1/Pass 2 acceptance + per-node COMMIT + resume tests land
+in commits 2-4 of the same task.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from course_supporter.storage.content_hash import (
+    EMPTY_NODE_CONTENT_HASH,
+)
+from course_supporter.storage.enclosing_context_hash import (
+    EnclosingContextHashService,
+)
+from course_supporter.storage.node_summary_orchestrator import (
+    NodeSummaryGenerationOrchestrator,
+)
+from course_supporter.storage.orm import CourseNode, NodeSummaryRaw, Tenant
+from tests._helpers.course_node_factory import make_root_course_node
+
+pytestmark = pytest.mark.requires_db
+
+
+# ── Tree builder ─────────────────────────────────────────────────
+
+
+async def _build_course(
+    session: AsyncSession,
+) -> dict[str, CourseNode]:
+    """Build a deterministic 7-node tree:
+
+    root
+    ├── a
+    │   ├── a1
+    │   └── a2
+    ├── b
+    │   └── b1
+    └── c
+    """
+    tenant = Tenant(name=f"orch-{uuid.uuid4().hex[:8]}")
+    session.add(tenant)
+    await session.flush()
+
+    root = make_root_course_node(tenant_id=tenant.id, title="root", order=0)
+    session.add(root)
+    await session.flush()
+
+    nodes: dict[str, CourseNode] = {"root": root}
+    layout = [
+        ("a", root.id, 0),
+        ("a1", None, 0),
+        ("a2", None, 1),
+        ("b", root.id, 1),
+        ("b1", None, 0),
+        ("c", root.id, 2),
+    ]
+    placeholder: dict[str, uuid.UUID] = {}
+    for name, parent_id, order in layout:
+        if name in {"a1", "a2"}:
+            parent_id = placeholder["a"]
+        elif name == "b1":
+            parent_id = placeholder["b"]
+        node = CourseNode(
+            tenant_id=tenant.id,
+            parent_id=parent_id,
+            title=name,
+            order=order,
+        )
+        session.add(node)
+        await session.flush()
+        nodes[name] = node
+        placeholder[name] = node.id
+
+    return nodes
+
+
+async def _make_raw(
+    session: AsyncSession,
+    *,
+    course_node_id: uuid.UUID,
+    source_content_hash: str | None = None,
+    enclosing_context: str | None = None,
+    enclosing_context_source_hash: str | None = None,
+) -> NodeSummaryRaw:
+    raw = NodeSummaryRaw(
+        course_node_id=course_node_id,
+        source_content_hash=source_content_hash,
+        enclosing_context=enclosing_context,
+        enclosing_context_source_hash=enclosing_context_source_hash,
+    )
+    session.add(raw)
+    await session.flush()
+    return raw
+
+
+# ── Structural in-scope = subtree of vertex ──────────────────────
+
+
+class TestInScopeIsSubtreeOfVertex:
+    """Structural ``in_scope`` is the subtree under ``vertex``."""
+
+    async def test_root_vertex_covers_entire_course(
+        self, db_session: AsyncSession
+    ) -> None:
+        nodes = await _build_course(db_session)
+        orch = NodeSummaryGenerationOrchestrator(db_session)
+        scope = await orch.validate_scope(nodes["root"].id, force=False)
+        expected = {n.id for n in nodes.values()}
+        assert set(scope.in_scope_node_ids) == expected
+
+    async def test_inner_vertex_covers_only_its_subtree(
+        self, db_session: AsyncSession
+    ) -> None:
+        nodes = await _build_course(db_session)
+        orch = NodeSummaryGenerationOrchestrator(db_session)
+        scope = await orch.validate_scope(nodes["a"].id, force=False)
+        assert set(scope.in_scope_node_ids) == {
+            nodes["a"].id,
+            nodes["a1"].id,
+            nodes["a2"].id,
+        }
+
+
+# ── Axis 1 — content_hash linkage ────────────────────────────────
+
+
+class TestAxisOneStaleness:
+    """Raw missing OR ``source_content_hash`` mismatch → axis-1 stale."""
+
+    async def test_all_nodes_stale_when_no_raws(self, db_session: AsyncSession) -> None:
+        nodes = await _build_course(db_session)
+        orch = NodeSummaryGenerationOrchestrator(db_session)
+        # Vertex = subtree "a"; uncovered = everything else (root, b, b1, c).
+        scope = await orch.validate_scope(nodes["a"].id, force=False)
+        expected_uncovered = {
+            nodes["root"].id,
+            nodes["b"].id,
+            nodes["b1"].id,
+            nodes["c"].id,
+        }
+        assert set(scope.uncovered_stale_node_ids) == expected_uncovered
+
+    async def test_matching_source_hash_clears_axis1(
+        self, db_session: AsyncSession
+    ) -> None:
+        # Axis-1 alone is fresh; axis-2 still marks non-roots stale
+        # because their ``enclosing_context_source_hash`` is NULL while
+        # the parent's implicit ``enclosing_context or ""`` hashes to a
+        # real digest. Root short-circuits axis-2 (no parent).
+        # → uncovered_stale = {non-root outside vertex} = {b, b1, c}.
+        nodes = await _build_course(db_session)
+        for node in nodes.values():
+            await _make_raw(
+                db_session,
+                course_node_id=node.id,
+                source_content_hash=node.content_hash,
+            )
+        orch = NodeSummaryGenerationOrchestrator(db_session)
+        scope = await orch.validate_scope(nodes["a"].id, force=False)
+        # Root excluded (axis-2 N/A); a/a1/a2 in vertex's subtree.
+        assert set(scope.uncovered_stale_node_ids) == {
+            nodes["b"].id,
+            nodes["b1"].id,
+            nodes["c"].id,
+        }
+        assert nodes["root"].id not in scope.uncovered_stale_node_ids
+
+    async def test_mismatched_source_hash_marks_stale(
+        self, db_session: AsyncSession
+    ) -> None:
+        nodes = await _build_course(db_session)
+        # Root + a + a1 + a2 — fresh; b/b1/c — wrong hash (axis-1 stale).
+        for name in ("root", "a", "a1", "a2"):
+            await _make_raw(
+                db_session,
+                course_node_id=nodes[name].id,
+                source_content_hash=nodes[name].content_hash,
+            )
+        wrong_hash = "f" * 64
+        for name in ("b", "b1", "c"):
+            await _make_raw(
+                db_session,
+                course_node_id=nodes[name].id,
+                source_content_hash=wrong_hash,
+            )
+
+        orch = NodeSummaryGenerationOrchestrator(db_session)
+        scope = await orch.validate_scope(nodes["a"].id, force=False)
+        assert set(scope.uncovered_stale_node_ids) == {
+            nodes["b"].id,
+            nodes["b1"].id,
+            nodes["c"].id,
+        }
+
+
+# ── Axis 2 — enclosing_context linkage ───────────────────────────
+
+
+class TestAxisTwoStaleness:
+    """Non-root Raw with mismatched
+    ``enclosing_context_source_hash`` → axis-2 stale.
+    """
+
+    async def test_axis2_stale_when_parent_context_drifts(
+        self, db_session: AsyncSession
+    ) -> None:
+        nodes = await _build_course(db_session)
+        # Every node has a Raw with matching axis-1 hash (so axis-1 is clean).
+        # Parents carry a non-trivial enclosing_context, but the child's
+        # enclosing_context_source_hash is stale (None) → axis-2 stale.
+        for node in nodes.values():
+            await _make_raw(
+                db_session,
+                course_node_id=node.id,
+                source_content_hash=node.content_hash,
+                enclosing_context="parent context payload",
+            )
+
+        orch = NodeSummaryGenerationOrchestrator(db_session)
+        # Vertex = "a" (inner); uncovered = nodes outside subtree that are
+        # axis-2-stale. b1 has a parent (b) whose enclosing_context is
+        # non-empty, and b1's enclosing_context_source_hash is NULL ≠
+        # the parent's hash → stale. Same for any other non-root.
+        scope = await orch.validate_scope(nodes["a"].id, force=False)
+        # Root has no parent (axis-2 N/A — never stale by axis 2).
+        # b1 / c — non-root with NULL source_hash, parent has context → stale.
+        # b is non-root child of root; same reasoning → stale.
+        assert nodes["b"].id in scope.uncovered_stale_node_ids
+        assert nodes["b1"].id in scope.uncovered_stale_node_ids
+        assert nodes["c"].id in scope.uncovered_stale_node_ids
+        assert nodes["root"].id not in scope.uncovered_stale_node_ids
+
+    async def test_axis2_fresh_when_source_hash_matches(
+        self, db_session: AsyncSession
+    ) -> None:
+        nodes = await _build_course(db_session)
+        # Every parent's enclosing_context is the empty string; children get
+        # the corresponding computed source-hash → axis-2 fresh.
+        for node in nodes.values():
+            await _make_raw(
+                db_session,
+                course_node_id=node.id,
+                source_content_hash=node.content_hash,
+                enclosing_context="",
+            )
+        # Now write each child's enclosing_context_source_hash from the
+        # 3.2.1 service so axis-2 is in steady state.
+        encl = EnclosingContextHashService(db_session)
+        for name in ("a", "a1", "a2", "b", "b1", "c"):
+            raw_row = (
+                await db_session.execute(
+                    select(NodeSummaryRaw).where(
+                        NodeSummaryRaw.course_node_id == nodes[name].id
+                    )
+                )
+            ).scalar_one()
+            computed = await encl.compute_source_hash_for(raw_row)
+            await encl.update_source_hash(raw_row, computed)
+
+        orch = NodeSummaryGenerationOrchestrator(db_session)
+        scope = await orch.validate_scope(nodes["root"].id, force=False)
+        assert scope.uncovered_stale_node_ids == []
+
+
+# ── force semantics + error cases ────────────────────────────────
+
+
+class TestForceAndErrorHandling:
+    """``force`` is informational at this layer; soft-delete raises."""
+
+    async def test_force_does_not_change_classification(
+        self, db_session: AsyncSession
+    ) -> None:
+        nodes = await _build_course(db_session)
+        orch = NodeSummaryGenerationOrchestrator(db_session)
+        a = await orch.validate_scope(nodes["a"].id, force=False)
+        b = await orch.validate_scope(nodes["a"].id, force=True)
+        assert a.in_scope_node_ids == b.in_scope_node_ids
+        assert a.uncovered_stale_node_ids == b.uncovered_stale_node_ids
+
+    async def test_soft_deleted_vertex_raises(self, db_session: AsyncSession) -> None:
+        nodes = await _build_course(db_session)
+        nodes["a"].deleted_at = datetime.now(UTC)
+        await db_session.flush()
+        orch = NodeSummaryGenerationOrchestrator(db_session)
+        with pytest.raises(ValueError, match="not found or soft-deleted"):
+            await orch.validate_scope(nodes["a"].id, force=False)
+
+    async def test_missing_vertex_raises(self, db_session: AsyncSession) -> None:
+        orch = NodeSummaryGenerationOrchestrator(db_session)
+        with pytest.raises(ValueError, match="not found or soft-deleted"):
+            await orch.validate_scope(uuid.uuid4(), force=False)
+
+
+# ── content_hash sanity check on empty CourseNode ────────────────
+
+
+class TestEmptyContentHashRecorded:
+    """Sanity: freshly-INSERTed CourseNode carries the empty-content-hash literal."""
+
+    async def test_fresh_root_has_empty_node_content_hash(
+        self, db_session: AsyncSession
+    ) -> None:
+        tenant = Tenant(name=f"orch-empty-{uuid.uuid4().hex[:8]}")
+        db_session.add(tenant)
+        await db_session.flush()
+        root = make_root_course_node(tenant_id=tenant.id, title="r", order=0)
+        db_session.add(root)
+        await db_session.flush()
+        assert root.content_hash == EMPTY_NODE_CONTENT_HASH

--- a/tests/storage/test_node_summary_run_state.py
+++ b/tests/storage/test_node_summary_run_state.py
@@ -1,0 +1,115 @@
+"""Pydantic round-trip tests for ``NodeSummaryRunState`` (Phase 3.2.2).
+
+Pins the JSON shape that lives under ``Job.stage_progress`` for the
+``node_summary_regeneration`` job type. ``Job.current_stage`` is the
+column-of-truth for the active pass and is NOT mirrored into this
+JSON (Q-4 ratify: avoid two sources for the same fact).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from course_supporter.storage.node_summary_run_state import (
+    NodeSummaryNodeStatus,
+    NodeSummaryRunError,
+    NodeSummaryRunScope,
+    NodeSummaryRunState,
+)
+
+
+class TestNodeSummaryRunStateRoundTrip:
+    """JSON-mode round-trip — what we write into JSONB equals what we read back."""
+
+    def test_minimal_roundtrip(self) -> None:
+        vertex = uuid.uuid4()
+        state = NodeSummaryRunState(vertex_node_id=vertex)
+        payload = state.to_jsonb()
+        restored = NodeSummaryRunState.from_jsonb(payload)
+        assert restored.vertex_node_id == vertex
+        assert restored.force is False
+        assert restored.pass1 == {}
+        assert restored.pass2 == {}
+        assert restored.errors == []
+        assert restored.scope.in_scope_node_ids == []
+        assert restored.scope.uncovered_stale_node_ids == []
+
+    def test_full_payload_roundtrip(self) -> None:
+        vertex = uuid.uuid4()
+        a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        state = NodeSummaryRunState(
+            vertex_node_id=vertex,
+            force=True,
+            scope=NodeSummaryRunScope(
+                in_scope_node_ids=[a, b, c],
+                uncovered_stale_node_ids=[],
+            ),
+            pass1={
+                a: NodeSummaryNodeStatus.DONE,
+                b: NodeSummaryNodeStatus.SKIPPED_MEMO,
+                c: NodeSummaryNodeStatus.PENDING,
+            },
+            pass2={a: NodeSummaryNodeStatus.PENDING},
+            errors=[
+                NodeSummaryRunError(
+                    node_id=c,
+                    stage="bottomup",
+                    reason="LLM ladder exhausted",
+                )
+            ],
+        )
+        payload = state.to_jsonb()
+        restored = NodeSummaryRunState.from_jsonb(payload)
+        assert restored.force is True
+        assert restored.scope.in_scope_node_ids == [a, b, c]
+        assert restored.pass1[a] is NodeSummaryNodeStatus.DONE
+        assert restored.pass1[b] is NodeSummaryNodeStatus.SKIPPED_MEMO
+        assert restored.pass2[a] is NodeSummaryNodeStatus.PENDING
+        assert len(restored.errors) == 1
+        assert restored.errors[0].stage == "bottomup"
+        assert restored.errors[0].node_id == c
+
+
+class TestJsonbCompatibility:
+    """JSON-mode dump produces JSONB-storable primitives (no UUID/datetime objects)."""
+
+    def test_uuids_serialize_to_strings(self) -> None:
+        state = NodeSummaryRunState(vertex_node_id=uuid.uuid4())
+        payload = state.to_jsonb()
+        assert isinstance(payload["vertex_node_id"], str)
+        assert uuid.UUID(payload["vertex_node_id"]) == state.vertex_node_id
+
+    def test_datetimes_serialize_to_iso8601(self) -> None:
+        fixed = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+        state = NodeSummaryRunState(
+            vertex_node_id=uuid.uuid4(),
+            started_at=fixed,
+            updated_at=fixed,
+        )
+        payload = state.to_jsonb()
+        assert isinstance(payload["started_at"], str)
+        assert payload["started_at"].startswith("2026-06-11T12:00:00")
+
+    def test_status_enum_serializes_as_string_value(self) -> None:
+        node_id = uuid.uuid4()
+        state = NodeSummaryRunState(
+            vertex_node_id=uuid.uuid4(),
+            pass1={node_id: NodeSummaryNodeStatus.SKIPPED_MEMO},
+        )
+        payload = state.to_jsonb()
+        # JSONB cannot key on enum; pydantic mode='json' stringifies
+        # the UUID key and the StrEnum value.
+        assert payload["pass1"][str(node_id)] == "skipped_memo"
+
+
+class TestExtraForbidden:
+    """``extra='forbid'`` pins the shape — unknown fields raise."""
+
+    def test_unknown_top_level_field_raises(self) -> None:
+        payload = NodeSummaryRunState(vertex_node_id=uuid.uuid4()).to_jsonb()
+        payload["current_stage"] = "bottomup"  # Q-4 ratify: NOT allowed here
+        import pytest
+
+        with pytest.raises(ValueError):
+            NodeSummaryRunState.from_jsonb(payload)


### PR DESCRIPTION
## Summary

Phase 3.2.2 — двопрохідний оркестратор методичної генерації (vision §3 KD10), skeleton-first. Pass 1 (bottom-up) + Pass 2 (top-down) повний цикл з мемоізацією по обох осях, per-node COMMIT, ensure-Raw + None-контракт, run-state на ``Job.stage_progress``. LLM hook через ``MethodistGenerator`` Protocol з no-op default — Phase 3.2.3 під'єднається через DI без рефактору.

## Composition

4 атомарних коміти + 1 schema migration:

* ``3b028d2`` — scope-validation + run-state Pydantic + ``source_content_hash`` migration (Q-2.MEMO Option A: окрема колонка для bottom-up memo key per KD10 line 1011, не self-hash з KD9 line 729).
* ``dd5dbfe`` — Pass 1 leg (ensure-Raw via PG ``ON CONFLICT DO NOTHING`` + memo-skip + materialise source_content_hash + per-node COMMIT).
* ``53fc7be`` — Pass 2 leg (root-of-course → ``NOT_APPLICABLE``; None-контракт із A1/A2/B дискримінацією через ``Pass2ParentRawMissingError``; composite-key memo через 3.2.1; materialise via service).
* ``6251b0b`` — acceptance closure (crash-resume FULL, mixed-staleness, deeply nested, multiple force; cross-run errors[] bugfix per Q-4.RESUME ratify (b)).

## Key ratified decisions

* **Q-1 scope-validation** — method on orchestrator, returns ``NodeSummaryRunScope`` (Pydantic), logic-only (HTTP-surfacing = 3.2.4).
* **Q-2.MEMO Option A** — new column ``NodeSummaryRaw.source_content_hash`` (axis-1 source linkage); self ``content_hash`` (KD9 line 729) untouched.
* **Q-3 single Protocol** — ``MethodistGenerator`` with ``generate_bottomup`` / ``generate_topdown``; mirrors ``ladders_methodist.yaml`` shape.
* **Q-4 run-state** — Pydantic ``NodeSummaryRunState`` under ``Job.stage_progress``; no ``current_stage`` mirror (column-of-truth in Job); ``errors[]`` append-only ACROSS runs (preserved on re-entry via tolerant per-entry parse).
* **Q-5 worker boundary** — orchestrator entry = plain Python ``run(job_id, vertex_node_id, force=False)`` on existing Job row; enqueue / ARQ task / HTTP route = 3.2.4.
* **K1 memo-skip unconditional w.r.t. force** — force only widens scope at validate-time; fresh nodes inside scope are ALWAYS skipped.
* **K2 walk continues on per-node error** — recorded into ``errors[]`` + ``pass2[node]=ERROR``; walk completes regardless.
* **K3 strictly sequential visits** — full-replace JSON on ``Job.stage_progress`` safe only because no two visits race; future ``asyncio.gather`` = STOP-escalate.

## Acceptance map (#1-#8 all closed)

| # | Acceptance | Test(s) |
|---|---|---|
| #1 | doctor PASS + alembic round-trip | manual + ``make doctor`` + downgrade/upgrade clean |
| #2 | full ``--run-db`` green | **2352 passed / 0 failed / 3 skipped** |
| #3 | Pass 1 idempotency | ``TestIdempotency`` |
| #4 | leaf→root + root→leaves ordering | ``TestLeafToRootOrder`` + ``TestPassOrdering`` + ``TestRootNotApplicable`` + ``TestDeeplyNestedTree`` |
| #5 | None-контракт | ``TestNoneContractDiscrimination`` (A2 + negative pin on ``update_source_hash(None)``) |
| #6 | run-state + crash-resume FULL | ``TestPass1ResumeAfterError`` + ``TestPass2ResumeAfterError`` + ``TestCrashInPass1NodePassesPass2InSameRun`` + ``TestErrorsPreservedAcrossRuns`` + ``TestReadBackToleratesMalformedEntries`` |
| #7 | composite-key skip doesn't touch ``Final.enclosing_context_updated_at`` | ``TestFinalUpdatedAtUntouched`` (inverted pin) |
| #8 | diff scope | only skeleton + tests; ``content_hash.py`` / ``enclosing_context_hash.py`` consumed read-only |

## Test plan

- [ ] CI green (Lint / Type Check / Tests / ai-review / GitGuardian)
- [ ] Verify ``content_hash.py`` and ``enclosing_context_hash.py`` are UNTOUCHED (read-only consume)
- [ ] Verify migration ``phase322_raw_source_hash`` round-trip clean against CI Postgres
- [ ] Verify ``NodeSummaryRaw.source_content_hash`` column present + nullable on upgrade
- [ ] Sanity check vision §3 KD10 line 1011 semantic: ``source_content_hash`` is bottom-up memo key, not self-hash
- [ ] Sanity check Pass 1 ERROR doesn't block Pass 2 of same node in same run (``TestCrashInPass1NodePassesPass2InSameRun``)
- [ ] Confirm boundary discipline: no changes in ``worker.py`` / ``enqueue.py`` / API routes / ``agents/`` / ``prompts/`` / ``config/ladders_*.yaml`` / ``HashableEntity``
- [ ] After merge: draft ``POST-MERGE-NOTES-3-2-2.md`` for vision-side review (DD-candidate: third-channel Final write + ``enclosing_context_updated_at`` writer in 3.2.4)

## Vision-side follow-up notes

* Vision update candidate — KD9 table should add ``NodeSummaryRaw | source_content_hash | CourseNode.content_hash at generation time — bottom-up memo key (KD10)`` row. KD9 line 729 (self-hash) remains correct as-is.
* Phase 3.2.3 wiring point: replace ``_NoOpMethodistGenerator`` default via DI on ``NodeSummaryGenerationOrchestrator(session, methodist=...)``. No orchestrator refactor needed.
* Phase 3.2.4 boundary: ``enqueue_node_summary_regeneration`` helper + ARQ task ``arq_regenerate_node_summary`` + ``POST /node-summary-regeneration`` API + ``Final.enclosing_context_updated_at`` third-channel writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)