### PR TITLE
task(3.2.5b): tree-feed default_language + summary badge state (backend)

### DIFF
--- a/src/course_supporter/api/routes/nodes.py
+++ b/src/course_supporter/api/routes/nodes.py
@@ -48,7 +48,10 @@ from course_supporter.jobs.cancellation_service import JobCancellationService
 from course_supporter.services.s3_cleanup_orchestration import enqueue_s3_cleanup
 from course_supporter.storage.cascade import CascadeDeleteService, build_cascade_map
 from course_supporter.storage.content_hash import ContentHashService
-from course_supporter.storage.course_node_repository import CourseNodeRepository
+from course_supporter.storage.course_node_repository import (
+    CourseNodeRepository,
+    SummaryStatus,
+)
 from course_supporter.storage.orm import CourseNode
 from course_supporter.storage.s3 import S3Client
 
@@ -76,6 +79,32 @@ def _node_response(node: CourseNode) -> NodeResponse:
     )
     resp.authored_documents_count = len(active_documents)
     return resp
+
+
+def _collect_node_ids(node: NodeWithDocumentsResponse) -> list[uuid.UUID]:
+    """Flatten the response tree to its CourseNode ids (Task 3.2.5b)."""
+    ids = [node.id]
+    for child in node.children:
+        ids.extend(_collect_node_ids(child))
+    return ids
+
+
+def _apply_summary_states(
+    node: NodeWithDocumentsResponse,
+    states: dict[uuid.UUID, tuple[SummaryStatus, bool]],
+) -> None:
+    """Assign the batch-computed summary badge state onto the response tree.
+
+    Mirrors the post-``model_validate`` field-set pattern of
+    :func:`_node_response`, extended recursively. Pure Python O(n) walk —
+    no per-node query (the single batch ``SELECT`` already ran). Nodes
+    absent from ``states`` keep the schema defaults.
+    """
+    state = states.get(node.id)
+    if state is not None:
+        node.summary_status, node.materials_changed = state
+    for child in node.children:
+        _apply_summary_states(child, states)
 
 
 async def _require_node_for_tenant(
@@ -251,7 +280,14 @@ async def get_node_detail(
     tree_roots = await repo.get_subtree_with_active_documents(node_id)
     if not tree_roots:
         raise HTTPException(status_code=404, detail="Node not found")
-    return NodeWithDocumentsResponse.model_validate(tree_roots[0])
+    response = NodeWithDocumentsResponse.model_validate(tree_roots[0])
+
+    # Summary badge state (Task 3.2.5b): one batch query for the whole
+    # subtree, then a pure recursive walk to attach it — no N+1.
+    node_ids = _collect_node_ids(response)
+    states = await repo.fetch_summary_states(node_ids)
+    _apply_summary_states(response, states)
+    return response
 
 
 # ── Single node operations ──

--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -366,6 +366,16 @@ class NodeWithDocumentsResponse(BaseModel):
     id: uuid.UUID = Field(description="Unique node identifier (UUIDv7).")
     title: str = Field(description="Node title.")
     description: str | None = Field(description="Optional node description.")
+    default_language: str | None = Field(
+        default=None,
+        description=(
+            "Canonical ISO 639-3 language for materials under this subtree. "
+            "Root nodes (``parent_id`` is null) are guaranteed non-null by "
+            "the ``course_nodes_root_language_required`` CHECK constraint; "
+            "child nodes may be null (inheritance is resolved at ingestion "
+            "from the root, not stored)."
+        ),
+    )
     order: int = Field(description="0-based position among siblings.")
     content_hash: str | None = Field(
         description="Merkle hash of this node's content. ``null`` if not computed."

--- a/src/course_supporter/api/schemas.py
+++ b/src/course_supporter/api/schemas.py
@@ -15,6 +15,7 @@ from course_supporter.language import (
     normalize_and_validate,
 )
 from course_supporter.models.source import AssignmentType, MaterialRole, SourceType
+from course_supporter.storage.course_node_repository import SummaryStatus
 
 # --- Material Tree Nodes ---
 
@@ -379,6 +380,26 @@ class NodeWithDocumentsResponse(BaseModel):
     order: int = Field(description="0-based position among siblings.")
     content_hash: str | None = Field(
         description="Merkle hash of this node's content. ``null`` if not computed."
+    )
+    summary_status: SummaryStatus = Field(
+        default="none",
+        description=(
+            "Methodist summary badge state (Task 3.2.5b): ``none`` (no "
+            "summary generated), ``draft`` (generated, not yet approved), "
+            "``approved`` (author-approved). Computed per-node in the "
+            "tree-feed — orthogonal to ``materials_changed``."
+        ),
+    )
+    materials_changed: bool = Field(
+        default=False,
+        description=(
+            "Axis-1 staleness ONLY: the node's materials changed after the "
+            "summary was generated (``Raw.source_content_hash`` differs from "
+            "the live ``CourseNode.content_hash``). NOT the generate-route's "
+            'two-axis ``uncovered_stale`` — the label is "materials changed", '
+            'not "needs regeneration". Independent of ``summary_status`` (an '
+            "approved node can still be ``materials_changed``)."
+        ),
     )
     authored_documents: list[AuthoredDocumentSummaryResponse] = Field(
         default_factory=list,

--- a/src/course_supporter/storage/course_node_repository.py
+++ b/src/course_supporter/storage/course_node_repository.py
@@ -3,15 +3,59 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 from enum import Enum, auto
+from typing import Literal
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.attributes import set_committed_value
 
 from course_supporter.storage.content_hash import ContentHashService
-from course_supporter.storage.orm import AuthoredDocument, CourseNode
+from course_supporter.storage.orm import (
+    AuthoredDocument,
+    CourseNode,
+    NodeSummaryFinal,
+    NodeSummaryRaw,
+)
+
+# Methodist summary badge state surfaced on the tree-feed (Task 3.2.5b).
+# Lives in the storage layer (computation owner); api/schemas imports it
+# up — storage never imports api.
+SummaryStatus = Literal["none", "draft", "approved"]
+
+
+def compute_node_summary_state(
+    *,
+    raw_exists: bool,
+    final_approved: bool,
+    source_content_hash: str | None,
+    node_content_hash: str | None,
+) -> tuple[SummaryStatus, bool]:
+    """Pure derivation of a CourseNode's summary badge state (Task 3.2.5b).
+
+    DB-free so the three-state matrix + axis-1 ``materials_changed`` are
+    unit-testable without a session.
+
+    * ``summary_status`` — ``none`` (no active Raw) / ``draft`` (Raw
+      present, Final not yet approved) / ``approved`` (Final approved).
+    * ``materials_changed`` — axis-1 staleness ONLY (the node's stored
+      ``Raw.source_content_hash`` differs from the live
+      ``CourseNode.content_hash``). Computed strictly when a Raw exists
+      (no Raw → nothing to compare → ``False``, explicit guard, never a
+      leaked SQL ``NULL != ...``). INDEPENDENT of approval: an approved
+      node whose materials changed stays ``materials_changed=True`` (the
+      useful "approved but stale" signal) — the two fields are
+      orthogonal, neither masks the other (Ratified #8). This is NOT the
+      generate-route's two-axis ``uncovered_stale`` (axis-2 excluded by
+      design).
+    """
+    if not raw_exists:
+        return ("none", False)
+    status: SummaryStatus = "approved" if final_approved else "draft"
+    materials_changed = source_content_hash != node_content_hash
+    return (status, materials_changed)
 
 
 class _Unset(Enum):
@@ -472,6 +516,62 @@ class CourseNodeRepository:
                         node.parent = parent
 
         return roots
+
+    async def fetch_summary_states(
+        self, node_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, tuple[SummaryStatus, bool]]:
+        """Batch-compute the summary badge state for a set of CourseNodes.
+
+        ONE statement (Task 3.2.5b, Ratified #11 — no new
+        ``CourseNode→summary`` relationship): anchor on ``CourseNode``,
+        LEFT JOIN the active ``NodeSummaryRaw`` + active
+        ``NodeSummaryFinal``. ``deleted_at IS NULL`` is filtered on BOTH
+        join sides — a soft-deleted Raw/Final counts as absent (the 1:1
+        UNIQUE on ``course_node_id`` makes fan-out impossible, but the
+        filter is required for correctness regardless: a soft-deleted
+        Final must not read as ``approved``). Each row is reduced via
+        :func:`compute_node_summary_state`.
+
+        No N+1, no per-node query, no orchestrator. Nodes absent from the
+        result map keep the response defaults (``"none"`` / ``False``).
+        """
+        if not node_ids:
+            return {}
+        stmt = (
+            select(
+                CourseNode.id,
+                NodeSummaryRaw.id,
+                NodeSummaryRaw.source_content_hash,
+                CourseNode.content_hash,
+                NodeSummaryFinal.approved_at,
+            )
+            .select_from(CourseNode)
+            .outerjoin(
+                NodeSummaryRaw,
+                and_(
+                    NodeSummaryRaw.course_node_id == CourseNode.id,
+                    NodeSummaryRaw.deleted_at.is_(None),
+                ),
+            )
+            .outerjoin(
+                NodeSummaryFinal,
+                and_(
+                    NodeSummaryFinal.course_node_id == CourseNode.id,
+                    NodeSummaryFinal.deleted_at.is_(None),
+                ),
+            )
+            .where(CourseNode.id.in_(node_ids))
+        )
+        result = await self._session.execute(stmt)
+        states: dict[uuid.UUID, tuple[SummaryStatus, bool]] = {}
+        for node_id, raw_id, source_hash, node_hash, approved_at in result:
+            states[node_id] = compute_node_summary_state(
+                raw_exists=raw_id is not None,
+                final_approved=approved_at is not None,
+                source_content_hash=source_hash,
+                node_content_hash=node_hash,
+            )
+        return states
 
     async def move(
         self,

--- a/tests/integration/test_nodes_serialization_regression.py
+++ b/tests/integration/test_nodes_serialization_regression.py
@@ -126,3 +126,53 @@ async def test_create_root_node_returns_serializable_response(
         f"created_at must be non-empty ISO string: {payload!r}"
     )
     datetime.fromisoformat(created_at)
+
+
+async def test_detail_serializes_default_language(
+    node_client: AsyncClient,
+) -> None:
+    """GET /nodes/{id}/detail carries ``default_language`` (Task 3.2.5b commit-0).
+
+    The tree-feed (``NodeWithDocumentsResponse``) previously omitted
+    ``default_language``, so the UI language badge fell back to "auto"
+    on initial load even for a course with a stored language. The field
+    is now serialized from ``CourseNode.default_language`` via
+    ``from_attributes``.
+
+    Asserts:
+    * Root node serializes the stored, normalized language (``"ukr"``) —
+      roots are guaranteed non-null by the
+      ``course_nodes_root_language_required`` CHECK constraint.
+    * A child node created without an explicit language serializes
+      ``default_language = null`` (inheritance is resolved at ingestion
+      from the root, not stored) — tolerated, not an error.
+    """
+    root_resp = await node_client.post(
+        "/api/v1/nodes",
+        json={"title": "Lang detail root", "default_language": "ukr"},
+    )
+    assert root_resp.status_code == 201, root_resp.text
+    root_id = root_resp.json()["id"]
+
+    child_resp = await node_client.post(
+        f"/api/v1/nodes/{root_id}/children",
+        json={"title": "Lang detail child"},
+    )
+    assert child_resp.status_code == 201, child_resp.text
+    child_id = child_resp.json()["id"]
+
+    detail_resp = await node_client.get(f"/api/v1/nodes/{root_id}/detail")
+    assert detail_resp.status_code == 200, detail_resp.text
+    detail = detail_resp.json()
+
+    assert detail["default_language"] == "ukr", (
+        f"root must serialize stored language, got: {detail!r}"
+    )
+
+    children = detail["children"]
+    assert len(children) == 1, f"expected one child, got: {children!r}"
+    child = children[0]
+    assert child["id"] == child_id
+    assert child["default_language"] is None, (
+        f"child without explicit language must serialize null, got: {child!r}"
+    )

--- a/tests/integration/test_nodes_serialization_regression.py
+++ b/tests/integration/test_nodes_serialization_regression.py
@@ -176,3 +176,11 @@ async def test_detail_serializes_default_language(
     assert child["default_language"] is None, (
         f"child without explicit language must serialize null, got: {child!r}"
     )
+
+    # Task 3.2.5b commit-1: the tree-feed carries summary badge state.
+    # These nodes have no Raw (never generated) → ``none`` / ``false`` at
+    # the route boundary, on both root and child (recursive composition).
+    assert detail["summary_status"] == "none", detail
+    assert detail["materials_changed"] is False, detail
+    assert child["summary_status"] == "none", child
+    assert child["materials_changed"] is False, child

--- a/tests/storage/test_fetch_summary_states.py
+++ b/tests/storage/test_fetch_summary_states.py
@@ -1,0 +1,211 @@
+"""DB tests for ``CourseNodeRepository.fetch_summary_states`` (Task 3.2.5b).
+
+Exercises the single batch ``SELECT`` against a real Postgres session:
+the three ``summary_status`` values, axis-1 ``materials_changed``, and —
+critically — the ``deleted_at IS NULL`` filter on BOTH join sides:
+
+* a soft-deleted ``NodeSummaryFinal`` (even with ``approved_at`` set)
+  must NOT read as ``approved`` — it counts as absent;
+* a soft-deleted ``NodeSummaryRaw`` must NOT read as a summary — the
+  node reads as ``none``.
+
+An in-memory surrogate cannot exercise the active-filtered outer joins
+that PostgreSQL resolves, so these run under ``requires_db``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from course_supporter.config import get_settings
+from course_supporter.storage.course_node_repository import CourseNodeRepository
+from course_supporter.storage.orm import (
+    CourseNode,
+    NodeSummaryFinal,
+    NodeSummaryRaw,
+    Tenant,
+)
+from tests._helpers.course_node_factory import make_root_course_node
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.requires_db]
+
+
+@pytest.fixture(scope="module")
+async def engine() -> AsyncGenerator[AsyncEngine]:
+    eng = create_async_engine(get_settings().database_url, pool_size=2, max_overflow=0)
+    yield eng
+    await eng.dispose()
+
+
+@pytest.fixture()
+def session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+async def _make_child(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    parent_id: uuid.UUID,
+    content_hash: str,
+) -> CourseNode:
+    node = CourseNode(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        parent_id=parent_id,
+        title="case",
+        order=0,
+        content_hash=content_hash,
+    )
+    session.add(node)
+    await session.flush()
+    return node
+
+
+async def _make_raw(
+    session: AsyncSession,
+    *,
+    course_node_id: uuid.UUID,
+    source_content_hash: str | None,
+    deleted: bool = False,
+) -> None:
+    raw = NodeSummaryRaw(
+        id=uuid.uuid4(),
+        course_node_id=course_node_id,
+        source_content_hash=source_content_hash,
+    )
+    if deleted:
+        raw.deleted_at = datetime.now(UTC)
+    session.add(raw)
+    await session.flush()
+
+
+async def _make_final(
+    session: AsyncSession,
+    *,
+    course_node_id: uuid.UUID,
+    approved: bool,
+    deleted: bool = False,
+) -> None:
+    final = NodeSummaryFinal(
+        id=uuid.uuid4(),
+        course_node_id=course_node_id,
+        approved_at=datetime.now(UTC) if approved else None,
+    )
+    if deleted:
+        final.deleted_at = datetime.now(UTC)
+    session.add(final)
+    await session.flush()
+
+
+async def _cleanup(
+    session_factory: async_sessionmaker[AsyncSession], tenant_id: uuid.UUID
+) -> None:
+    from sqlalchemy import select as sa_select
+
+    async with session_factory() as session:
+        node_ids = sa_select(CourseNode.id).where(CourseNode.tenant_id == tenant_id)
+        await session.execute(
+            delete(NodeSummaryRaw).where(NodeSummaryRaw.course_node_id.in_(node_ids))
+        )
+        await session.execute(
+            delete(NodeSummaryFinal).where(
+                NodeSummaryFinal.course_node_id.in_(node_ids)
+            )
+        )
+        await session.execute(
+            delete(CourseNode).where(CourseNode.tenant_id == tenant_id)
+        )
+        await session.execute(delete(Tenant).where(Tenant.id == tenant_id))
+        await session.commit()
+
+
+async def test_fetch_summary_states_matrix(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """All states + the dual-side ``deleted_at`` filter in one tree."""
+    async with session_factory() as session:
+        tenant = Tenant(
+            id=uuid.uuid4(), name=f"sumstate-{uuid.uuid4()}", is_active=True
+        )
+        session.add(tenant)
+        await session.flush()
+
+        root = make_root_course_node(
+            id=uuid.uuid4(), tenant_id=tenant.id, title="root", order=0
+        )
+        session.add(root)
+        await session.flush()
+
+        # none — no Raw at all.
+        n_none = await _make_child(
+            session, tenant_id=tenant.id, parent_id=root.id, content_hash="h-none"
+        )
+        # draft, fresh — Raw matches node hash, Final unapproved.
+        n_draft = await _make_child(
+            session, tenant_id=tenant.id, parent_id=root.id, content_hash="h-draft"
+        )
+        await _make_raw(
+            session, course_node_id=n_draft.id, source_content_hash="h-draft"
+        )
+        await _make_final(session, course_node_id=n_draft.id, approved=False)
+        # approved + materials_changed — drifted hash must NOT be masked by approval.
+        n_appr = await _make_child(
+            session, tenant_id=tenant.id, parent_id=root.id, content_hash="h-current"
+        )
+        await _make_raw(session, course_node_id=n_appr.id, source_content_hash="h-old")
+        await _make_final(session, course_node_id=n_appr.id, approved=True)
+        # draft — Raw active, Final SOFT-DELETED with approved_at: must read draft.
+        n_delfinal = await _make_child(
+            session, tenant_id=tenant.id, parent_id=root.id, content_hash="h-df"
+        )
+        await _make_raw(
+            session, course_node_id=n_delfinal.id, source_content_hash="h-df"
+        )
+        await _make_final(
+            session, course_node_id=n_delfinal.id, approved=True, deleted=True
+        )
+        # none — only a SOFT-DELETED Raw: counts as absent.
+        n_delraw = await _make_child(
+            session, tenant_id=tenant.id, parent_id=root.id, content_hash="h-dr"
+        )
+        await _make_raw(
+            session,
+            course_node_id=n_delraw.id,
+            source_content_hash="h-dr",
+            deleted=True,
+        )
+        await session.commit()
+
+        repo = CourseNodeRepository(session)
+        states = await repo.fetch_summary_states(
+            [n_none.id, n_draft.id, n_appr.id, n_delfinal.id, n_delraw.id]
+        )
+
+    assert states[n_none.id] == ("none", False)
+    assert states[n_draft.id] == ("draft", False)
+    assert states[n_appr.id] == ("approved", True)
+    assert states[n_delfinal.id] == ("draft", False)
+    assert states[n_delraw.id] == ("none", False)
+
+    await _cleanup(session_factory, tenant.id)
+
+
+async def test_fetch_summary_states_empty_short_circuits(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Empty node-id list returns an empty map without emitting SQL."""
+    async with session_factory() as session:
+        repo = CourseNodeRepository(session)
+        assert await repo.fetch_summary_states([]) == {}

--- a/tests/unit/test_node_summary_state.py
+++ b/tests/unit/test_node_summary_state.py
@@ -1,0 +1,120 @@
+"""Unit tests for ``compute_node_summary_state`` (Task 3.2.5b commit-1).
+
+DB-free derivation of the tree-feed summary badge. Covers the three
+``summary_status`` values and the axis-1 ``materials_changed`` matrix,
+plus the two correctness guards ratified for this commit:
+
+* ``materials_changed`` is ``False`` whenever there is no Raw — never a
+  leaked SQL ``NULL != ...`` (explicit guard in the pure function).
+* ``materials_changed`` is INDEPENDENT of approval — an approved node
+  whose materials changed stays ``True`` (the "approved but stale"
+  signal); the two fields are orthogonal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from course_supporter.storage.course_node_repository import (
+    compute_node_summary_state,
+)
+
+
+def test_no_raw_is_none_and_never_materials_changed() -> None:
+    """No active Raw → ``none`` status, ``materials_changed`` forced False.
+
+    The source/node hashes are intentionally mismatched to prove the
+    guard does not leak a comparison when there is nothing to compare.
+    """
+    status, materials_changed = compute_node_summary_state(
+        raw_exists=False,
+        final_approved=False,
+        source_content_hash=None,
+        node_content_hash="abc123",
+    )
+    assert status == "none"
+    assert materials_changed is False
+
+
+def test_raw_unapproved_is_draft() -> None:
+    """Raw present, Final not approved → ``draft``."""
+    status, materials_changed = compute_node_summary_state(
+        raw_exists=True,
+        final_approved=False,
+        source_content_hash="hash-x",
+        node_content_hash="hash-x",
+    )
+    assert status == "draft"
+    assert materials_changed is False
+
+
+def test_raw_approved_is_approved() -> None:
+    """Raw present, Final approved → ``approved``."""
+    status, materials_changed = compute_node_summary_state(
+        raw_exists=True,
+        final_approved=True,
+        source_content_hash="hash-x",
+        node_content_hash="hash-x",
+    )
+    assert status == "approved"
+    assert materials_changed is False
+
+
+def test_materials_changed_when_hashes_differ() -> None:
+    """Draft node whose source hash drifted from the node hash → True."""
+    status, materials_changed = compute_node_summary_state(
+        raw_exists=True,
+        final_approved=False,
+        source_content_hash="generated-at-hash",
+        node_content_hash="current-materials-hash",
+    )
+    assert status == "draft"
+    assert materials_changed is True
+
+
+def test_materials_changed_independent_of_approval() -> None:
+    """Approved node with drifted materials stays ``materials_changed=True``.
+
+    Approval must NOT mask the staleness signal — this is the useful
+    "approved but stale, consider regenerating" case (Ratified #8).
+    """
+    status, materials_changed = compute_node_summary_state(
+        raw_exists=True,
+        final_approved=True,
+        source_content_hash="generated-at-hash",
+        node_content_hash="current-materials-hash",
+    )
+    assert status == "approved"
+    assert materials_changed is True
+
+
+def test_null_source_hash_with_raw_reads_as_changed() -> None:
+    """Raw exists but ``source_content_hash`` is NULL (pre-Pass-1 cache key).
+
+    Mirrors ``_is_axis1_fresh`` in the orchestrator: a missing cache key
+    is treated as stale (``None != node_hash`` → changed), consistent
+    with the generate-route's axis-1 semantics.
+    """
+    status, materials_changed = compute_node_summary_state(
+        raw_exists=True,
+        final_approved=False,
+        source_content_hash=None,
+        node_content_hash="current-materials-hash",
+    )
+    assert status == "draft"
+    assert materials_changed is True
+
+
+@pytest.mark.parametrize(
+    ("final_approved", "expected_status"),
+    [(False, "draft"), (True, "approved")],
+)
+def test_status_matrix(final_approved: bool, expected_status: str) -> None:
+    """Status tracks approval when a Raw exists."""
+    status, _ = compute_node_summary_state(
+        raw_exists=True,
+        final_approved=final_approved,
+        source_content_hash="h",
+        node_content_hash="h",
+    )
+    assert status == expected_status


### PR DESCRIPTION
Backend half of Task 3.2.5b (contract-first — merges before the UI PR). Two atomic commits on `NodeWithDocumentsResponse` (the `/detail` tree-feed that drives the canvas).

## commit-0 — `default_language` on tree-feed (`7dad168`)
Additive: `/detail` omitted `default_language`, so the UI language badge fell back to "auto" on initial load even for a course with a stored language. Field mirrors `NodeResponse.default_language` verbatim; serialized via `from_attributes`; route unchanged. Roots are non-null (CHECK constraint); children serialize null (inheritance not stored) — expected, within scope.

## commit-1 — `summary_status` + `materials_changed` (`6a1450a`)
Per-node methodist-summary badge state so the canvas draws badges across the whole tree in one call (Ratified #7).
- `summary_status`: `none` / `draft` / `approved`.
- `materials_changed`: axis-1 staleness ONLY (`Raw.source_content_hash != CourseNode.content_hash`), computed strictly when a Raw exists + **independent of approval** (approved-but-stale keeps the signal — Ratified #8). NOT the generate-route's two-axis `uncovered_stale`.
- Computation: one batch `SELECT` in `CourseNodeRepository.fetch_summary_states` (LEFT JOIN active Raw + active Final, `deleted_at IS NULL` on **both** sides). No N+1, no orchestrator, no new ORM relationship (Ratified #11). Route attaches the map via a pure recursive walk, mirroring `_node_response`.

## Verification
- `ruff` ✓, `mypy --strict src/` ✓ (137 files), full suite **2476 passed, 3 skipped** (`--run-db --run-redis`).
- Tests: unit state matrix + both guards; storage batch query incl. dual-side soft-delete filter; integration `/detail` carries the fields.
- Live spot on `python_start`: root `default_language=ukr` (not "auto"), `summary_status=draft`, `materials_changed=false`; recursive composition confirmed on child.

Backward-compatible (both new fields defaulted; sole consumer is the `/detail` route + recursion). No UI changes; no change to node-summary endpoints / ORM models / orchestrator / prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)