### PR TITLE
task(3.2.3-pre): StageRouter input-budget opt-in check (KD10)

### DIFF
--- a/src/course_supporter/llm/ladder_config.py
+++ b/src/course_supporter/llm/ladder_config.py
@@ -66,6 +66,19 @@ class StageConfig(BaseModel):
             :func:`validate_ladders_against_registry`. Mirrors
             ``ActionConfig.requires`` in the registry.
         ladder: Ordered fallback ladder; at least one entry.
+        input_budget_ratio: Optional opt-in input-budget check
+            (Phase 3.2.3-pre, KD10 «Token budget policy»). When set
+            (float in ``(0.0, 1.0]``), the router estimates input size
+            via :func:`course_supporter.llm.token_budget.estimate_tokens`
+            and skips a rung if the estimate exceeds
+            ``ratio * max_context`` of that rung's model from the
+            registry. ``None`` (default) preserves byte-identical
+            existing behavior — no estimation, no skip. The router
+            does NOT translate "no rung passes" into a domain-level
+            message ("restructure your course"); that translation
+            lives at the callsite (Phase 3.2.3a methodist agent).
+            Numeric policy value (e.g. 0.5 from KD10) is owned by the
+            caller's stage YAML, NOT hard-coded in the router.
     """
 
     model_config = _FORBID
@@ -73,6 +86,7 @@ class StageConfig(BaseModel):
     prompt_ref: str
     requires: list[Capability] = Field(default_factory=list)
     ladder: list[LadderEntry] = Field(min_length=1)
+    input_budget_ratio: float | None = Field(default=None, gt=0.0, le=1.0)
 
 
 class LadderFile(BaseModel):
@@ -160,7 +174,7 @@ def validate_ladders_against_registry(
 ) -> None:
     """Cross-check every ladder rung against the model registry (TASK-2.4.23).
 
-    Two invariants enforced fail-fast at startup:
+    Three invariants enforced fail-fast at startup:
 
     * **K — membership:** every ``rung.model`` must exist in
       ``registry.models``. A typo / rename / drift between
@@ -170,6 +184,14 @@ def validate_ladders_against_registry(
       ``stage.requires`` must appear in ``model.capabilities`` for each
       rung. Catches text-only models accidentally placed in a
       vision-required stage (and similar mismatches).
+    * **Input-budget (Phase 3.2.3-pre):** if a stage declares
+      ``input_budget_ratio``, every rung's model in the registry MUST
+      have a non-None ``max_context``. Otherwise the runtime
+      ratio-vs-context check at the StageRouter loop body would
+      degrade to "always skip" or "always pass" silently — depending
+      on guard wiring. Fail-fast at config-time so a missing
+      registry entry surfaces as a startup error, not as a misrouted
+      production hit.
 
     Errors are aggregated and raised as a single ``ValueError`` so a
     multi-typo config surfaces every problem at once. Mirrors the
@@ -177,8 +199,10 @@ def validate_ladders_against_registry(
     action chains.
 
     Raises:
-        ValueError: if any rung references an unknown model OR lacks a
-            capability declared in ``stage.requires``.
+        ValueError: if any rung references an unknown model, lacks a
+            capability declared in ``stage.requires``, OR (when the
+            stage declares ``input_budget_ratio``) lacks ``max_context``
+            in the registry.
     """
     errors: list[str] = []
 
@@ -197,6 +221,14 @@ def validate_ladders_against_registry(
                 errors.append(
                     f"Stage '{stage_name}' rung {i} model '{entry.model}' "
                     f"lacks required capabilities: {sorted(missing)}"
+                )
+
+            if stage.input_budget_ratio is not None and model.max_context is None:
+                errors.append(
+                    f"Stage '{stage_name}' rung {i} model '{entry.model}' "
+                    f"has no max_context in the registry "
+                    f"(required by input_budget_ratio="
+                    f"{stage.input_budget_ratio})"
                 )
 
     if errors:

--- a/src/course_supporter/llm/router.py
+++ b/src/course_supporter/llm/router.py
@@ -14,27 +14,11 @@ from pydantic import BaseModel
 from course_supporter.llm.providers.base import LLMProvider, StructuredOutputError
 from course_supporter.llm.registry import ModelConfig, ModelRegistryConfig
 from course_supporter.llm.schemas import LLMRequest, LLMResponse
+from course_supporter.llm.token_budget import estimate_tokens
 
 logger = structlog.get_logger()
 
-# Average chars per token across common LLM tokenizers.
-# Conservative estimate (lower ratio = higher token count = safer guard).
-_CHARS_PER_TOKEN = 3.5
-
 LogCallback = Callable[[LLMResponse, bool, str | None], Awaitable[None]]
-
-
-def estimate_tokens(prompt: str, system_prompt: str | None = None) -> int:
-    """Estimate token count from text length.
-
-    Uses a conservative chars-per-token ratio (~3.5) to avoid
-    underestimating. Accuracy is ±15-20%, sufficient for pre-flight
-    context window guards.
-    """
-    total_chars = len(prompt)
-    if system_prompt:
-        total_chars += len(system_prompt)
-    return int(total_chars / _CHARS_PER_TOKEN)
 
 
 # Return type for helper methods that inspect result via isinstance.

--- a/src/course_supporter/llm/stage_router.py
+++ b/src/course_supporter/llm/stage_router.py
@@ -60,6 +60,7 @@ from course_supporter.llm.ladder_config import LadderConfig, LadderEntry
 from course_supporter.llm.prompt_loader_md import StagePrompt, load_prompt
 from course_supporter.llm.registry import ModelRegistryConfig
 from course_supporter.llm.schemas import LLMRequest, LLMResponse
+from course_supporter.llm.token_budget import estimate_tokens
 from course_supporter.service_logging import _persist
 
 if TYPE_CHECKING:
@@ -218,6 +219,43 @@ class StageRouter:
             if not provider.enabled:
                 attempts.append((entry.provider, entry.model, "provider disabled"))
                 continue
+
+            # Phase 3.2.3-pre — opt-in input-budget check (KD10 «Token budget
+            # policy»). When the stage declares ``input_budget_ratio``, skip
+            # the rung if the estimated input exceeds ``ratio * max_context``.
+            # ``input_budget_ratio is None`` (default) → no estimation, no
+            # skip — byte-identical to pre-3.2.3-pre behavior.
+            # ``validate_ladders_against_registry`` enforces at startup that
+            # ``max_context`` is set on every rung's model when the stage
+            # declares the ratio, so reaching this branch with
+            # ``max_context is None`` would mean the validator did not run
+            # (callsite bug); the defensive skip surfaces that as a visible
+            # ladder reason rather than silently passing every rung.
+            if stage.input_budget_ratio is not None:
+                registry_model = self._registry.models.get(entry.model)
+                if registry_model is None or registry_model.max_context is None:
+                    attempts.append(
+                        (
+                            entry.provider,
+                            entry.model,
+                            "input budget check requires registry model "
+                            "with max_context (config-time validator skipped?)",
+                        )
+                    )
+                    continue
+                estimated_input = estimate_tokens(prompt.user or "", prompt.system)
+                budget = int(stage.input_budget_ratio * registry_model.max_context)
+                if estimated_input > budget:
+                    attempts.append(
+                        (
+                            entry.provider,
+                            entry.model,
+                            f"input budget exceeded: ~{estimated_input:,} "
+                            f"tokens > {stage.input_budget_ratio} * "
+                            f"{registry_model.max_context:,} = {budget:,}",
+                        )
+                    )
+                    continue
 
             request = self._build_request(
                 prompt, entry, stage_name, contents=contents, expects_json=expects_json

--- a/src/course_supporter/llm/token_budget.py
+++ b/src/course_supporter/llm/token_budget.py
@@ -1,0 +1,32 @@
+"""Input-size estimation for token-budget pre-flight checks.
+
+Shared module so the formula has a single definition across both
+routers (legacy :mod:`course_supporter.llm.router` and the KD16
+:mod:`course_supporter.llm.stage_router`). KD10 «Token budget policy»
+requires a deterministic estimate of input tokens before the LLM
+call so the router can skip rungs whose context window will not
+fit. The estimate is computed in code; the LLM is never asked.
+
+Phase 5 cleanup will remove the legacy router; this module survives
+that deletion intact — StageRouter's import path stays correct
+without dragging legacy-router source as a dependency.
+"""
+
+from __future__ import annotations
+
+# Average chars per token across common LLM tokenizers.
+# Conservative estimate (lower ratio = higher token count = safer guard).
+_CHARS_PER_TOKEN = 3.5
+
+
+def estimate_tokens(prompt: str, system_prompt: str | None = None) -> int:
+    """Estimate token count from text length.
+
+    Uses a conservative chars-per-token ratio (~3.5) to avoid
+    underestimating. Accuracy is ±15-20%, sufficient for pre-flight
+    context window guards.
+    """
+    total_chars = len(prompt)
+    if system_prompt:
+        total_chars += len(system_prompt)
+    return int(total_chars / _CHARS_PER_TOKEN)

--- a/tests/unit/test_llm/test_ladder_config.py
+++ b/tests/unit/test_llm/test_ladder_config.py
@@ -576,3 +576,176 @@ class TestProductionLaddersValidate:
         assert config.get_stage("video_pass_2c_denoise").requires == []
         assert config.get_stage("audio_pass_2c_denoise").requires == []
         assert config.get_stage("example_stage").requires == []
+
+
+# ── Phase 3.2.3-pre: input_budget_ratio field + config-time validator ──
+
+
+def _registry_with_max_context(
+    *, vl_max_context: int | None = 1_000_000, text_max_context: int | None = 32_000
+) -> ModelRegistryConfig:
+    """Registry where models carry ``max_context`` (Phase 3.2.3-pre coverage).
+
+    ``_two_model_registry`` above leaves ``max_context=None`` everywhere
+    (capabilities-focused). The input-budget validator (and runtime
+    skip block in StageRouter) need real values; this helper exposes
+    a knob per model so a test can omit ``max_context`` selectively.
+    """
+    return ModelRegistryConfig(
+        providers={
+            "anthropic": ProviderConfig(
+                type="llm",
+                models=[
+                    ProviderModelConfig(
+                        id="vl-model",
+                        capabilities=[
+                            Capability.VISION,
+                            Capability.STRUCTURED_OUTPUT,
+                        ],
+                        max_context=vl_max_context,
+                    ),
+                    ProviderModelConfig(
+                        id="text-model",
+                        capabilities=[Capability.STRUCTURED_OUTPUT],
+                        max_context=text_max_context,
+                    ),
+                ],
+            )
+        },
+        actions={},
+    )
+
+
+class TestStageConfigInputBudgetRatioField:
+    """``input_budget_ratio`` field on :class:`StageConfig` — shape + bounds."""
+
+    def test_default_is_none(self) -> None:
+        stage = StageConfig(
+            prompt_ref="prompts/x.md",
+            ladder=[LadderEntry(provider="anthropic", model="m")],
+        )
+        assert stage.input_budget_ratio is None
+
+    def test_accepts_valid_ratio(self) -> None:
+        stage = StageConfig(
+            prompt_ref="prompts/x.md",
+            ladder=[LadderEntry(provider="anthropic", model="m")],
+            input_budget_ratio=0.5,
+        )
+        assert stage.input_budget_ratio == 0.5
+
+    def test_upper_bound_inclusive(self) -> None:
+        # 1.0 is allowed (whole context window usable, no reserve).
+        stage = StageConfig(
+            prompt_ref="prompts/x.md",
+            ladder=[LadderEntry(provider="anthropic", model="m")],
+            input_budget_ratio=1.0,
+        )
+        assert stage.input_budget_ratio == 1.0
+
+    def test_rejects_zero(self) -> None:
+        # 0.0 is meaningless (would skip every rung) — must be > 0.
+        with pytest.raises(ValueError):
+            StageConfig(
+                prompt_ref="prompts/x.md",
+                ladder=[LadderEntry(provider="anthropic", model="m")],
+                input_budget_ratio=0.0,
+            )
+
+    def test_rejects_above_one(self) -> None:
+        with pytest.raises(ValueError):
+            StageConfig(
+                prompt_ref="prompts/x.md",
+                ladder=[LadderEntry(provider="anthropic", model="m")],
+                input_budget_ratio=1.5,
+            )
+
+    def test_rejects_negative(self) -> None:
+        with pytest.raises(ValueError):
+            StageConfig(
+                prompt_ref="prompts/x.md",
+                ladder=[LadderEntry(provider="anthropic", model="m")],
+                input_budget_ratio=-0.1,
+            )
+
+
+class TestInputBudgetRatioConfigTimeValidation:
+    """``validate_ladders_against_registry`` enforces max_context presence
+    when a stage declares ``input_budget_ratio``.
+    """
+
+    def test_happy_path_all_rungs_have_max_context(self) -> None:
+        cfg = LadderConfig(
+            stages={
+                "demo": StageConfig(
+                    prompt_ref="prompts/x.md",
+                    ladder=[LadderEntry(provider="anthropic", model="vl-model")],
+                    input_budget_ratio=0.5,
+                )
+            }
+        )
+        validate_ladders_against_registry(cfg, _registry_with_max_context())
+
+    def test_rung_without_max_context_raises(self) -> None:
+        # vl-model has max_context=None in registry → invariant violated.
+        registry = _registry_with_max_context(vl_max_context=None)
+        cfg = LadderConfig(
+            stages={
+                "demo": StageConfig(
+                    prompt_ref="prompts/x.md",
+                    ladder=[LadderEntry(provider="anthropic", model="vl-model")],
+                    input_budget_ratio=0.5,
+                )
+            }
+        )
+        with pytest.raises(ValueError) as exc_info:
+            validate_ladders_against_registry(cfg, registry)
+        msg = str(exc_info.value)
+        assert "Stage 'demo' rung 0" in msg
+        assert "vl-model" in msg
+        assert "no max_context" in msg
+        assert "input_budget_ratio=0.5" in msg
+
+    def test_no_ratio_means_no_max_context_check(self) -> None:
+        # Without input_budget_ratio, missing max_context is fine — this is the
+        # byte-identical-pre-3.2.3-pre regression pin.
+        registry = _registry_with_max_context(
+            vl_max_context=None, text_max_context=None
+        )
+        cfg = LadderConfig(
+            stages={
+                "demo": StageConfig(
+                    prompt_ref="prompts/x.md",
+                    ladder=[LadderEntry(provider="anthropic", model="vl-model")],
+                )
+            }
+        )
+        validate_ladders_against_registry(cfg, registry)
+
+    def test_per_rung_max_context_aggregates_errors(self) -> None:
+        # ratio set + multi-rung ladder where ONLY some rungs miss max_context.
+        registry = _registry_with_max_context(
+            vl_max_context=1_000_000, text_max_context=None
+        )
+        cfg = LadderConfig(
+            stages={
+                "demo": StageConfig(
+                    prompt_ref="prompts/x.md",
+                    ladder=[
+                        LadderEntry(provider="anthropic", model="vl-model"),
+                        LadderEntry(provider="anthropic", model="text-model"),
+                    ],
+                    input_budget_ratio=0.5,
+                )
+            }
+        )
+        with pytest.raises(ValueError) as exc_info:
+            validate_ladders_against_registry(cfg, registry)
+        msg = str(exc_info.value)
+        # Only rung 1 (text-model) is reported — vl-model has max_context.
+        assert "rung 1" in msg
+        assert "text-model" in msg
+        assert (
+            "rung 0" not in msg
+            or "vl-model" not in msg.split("rung 0")[1].split("rung 1")[0]
+        )

--- a/tests/unit/test_llm/test_stage_router.py
+++ b/tests/unit/test_llm/test_stage_router.py
@@ -1294,17 +1294,14 @@ class TestInputBudgetSkipBlock:
         # small max_context so the budget check skips it before
         # provider.complete is called; the second rung's model has a huge
         # max_context and the call proceeds.
-        provider = AsyncMock(spec=LLMProvider)
-        provider.enabled = True
-        provider.complete = AsyncMock(return_value=_ok_response("from-big"))
-        provider.classify_error = lambda _exc: ErrorCategory.SEMANTIC
+        provider = _ok_provider("from-big")
 
         # ratio=0.1: 0.1 * 100 = 10-token budget < 20-token estimate
         # -> skip first rung.
         # Second rung: 0.1 * 1_000_000 = 100_000 >> 20 -> passes.
         router = StageRouter(
             _budget_config(input_budget_ratio=0.1),
-            {"anthropic": provider},  # type: ignore[dict-item]
+            {"anthropic": provider},
             registry=_two_rung_registry(
                 first_max_context=100, second_max_context=1_000_000
             ),

--- a/tests/unit/test_llm/test_stage_router.py
+++ b/tests/unit/test_llm/test_stage_router.py
@@ -1290,21 +1290,17 @@ class TestInputBudgetSkipBlock:
         # Prompt: 35 + 35 = 70 chars → estimate 70/3.5 = 20 tokens.
         _mock_load_prompt_with_size(monkeypatch, system_chars=35, user_chars=35)
 
-        first_provider = _ok_provider("from-small")
-        second_provider = _ok_provider("from-big")
-        # Single provider dict — both rungs hit the same provider, but the
-        # first rung's model has a small max_context so the budget check
-        # skips it; the second rung's model has a huge max_context and the
-        # call proceeds.
+        # Single provider services both rungs; first rung's model has a
+        # small max_context so the budget check skips it before
+        # provider.complete is called; the second rung's model has a huge
+        # max_context and the call proceeds.
         provider = AsyncMock(spec=LLMProvider)
         provider.enabled = True
         provider.complete = AsyncMock(return_value=_ok_response("from-big"))
         provider.classify_error = lambda _exc: ErrorCategory.SEMANTIC
 
-        # ratio=0.5 * max_context=100 -> budget = 50 tokens.
-        # Estimated input = 20 tokens -> fits -> passes (the WRONG result
-        # if we want to skip). For SKIP we need estimate > budget; use
-        # ratio=0.1: 0.1 * 100 = 10 < 20 -> skip first rung.
+        # ratio=0.1: 0.1 * 100 = 10-token budget < 20-token estimate
+        # -> skip first rung.
         # Second rung: 0.1 * 1_000_000 = 100_000 >> 20 -> passes.
         router = StageRouter(
             _budget_config(input_budget_ratio=0.1),
@@ -1322,10 +1318,6 @@ class TestInputBudgetSkipBlock:
         request = provider.complete.await_args.args[0]
         assert request.model == "big-context"
         assert result.model_used == "big-context"
-
-        # silence unused builder
-        del first_provider
-        del second_provider
 
     async def test_all_rungs_skipped_raises_ladder_exhausted_with_reasons(
         self,

--- a/tests/unit/test_llm/test_stage_router.py
+++ b/tests/unit/test_llm/test_stage_router.py
@@ -22,6 +22,7 @@ from course_supporter.llm.ladder_config import (
 )
 from course_supporter.llm.prompt_loader_md import StagePrompt
 from course_supporter.llm.providers.base import LLMProvider
+from course_supporter.llm.registry import ModelRegistryConfig
 from course_supporter.llm.schemas import LLMResponse
 from course_supporter.llm.stage_router import StageResult, StageRouter
 from tests._helpers.registry import empty_registry as _registry
@@ -1209,3 +1210,172 @@ class TestRegistryAwareMaxTokens:
 
         request = provider.complete.await_args.args[0]
         assert request.max_tokens is None
+
+
+# ── Phase 3.2.3-pre — input-budget opt-in skip block ─────────────
+
+
+def _two_rung_registry(
+    *,
+    first_max_context: int | None = 100,
+    second_max_context: int | None = 1_000_000,
+) -> ModelRegistryConfig:
+    """Build a registry with two models, configurable ``max_context``."""
+    from course_supporter.llm.registry import (
+        ProviderConfig,
+        ProviderModelConfig,
+    )
+
+    return ModelRegistryConfig(
+        providers={
+            "anthropic": ProviderConfig(
+                type="llm",
+                models=[
+                    ProviderModelConfig(
+                        id="small-context",
+                        max_context=first_max_context,
+                    ),
+                    ProviderModelConfig(
+                        id="big-context",
+                        max_context=second_max_context,
+                    ),
+                ],
+            )
+        },
+        actions={},
+    )
+
+
+def _budget_config(
+    *,
+    input_budget_ratio: float | None,
+    entries: Iterable[tuple[str, str]] = (
+        ("anthropic", "small-context"),
+        ("anthropic", "big-context"),
+    ),
+) -> LadderConfig:
+    """Build a two-rung ladder with the given input_budget_ratio."""
+    return LadderConfig(
+        stages={
+            "demo": StageConfig(
+                prompt_ref="prompts/example/v1.md",
+                ladder=_ladder(*entries),
+                input_budget_ratio=input_budget_ratio,
+            )
+        }
+    )
+
+
+def _mock_load_prompt_with_size(
+    monkeypatch: pytest.MonkeyPatch, *, system_chars: int, user_chars: int
+) -> None:
+    """Replace load_prompt with sized templates so estimate_tokens is deterministic."""
+    monkeypatch.setattr(
+        "course_supporter.llm.stage_router.load_prompt",
+        lambda prompt_ref, *, base_path=None: StagePrompt(
+            system="s" * system_chars,
+            user="u" * user_chars,
+        ),
+    )
+
+
+class TestInputBudgetSkipBlock:
+    """Phase 3.2.3-pre — opt-in input-budget check skips rungs at runtime."""
+
+    async def test_rung_skipped_when_input_exceeds_ratio_budget(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """First rung's small max_context can't fit input; ladder advances."""
+        # Prompt: 35 + 35 = 70 chars → estimate 70/3.5 = 20 tokens.
+        _mock_load_prompt_with_size(monkeypatch, system_chars=35, user_chars=35)
+
+        first_provider = _ok_provider("from-small")
+        second_provider = _ok_provider("from-big")
+        # Single provider dict — both rungs hit the same provider, but the
+        # first rung's model has a small max_context so the budget check
+        # skips it; the second rung's model has a huge max_context and the
+        # call proceeds.
+        provider = AsyncMock(spec=LLMProvider)
+        provider.enabled = True
+        provider.complete = AsyncMock(return_value=_ok_response("from-big"))
+        provider.classify_error = lambda _exc: ErrorCategory.SEMANTIC
+
+        # ratio=0.5 * max_context=100 -> budget = 50 tokens.
+        # Estimated input = 20 tokens -> fits -> passes (the WRONG result
+        # if we want to skip). For SKIP we need estimate > budget; use
+        # ratio=0.1: 0.1 * 100 = 10 < 20 -> skip first rung.
+        # Second rung: 0.1 * 1_000_000 = 100_000 >> 20 -> passes.
+        router = StageRouter(
+            _budget_config(input_budget_ratio=0.1),
+            {"anthropic": provider},  # type: ignore[dict-item]
+            registry=_two_rung_registry(
+                first_max_context=100, second_max_context=1_000_000
+            ),
+        )
+
+        result = await router.execute_for_stage("demo")
+
+        # Second rung answered: provider.complete was called exactly once,
+        # with the second model.
+        assert provider.complete.await_count == 1
+        request = provider.complete.await_args.args[0]
+        assert request.model == "big-context"
+        assert result.model_used == "big-context"
+
+        # silence unused builder
+        del first_provider
+        del second_provider
+
+    async def test_all_rungs_skipped_raises_ladder_exhausted_with_reasons(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Every rung's max_context too small for the prompt → exhaustion."""
+        # Prompt: 350 + 350 = 700 chars → estimate 700/3.5 = 200 tokens.
+        _mock_load_prompt_with_size(monkeypatch, system_chars=350, user_chars=350)
+
+        provider = _ok_provider("never-called")
+
+        # ratio=0.5; budgets = 50 and 60 tokens; estimate=200 > both → skip
+        # all → LadderExhaustedError.
+        router = StageRouter(
+            _budget_config(input_budget_ratio=0.5),
+            {"anthropic": provider},
+            registry=_two_rung_registry(first_max_context=100, second_max_context=120),
+        )
+
+        with pytest.raises(LadderExhaustedError) as exc_info:
+            await router.execute_for_stage("demo")
+
+        # Provider.complete was NEVER called — both skipped pre-call.
+        assert provider.complete.await_count == 0
+
+        msg = str(exc_info.value)
+        # Both rungs surfaced as input-budget-exceeded.
+        assert msg.count("input budget exceeded") == 2
+        assert "small-context" in msg
+        assert "big-context" in msg
+
+    async def test_byte_identical_when_ratio_not_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Stage without ``input_budget_ratio`` → no estimation, no skip."""
+        _mock_load_prompt_with_size(monkeypatch, system_chars=350, user_chars=350)
+
+        provider = _ok_provider("ok")
+        # ratio is None — even a tiny max_context must NOT trigger skip.
+        router = StageRouter(
+            _budget_config(input_budget_ratio=None),
+            {"anthropic": provider},
+            registry=_two_rung_registry(first_max_context=10, second_max_context=10),
+        )
+
+        result = await router.execute_for_stage("demo")
+
+        # First rung answers without budget check.
+        assert provider.complete.await_count == 1
+        request = provider.complete.await_args.args[0]
+        assert request.model == "small-context"
+        assert result.model_used == "small-context"

--- a/tests/unit/test_llm/test_token_budget.py
+++ b/tests/unit/test_llm/test_token_budget.py
@@ -1,0 +1,33 @@
+"""Unit tests for :mod:`course_supporter.llm.token_budget`.
+
+Pins the chars-per-token ratio (~3.5) so a future tweak surfaces as
+a test diff rather than a silent change in router skip thresholds.
+"""
+
+from __future__ import annotations
+
+from course_supporter.llm.token_budget import estimate_tokens
+
+
+class TestEstimateTokens:
+    """``estimate_tokens`` is a deterministic chars/3.5 estimate."""
+
+    def test_empty_prompt_returns_zero(self) -> None:
+        assert estimate_tokens("") == 0
+
+    def test_estimate_uses_chars_per_token_ratio(self) -> None:
+        # 35 chars / 3.5 = 10 tokens (exact integer at the boundary).
+        assert estimate_tokens("a" * 35) == 10
+
+    def test_system_prompt_is_added_to_total(self) -> None:
+        prompt = "a" * 14  # 4 tokens at 3.5 chars/token
+        system_prompt = "b" * 21  # 6 tokens
+        # 14 + 21 = 35 chars / 3.5 = 10 tokens.
+        assert estimate_tokens(prompt, system_prompt) == 10
+
+    def test_system_prompt_none_treated_as_absent(self) -> None:
+        assert estimate_tokens("a" * 35, None) == 10
+
+    def test_truncates_to_int(self) -> None:
+        # 5 chars / 3.5 = 1.428... → floor via int() → 1.
+        assert estimate_tokens("hello") == 1


### PR DESCRIPTION
## Summary

Phase 3.2.3-pre — opt-in input-budget pre-flight check in ``StageRouter`` per vision §3 KD10 «Token budget policy». Three atomic commits, one PR. Resolves S1 from the Phase 3.2.3 readiness probe (ratify: infrastructural impl in StageRouter as a separate task before 3.2.3a).

No production ladder declares the new field yet; existing stage behavior is byte-identical. Phase 3.2.3a methodist agent (after the calibration spike) will be the first consumer.

## Composition

- ``f9806ea`` — extract ``estimate_tokens`` to a new minimal module ``llm/token_budget``. Shared formula, no second copy. Phase 5 cleanup-boundary: ``StageRouter`` survives legacy ``ModelRouter`` deletion without a broken import edge. ``router.py`` becomes a consumer.
- ``4a5c83b`` — ``StageConfig.input_budget_ratio: float | None`` (default None) constrained to ``(0.0, 1.0]``. ``validate_ladders_against_registry`` gains a third invariant: when the ratio is set, every rung's model in registry MUST have a non-None ``max_context``. Errors aggregate into the existing batched ``ValueError``.
- ``5655bcb`` — runtime skip block in ``execute_for_stage`` between the ``provider.enabled`` check and ``_build_request``. ``input_budget_ratio is None`` (default) → no estimation, no skip — byte-identical. When set: estimate input via ``estimate_tokens(prompt.user or '', prompt.system)``, skip the rung if ``estimated > ratio * registry_model.max_context``. Skip reason feeds the existing ``LadderExhaustedError`` aggregation.

## Key ratified decisions (operator+vision, 2026-06-11)

- **S1 option (б)** — infrastructural impl in StageRouter, separate task before 3.2.3a.
- **Numeric policy value (e.g. 0.5 from KD10) NOT hard-coded in the router.** Stage YAML owns the value; future calibration spike picks per-stage numbers.
- **Domain-level translation ("restructure your course") at callsite**, not in router. Phase 3.2.3a methodist agent will catch ``LadderExhaustedError`` with input-budget reasons and translate.
- **Token-budget formula moves to shared module** (Q1 option B) — survives Phase 5 cleanup of legacy router.
- **Config-time validator extension** mirrors TASK-2.4.23 pattern (K + Q-axis1 fail-fast); adds third invariant for max_context presence when ratio is set.

## Acceptance map

| # | Acceptance | Test |
|---|---|---|
| #1 | full ``--run-db`` green; existing StageRouter tests unmodified | 70 router+stage_router tests pass; ``test_byte_identical_when_ratio_not_set`` regression-pin |
| #2.а | rung skipped when input exceeds budget; ladder advances | ``test_rung_skipped_when_input_exceeds_ratio_budget`` |
| #2.б | no rung fits → exhaustion with skip reasons | ``test_all_rungs_skipped_raises_ladder_exhausted_with_reasons`` |
| #2.в | stage without field → behavior unchanged | ``test_byte_identical_when_ratio_not_set`` |
| #3 | config with ratio + rung without max_context fails at startup | ``test_rung_without_max_context_raises`` + ``test_per_rung_max_context_aggregates_errors`` + ``test_no_ratio_means_no_max_context_check`` |

## Test plan

- [ ] CI green (Lint / Type Check / Tests / ai-review / GitGuardian)
- [ ] Verify ``router.py`` import edge — no circular, no behavior change in legacy ``ModelRouter`` (existing tests still pass)
- [ ] Verify no production ladder YAML touched (``ladders_*.yaml`` git diff = 0)
- [ ] Verify byte-identical regression: existing 70 router + stage_router tests pass without modification
- [ ] Verify config-time validator catches missing ``max_context`` when ``input_budget_ratio`` set; production ``ladders_*.yaml`` (no ratio declared) still validates clean
- [ ] Sanity check skip-reason format ``input budget exceeded: ~N tokens > ratio * max_context = budget`` reads correctly in ``LadderExhaustedError`` aggregated message
- [ ] After merge: draft ``POST-MERGE-NOTES-3-2-3-pre.md`` for vision-side review (DD candidate: KD10 50%-vs-other-ratio policy clarification; phase 3.2.3a calibration spike scope)

## Vision-side follow-up notes

- KD10 mentions "≤ 50% context_window" as policy. The router does not encode 50% — it accepts any ratio in ``(0.0, 1.0]`` per stage. Phase 3.2.3a calibration spike picks per-stage values. Worth a vision-side note: 50% is the methodist default, not a router invariant.
- ``estimate_tokens`` accuracy ±15-20% (chars/3.5 ratio); for premium-rung edge cases the spike should validate that a 0.5 ratio + this estimator margin keeps real input safely under the model's hard limit. If not, a tighter ratio or a more accurate tokenizer becomes the spike outcome — both fit within the current router contract.
- Phase 5 cleanup-boundary: ``llm/router.py`` deletion now safe for ``StageRouter`` (formula lives in ``llm/token_budget``).

🤖 Generated with [Claude Code](https://claude.com/claude-code)